### PR TITLE
chore: Add testmondata to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.testmondata*
 cover/
 
 # Translations


### PR DESCRIPTION
## Summary
- Add `.testmondata*` to `.gitignore` to prevent testmon SQLite journal files from appearing as untracked

## Test plan
- [x] Verified `.testmondata-shm` and `.testmondata-wal` are now ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)