### PR TITLE
chore(version): Bump to v0.6.10-alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scitex-cloud"
-version = "0.1.0"
+version = "0.6.10-alpha"
 description = "SciTeX Cloud - Deployment and management CLI for SciTeX"
 readme = "README.md"
 license = {text = "AGPL-3.0"}

--- a/src/scitex_cloud/__init__.py
+++ b/src/scitex_cloud/__init__.py
@@ -10,7 +10,7 @@ Usage:
     scitex-cloud --help
 """
 
-__version__ = "0.1.0"
+__version__ = "0.6.10-alpha"
 __author__ = "SciTeX Team"
 
 from .config.environments import Environment, get_environment


### PR DESCRIPTION
## Summary
- Patch version bump: v0.6.9-alpha → v0.6.10-alpha
- Includes Terminal Broker path fix (PR #27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)