### PR TITLE
feat(workspace): add shared viewer pane with multi-format file viewing

### DIFF
--- a/apps/console_app/static/console_app/ts/workspace/jobs/JobsPanelManager.ts
+++ b/apps/console_app/static/console_app/ts/workspace/jobs/JobsPanelManager.ts
@@ -155,19 +155,17 @@ export class JobsPanelManager {
       const response = await fetch("/console/api/jobs/");
       const data: JobsResponse = await response.json();
 
-      const badge = document.getElementById("jobs-badge");
-      if (!badge) return;
-
       const activeJobs = data.running + data.pending;
-
-      if (activeJobs > 0) {
-        badge.textContent = String(activeJobs);
-        badge.style.display = "inline-flex";
-        badge.classList.toggle("has-jobs", activeJobs !== this.lastJobCount);
-      } else {
-        badge.style.display = "none";
+      for (const id of ["jobs-badge", "ai-jobs-badge"]) {
+        const el = document.getElementById(id);
+        if (!el) continue;
+        if (activeJobs > 0) {
+          el.textContent = String(activeJobs);
+          el.style.display = "inline-flex";
+        } else {
+          el.style.display = "none";
+        }
       }
-
       this.lastJobCount = activeJobs;
     } catch (error) {
       console.warn("[JobsPanelManager] Failed to update badge:", error);

--- a/apps/hub_app/templates/hub_app/index.html
+++ b/apps/hub_app/templates/hub_app/index.html
@@ -57,6 +57,60 @@
             <div style="padding:0.5rem 1rem;">
                 <span class="badge badge-wip">WIP</span>
             </div>
+            {% if quick_ref %}
+                <div class="hub-quick-ref"
+                     style="margin:0 1rem 1rem;
+                            padding:0.75rem 1rem;
+                            background:var(--workspace-bg-secondary, #161b22);
+                            border:1px solid var(--workspace-border-default, #30363d);
+                            border-radius:6px;
+                            font-size:0.85rem;
+                            line-height:1.6">
+                    <h4 style="margin:0 0 0.5rem;
+                               font-size:0.9rem;
+                               color:var(--text-primary, #e6edf3)">
+                        <i class="fas fa-info-circle"></i> Quick Reference
+                    </h4>
+                    <div style="color:var(--text-muted, #8b949e);">
+                        <div style="margin-bottom:0.4rem;">
+                            <strong>SSH Access:</strong>
+                            {% if quick_ref.is_dev %}
+                                <code style="background:var(--workspace-bg-tertiary, #0d1117);
+                                             padding:2px 6px;
+                                             border-radius:3px">ssh -p {{ quick_ref.ssh_port }} {{ quick_ref.username }}@{{ quick_ref.ssh_hostname }}</code>
+                            {% else %}
+                                Via <a href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"
+    target="_blank">cloudflared</a> tunnel &mdash; see <a href="/accounts/settings/ssh-keys/">SSH Keys</a>
+                            {% endif %}
+                        </div>
+                        <div style="margin-bottom:0.4rem;">
+                            <strong>Shortcuts:</strong>
+                            <kbd style="background:var(--workspace-bg-tertiary, #0d1117);
+                                        padding:1px 5px;
+                                        border-radius:3px;
+                                        font-size:0.8rem">Alt+A</kbd> AI Panel &nbsp;
+                            <kbd style="background:var(--workspace-bg-tertiary, #0d1117);
+                                        padding:1px 5px;
+                                        border-radius:3px;
+                                        font-size:0.8rem">Alt+S</kbd> Scholar &nbsp;
+                            <kbd style="background:var(--workspace-bg-tertiary, #0d1117);
+                                        padding:1px 5px;
+                                        border-radius:3px;
+                                        font-size:0.8rem">Alt+W</kbd> Writer &nbsp;
+                            <kbd style="background:var(--workspace-bg-tertiary, #0d1117);
+                                        padding:1px 5px;
+                                        border-radius:3px;
+                                        font-size:0.8rem">?</kbd> All shortcuts
+                        </div>
+                        <div>
+                            <strong>Links:</strong>
+                            <a href="/accounts/settings/ssh-keys/">SSH Keys</a> &middot;
+                            <a href="/server-status/">Server Status</a> &middot;
+                            <a href="/keyboard-shortcuts/">All Shortcuts</a>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
             {% if current_project %}
                 <!-- GitHub-style file browser (reusing project_app partials) -->
                 <div class="hub-browse-container">

--- a/apps/hub_app/views/index.py
+++ b/apps/hub_app/views/index.py
@@ -13,11 +13,24 @@ logger = logging.getLogger(__name__)
 
 def build_hub_context(request, current_project=None):
     """Build hub-specific template context for both full page and partial views."""
+
     context = {
         "is_visitor": False,
         "module_name": "Hub",
         "module_icon": "fa-home",
         "current_project": current_project,
+    }
+
+    # Quick Reference: SSH and URL info
+    host = request.get_host()
+    is_dev = "127.0.0.1" in host or "localhost" in host
+    ssh_hostname = "127.0.0.1" if is_dev else "ssh.scitex.ai"
+    ssh_port = "2200" if is_dev else ""
+    context["quick_ref"] = {
+        "ssh_hostname": ssh_hostname,
+        "ssh_port": ssh_port,
+        "is_dev": is_dev,
+        "username": request.user.username,
     }
 
     # Mark as demo if visitor

--- a/apps/public_app/templatetags/vite.py
+++ b/apps/public_app/templatetags/vite.py
@@ -236,6 +236,7 @@ def _entry_to_ts_path(entry_name: str) -> str:
         "shared/components/cookie-consent": "static/shared/ts/components/cookie-consent.ts",
         "shared/components/project-selector": "static/shared/ts/components/project-selector.ts",
         "shared/workspace-tree-init": "static/shared/ts/components/workspace-files-tree/auto-init.ts",
+        "shared/workspace-viewer-init": "static/shared/ts/components/workspace-viewer/init.ts",
         # Landing page
         "public_app/landing/hero-demo": "apps/public_app/static/public_app/ts/landing/hero-demo.ts",
         "public_app/pages/visitor-pool-full": "apps/public_app/static/public_app/ts/pages/visitor-pool-full.ts",

--- a/apps/public_app/views/pages_shortcuts.py
+++ b/apps/public_app/views/pages_shortcuts.py
@@ -19,7 +19,6 @@ KEYBOARD_SHORTCUTS_DATA = [
                 "shortcuts": [
                     {"keys": "Alt+F", "description": "Files"},
                     {"keys": "Alt+S", "description": "Scholar"},
-                    {"keys": "Alt+C", "description": "Console"},
                     {"keys": "Alt+V", "description": "Visualizer"},
                     {"keys": "Alt+W", "description": "Writer"},
                     {"keys": "Alt+Z", "description": "Zen Mode"},
@@ -70,36 +69,6 @@ KEYBOARD_SHORTCUTS_DATA = [
                 "shortcuts": [
                     {"keys": "Ctrl+S", "description": "Save to library"},
                     {"keys": "Ctrl+C", "description": "Copy citation"},
-                ],
-            },
-        ],
-    },
-    {
-        "name": "Console",
-        "slug": "code",
-        "icon": "💻",
-        "description": "Terminal workspace",
-        "sections": [
-            {
-                "title": "Files",
-                "shortcuts": [
-                    {"keys": "Ctrl+S", "description": "Save file"},
-                    {"keys": "Ctrl+N", "description": "New file"},
-                    {"keys": "Ctrl+Tab", "description": "Next tab"},
-                    {"keys": "Ctrl+Shift+Tab", "description": "Prev tab"},
-                ],
-            },
-            {
-                "title": "Terminal",
-                "shortcuts": [
-                    {"keys": "Ctrl+Shift+T", "description": "New terminal"},
-                    {"keys": "Ctrl+`", "description": "Toggle terminal"},
-                ],
-            },
-            {
-                "title": "View",
-                "shortcuts": [
-                    {"keys": "Ctrl+B", "description": "Toggle sidebar"},
                 ],
             },
         ],

--- a/apps/scholar_app/static/scholar_app/css/library/library.css
+++ b/apps/scholar_app/static/scholar_app/css/library/library.css
@@ -12,10 +12,12 @@
   padding: 0;
 }
 
-/* Paper list column — middle pane */
+/* Paper list column — left pane, resizable via library-resizer */
 .library-tab-inner {
-  width: clamp(260px, 35%, 500px);
+  width: 400px;
   flex-shrink: 0;
+  flex-grow: 0;
+  min-width: 200px;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -23,11 +25,10 @@
   border-right: 1px solid var(--workspace-border-default);
 }
 
-/* Details panel column — right pane, grows to fill */
+/* Details panel column — right pane, grows to fill remaining space */
 .library-details-panel {
   flex: 1;
   min-width: 200px;
-  max-width: 50%;
   overflow-y: auto;
   overflow-x: hidden;
   background-color: var(--workspace-bg-primary);
@@ -38,13 +39,6 @@
 /* Resizer handle between paper list and details */
 .library-resizer {
   flex-shrink: 0;
-}
-
-/* Narrow screen: tighter paper list */
-@media (max-width: 900px) {
-  .library-tab-inner {
-    width: clamp(260px, 30%, 400px);
-  }
 }
 
 /* Tab Badge */

--- a/apps/scholar_app/templates/scholar_app/scholar_unified.html
+++ b/apps/scholar_app/templates/scholar_app/scholar_unified.html
@@ -610,11 +610,11 @@
         <div class="panel-resizer library-resizer"
              id="library-resizer"
              data-panel-resizer
-             data-target=".library-details-panel"
-             data-direction="right"
+             data-target=".library-tab-inner"
+             data-direction="left"
              data-min-width="200"
-             data-default-width="340"
-             data-storage-key="library-details-width"
+             data-default-width="400"
+             data-storage-key="library-list-width"
              data-storage-prefix="scitex-scholar-"></div>
         <div class="library-details-panel">{% include "scholar_app/library_partials/library_details.html" %}</div>
     </div>

--- a/static/shared/css/components/global-ai-chat/02-panel-header.css
+++ b/static/shared/css/components/global-ai-chat/02-panel-header.css
@@ -50,24 +50,14 @@
   color: #5a9a7e; /* success green — indicates feature is on */
 }
 
-/* Model badge — inline in the panel title */
+/* Model badge — inline in the settings panel LLM label */
 .scitex-ai-model-badge {
-  font-size: 0.625rem;
+  font-size: 0.6rem;
   font-family: monospace;
-  font-weight: 500;
-  color: var(--text-muted, #8b949e);
-  background: var(--bg-hover, rgba(255, 255, 255, 0.07));
-  border: 1px solid var(--border-default, #30363d);
-  padding: 1px 5px;
-  border-radius: 3px;
-  vertical-align: middle;
-  opacity: 0.85;
-  empty-cells: hide;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 100%;
-  display: block;
+  font-weight: 400;
+  color: var(--text-dimmed, #484f58);
+  display: inline;
+  margin-left: 0.25rem;
 }
 
 .scitex-ai-model-badge:empty {

--- a/static/shared/css/components/global-ai-chat/03-mode-toggle.css
+++ b/static/shared/css/components/global-ai-chat/03-mode-toggle.css
@@ -35,6 +35,23 @@
   border-color: rgba(90, 154, 126, 0.4);
 }
 
+/* Job count badge on mode buttons */
+.ai-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  background-color: var(--workspace-icon-primary, #5a9a7e);
+  color: #fff;
+  border-radius: 7px;
+  margin-left: 2px;
+  line-height: 1;
+}
+
 /* ============================================================
    View Switching (Chat / Console views)
    ============================================================ */

--- a/static/shared/css/components/panel-resizer.css
+++ b/static/shared/css/components/panel-resizer.css
@@ -179,14 +179,18 @@ body.no-transition * {
    The .panels-ready class is added by autoInitPanels() after all widths are set. */
 body.no-transition .workspace-three-col .ws-ai-pane,
 body.no-transition .workspace-three-col .ws-worktree-pane,
+body.no-transition .workspace-three-col .ws-viewer-pane,
 body.no-transition .workspace-shell .ws-ai-pane,
-body.no-transition .workspace-shell .ws-worktree-pane {
+body.no-transition .workspace-shell .ws-worktree-pane,
+body.no-transition .workspace-shell .ws-viewer-pane {
   visibility: hidden;
 }
 
 body.no-transition .workspace-three-col.panels-ready .ws-ai-pane,
 body.no-transition .workspace-three-col.panels-ready .ws-worktree-pane,
+body.no-transition .workspace-three-col.panels-ready .ws-viewer-pane,
 body.no-transition .workspace-shell.panels-ready .ws-ai-pane,
-body.no-transition .workspace-shell.panels-ready .ws-worktree-pane {
+body.no-transition .workspace-shell.panels-ready .ws-worktree-pane,
+body.no-transition .workspace-shell.panels-ready .ws-viewer-pane {
   visibility: visible;
 }

--- a/static/shared/css/components/workspace-three-col.css
+++ b/static/shared/css/components/workspace-three-col.css
@@ -147,125 +147,6 @@
   min-height: 80px;
 }
 
-/* File preview panel (bottom of worktree) */
-.ws-worktree-preview {
-  border-top: 1px solid var(--border-default, #30363d);
-  max-height: 50%;
-  min-height: 100px;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.ws-preview-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 4px 8px;
-  background: var(--bg-tertiary, #21262d);
-  border-bottom: 1px solid var(--border-default, #30363d);
-  flex-shrink: 0;
-}
-
-.ws-preview-title {
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: var(--text-primary, #c9d1d9);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ws-preview-open {
-  color: var(--text-dimmed, #484f58);
-  font-size: 0.65rem;
-  margin-left: auto;
-  text-decoration: none;
-}
-
-.ws-preview-open:hover {
-  color: var(--accent-color, #58a6ff);
-}
-
-.ws-preview-close {
-  display: flex !important;
-  padding: 2px 4px;
-  font-size: 0.65rem;
-}
-
-.ws-preview-content {
-  flex: 1;
-  overflow: auto;
-  padding: 0;
-}
-
-.ws-preview-code {
-  margin: 0;
-  padding: 6px 8px;
-  font-size: 0.7rem;
-  line-height: 1.4;
-  font-family: "JetBrains Mono", monospace;
-  color: var(--text-primary, #c9d1d9);
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-
-.ws-preview-image {
-  max-width: 100%;
-  max-height: 200px;
-  object-fit: contain;
-  display: block;
-  margin: 8px auto;
-}
-
-.ws-preview-binary {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  padding: 16px;
-  color: var(--text-muted, #8b949e);
-  font-size: 0.75rem;
-}
-
-.ws-preview-binary i {
-  font-size: 1.5rem;
-  opacity: 0.5;
-}
-
-.ws-preview-download {
-  color: var(--accent-color, #58a6ff);
-  text-decoration: none;
-  font-size: 0.7rem;
-}
-
-.ws-preview-download:hover {
-  text-decoration: underline;
-}
-
-.ws-preview-loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  color: var(--text-muted, #8b949e);
-}
-
-.ws-preview-error {
-  padding: 12px;
-  color: var(--danger-color, #f85149);
-  font-size: 0.75rem;
-  text-align: center;
-}
-
-.ws-preview-truncated {
-  padding: 4px 8px;
-  font-size: 0.65rem;
-  color: var(--text-dimmed, #484f58);
-  border-top: 1px solid var(--border-default, #30363d);
-  text-align: center;
-}
-
 /* ============================================================
    Module pane (right, fills remaining space)
    ============================================================ */
@@ -414,7 +295,8 @@ body.scitex-ai-open #workspace-three-col #main-content {
   }
 
   .ws-ai-pane,
-  .ws-worktree-pane {
+  .ws-worktree-pane,
+  .ws-viewer-pane {
     display: none;
   }
 }

--- a/static/shared/css/components/workspace-viewer.css
+++ b/static/shared/css/components/workspace-viewer.css
@@ -1,0 +1,183 @@
+/**
+ * @component Workspace Viewer Pane
+ * @description Collapsible viewer/editor pane for files. Same pattern as
+ *   ws-ai-pane and ws-worktree-pane. Sits between worktree and module content.
+ * @category Layouts
+ * @darkmode true
+ */
+
+/* ============================================================
+   Viewer pane flex item
+   ============================================================ */
+
+.ws-viewer-pane {
+  flex-shrink: 0;
+  position: relative;
+  overflow: visible;
+}
+
+#ws-viewer-sidebar {
+  position: relative;
+  height: 100%;
+  width: 480px;
+  background: var(--bg-secondary, #161b22);
+  border-right: 1px solid var(--border-default, #30363d);
+  overflow: visible;
+  transition: width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#ws-viewer-sidebar.collapsed {
+  width: 40px;
+  overflow: hidden;
+}
+
+/* Short label shown when collapsed; full label shown when expanded */
+#ws-viewer-sidebar .sidebar-title-full {
+  display: none;
+}
+
+#ws-viewer-sidebar:not(.collapsed) .sidebar-title-full {
+  display: inline;
+}
+
+#ws-viewer-sidebar:not(.collapsed) .sidebar-title {
+  display: none;
+}
+
+/* Hide header actions when collapsed */
+#ws-viewer-sidebar.collapsed .ws-viewer-header-actions {
+  display: none;
+}
+
+/* ============================================================
+   Tab bar (inside header)
+   ============================================================ */
+
+.ws-viewer-tabs {
+  display: flex;
+  gap: 1px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex: 1;
+  min-width: 0;
+  margin-left: 8px;
+  scrollbar-width: none;
+}
+
+.ws-viewer-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.ws-viewer-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  font-size: 0.7rem;
+  color: var(--text-muted, #8b949e);
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  white-space: nowrap;
+  max-width: 140px;
+  transition: all 0.15s ease;
+}
+
+.ws-viewer-tab:hover {
+  color: var(--text-primary, #c9d1d9);
+  background: var(--bg-tertiary, #21262d);
+}
+
+.ws-viewer-tab.active {
+  color: var(--text-primary, #c9d1d9);
+  background: var(--bg-tertiary, #21262d);
+}
+
+.ws-viewer-tab-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ws-viewer-tab-close {
+  font-size: 0.65rem;
+  opacity: 0;
+  padding: 0 2px;
+  line-height: 1;
+  color: var(--text-muted, #8b949e);
+  cursor: pointer;
+  transition: opacity 0.1s;
+}
+
+.ws-viewer-tab:hover .ws-viewer-tab-close,
+.ws-viewer-tab.active .ws-viewer-tab-close {
+  opacity: 1;
+}
+
+.ws-viewer-tab-close:hover {
+  color: var(--danger-color, #f85149);
+}
+
+/* Drag-and-drop */
+.ws-viewer-tab.dragging {
+  opacity: 0.4;
+}
+
+.ws-viewer-tab.drag-over {
+  border-left: 2px solid var(--accent-color, #58a6ff);
+}
+
+/* ============================================================
+   Viewer content area
+   ============================================================ */
+
+.ws-viewer-body {
+  display: flex;
+  flex-direction: column;
+  height: calc(100% - 36px); /* minus header */
+  overflow: hidden;
+}
+
+.ws-viewer-content {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.ws-viewer-monaco {
+  width: 100%;
+  height: 100%;
+}
+
+.ws-viewer-media {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+/* Empty state */
+.ws-viewer-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 0.5rem;
+  color: var(--text-muted, #8b949e);
+  font-size: 0.85rem;
+}
+
+.ws-viewer-empty i {
+  font-size: 1.5rem;
+  opacity: 0.5;
+}
+
+/* ============================================================
+   Responsive: hide on narrow viewports
+   ============================================================ */
+
+@media (max-width: 768px) {
+  .ws-viewer-pane {
+    display: none;
+  }
+}

--- a/static/shared/ts/components/shortcuts-modal.ts
+++ b/static/shared/ts/components/shortcuts-modal.ts
@@ -8,7 +8,7 @@ console.log("[DEBUG] shortcuts-modal.ts loaded");
 /**
  * App context types
  */
-type AppContext = "global" | "files" | "scholar" | "code" | "vis" | "writer";
+type AppContext = "global" | "files" | "scholar" | "vis" | "writer";
 
 /**
  * Shortcut definition
@@ -36,7 +36,6 @@ const CONTEXT_SECTIONS: Record<AppContext, ShortcutSection[]> = {
       shortcuts: [
         { keys: "Alt+F", description: "Files" },
         { keys: "Alt+S", description: "Scholar" },
-        { keys: "Alt+C", description: "Console" },
         { keys: "Alt+V", description: "Visualizer" },
         { keys: "Alt+W", description: "Writer" },
         { keys: "Alt+Z", description: "Zen Mode" },
@@ -83,28 +82,6 @@ const CONTEXT_SECTIONS: Record<AppContext, ShortcutSection[]> = {
         { keys: "Ctrl+S", description: "Save to library" },
         { keys: "Ctrl+C", description: "Copy citation" },
       ],
-    },
-  ],
-  console: [
-    {
-      title: "Files",
-      shortcuts: [
-        { keys: "Ctrl+S", description: "Save file" },
-        { keys: "Ctrl+N", description: "New file" },
-        { keys: "Ctrl+Tab", description: "Next tab" },
-        { keys: "Ctrl+Shift+Tab", description: "Prev tab" },
-      ],
-    },
-    {
-      title: "Terminal",
-      shortcuts: [
-        { keys: "Ctrl+Shift+T", description: "New terminal" },
-        { keys: "Ctrl+`", description: "Toggle terminal" },
-      ],
-    },
-    {
-      title: "View",
-      shortcuts: [{ keys: "Ctrl+B", description: "Toggle sidebar" }],
     },
   ],
   vis: [
@@ -208,7 +185,6 @@ function detectContext(): AppContext {
   const path = window.location.pathname;
   if (path.startsWith("/files/")) return "files";
   if (path.startsWith("/scholar/")) return "scholar";
-  if (path.startsWith("/console/")) return "code";
   if (path.startsWith("/vis/")) return "vis";
   if (path.startsWith("/writer/")) return "writer";
   return "global";
@@ -222,7 +198,6 @@ function getContextName(context: AppContext): string {
     global: "Global",
     files: "Files",
     scholar: "Scholar",
-    console: "Console",
     vis: "Visualizer",
     writer: "Writer",
   };

--- a/static/shared/ts/components/workspace-files-tree/auto-init.ts
+++ b/static/shared/ts/components/workspace-files-tree/auto-init.ts
@@ -11,7 +11,6 @@ import { initHiddenFilesToggle } from "./HiddenFilesToggle.ts";
 import { initGitStatusToggle } from "./GitStatusToggle.ts";
 import { initModuleFilterButtons } from "./ModuleFilterButtons.ts";
 import { initSortToggle } from "./SortToggle.ts";
-import { FilePreviewPanel } from "./FilePreviewPanel.ts";
 
 declare global {
   interface Window {
@@ -87,21 +86,7 @@ export async function autoInitWorktreePanes(): Promise<void> {
     const username = pane.dataset.username;
     if (!slug || !username) continue;
 
-    // Initialize file preview panel if present in DOM
-    const previewEl = document.getElementById("ws-worktree-preview");
-    let previewPanel: FilePreviewPanel | null = null;
-    if (previewEl) {
-      previewPanel = new FilePreviewPanel(previewEl);
-      previewPanel.configure(username, slug);
-      // Close button
-      document
-        .getElementById("ws-preview-close")
-        ?.addEventListener("click", () => {
-          previewPanel?.hide();
-        });
-    }
-
-    // Delegate to custom handler if set; preview is handled via DOM event below
+    // Delegate to custom handler if set; file viewing handled by workspace-viewer pane
     const onFileSelect = window.scitexOnFileSelect || (() => {});
 
     const tree = new WorkspaceFilesTree({
@@ -116,13 +101,6 @@ export async function autoInitWorktreePanes(): Promise<void> {
 
     await tree.initialize();
 
-    // Preview panel: listen via DOM event so it persists even when modules replace onFileSelect
-    if (previewPanel) {
-      pane.addEventListener("file-select", ((e: CustomEvent) => {
-        const path = e.detail?.path;
-        if (path) previewPanel!.show(path);
-      }) as EventListener);
-    }
     initHiddenFilesToggle(tree);
     initGitStatusToggle(tree);
     initSortToggle(tree);

--- a/static/shared/ts/components/workspace-viewer/TabManager.ts
+++ b/static/shared/ts/components/workspace-viewer/TabManager.ts
@@ -1,0 +1,197 @@
+/**
+ * TabManager - Simplified tab manager for the shared workspace viewer.
+ *
+ * Differences from console_app FileTabManager:
+ * - No scratch buffer support
+ * - No FileCreationHelper dependency
+ * - No ModalManager dependency
+ * - No inline rename
+ * Keeps: localStorage persistence, drag-and-drop reorder, tab switching.
+ */
+
+import type { TabInfo } from "./types.ts";
+
+interface TabManagerConfig {
+  container: HTMLElement;
+  storageKey: string;
+  onSwitch: (path: string) => void;
+  onClose: (path: string) => void;
+}
+
+export class TabManager {
+  private tabs: Map<string, TabInfo> = new Map();
+  private activeTab: string | null = null;
+  private container: HTMLElement;
+  private storageKey: string;
+  private onSwitch: (path: string) => void;
+  private onClose: (path: string) => void;
+  private draggedPath: string | null = null;
+
+  constructor(config: TabManagerConfig) {
+    this.container = config.container;
+    this.storageKey = config.storageKey;
+    this.onSwitch = config.onSwitch;
+    this.onClose = config.onClose;
+  }
+
+  /** Add a tab if not already open, then switch to it. */
+  openTab(info: TabInfo): void {
+    if (!this.tabs.has(info.path)) {
+      this.tabs.set(info.path, info);
+    }
+    this.switchTab(info.path);
+  }
+
+  /** Remove a tab and switch to an adjacent one if needed. */
+  closeTab(path: string): void {
+    if (!this.tabs.has(path)) return;
+
+    const keys = Array.from(this.tabs.keys());
+    const idx = keys.indexOf(path);
+
+    this.tabs.delete(path);
+
+    if (this.activeTab === path) {
+      const remaining = Array.from(this.tabs.keys());
+      const nextKey = remaining[Math.min(idx, remaining.length - 1)] ?? null;
+      this.activeTab = nextKey;
+      if (nextKey) {
+        this.onSwitch(nextKey);
+      }
+    }
+
+    this.render();
+    this.saveState();
+    this.onClose(path);
+  }
+
+  /** Activate a tab and update the UI. */
+  switchTab(path: string): void {
+    if (!this.tabs.has(path)) return;
+    this.activeTab = path;
+    this.render();
+    this.saveState();
+    this.onSwitch(path);
+  }
+
+  getActiveTab(): string | null {
+    return this.activeTab;
+  }
+
+  /** Rebuild the tab bar from the current tabs map. */
+  render(): void {
+    this.container.innerHTML = "";
+
+    this.tabs.forEach((info, path) => {
+      const tab = this.createTabElement(path, info);
+      this.container.appendChild(tab);
+    });
+  }
+
+  saveState(): void {
+    const state = Array.from(this.tabs.values());
+    localStorage.setItem(
+      this.storageKey,
+      JSON.stringify({ tabs: state, active: this.activeTab }),
+    );
+  }
+
+  restoreState(): TabInfo[] | null {
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed.tabs)) return null;
+      return parsed.tabs as TabInfo[];
+    } catch {
+      return null;
+    }
+  }
+
+  // --- Private helpers ---
+
+  private createTabElement(path: string, info: TabInfo): HTMLElement {
+    const isActive = path === this.activeTab;
+
+    const tab = document.createElement("div");
+    tab.className = `ws-viewer-tab${isActive ? " active" : ""}`;
+    tab.dataset.path = path;
+    tab.title = path;
+
+    const nameSpan = document.createElement("span");
+    nameSpan.className = "ws-viewer-tab-name";
+    nameSpan.textContent = info.title || path.split("/").pop() || path;
+    tab.appendChild(nameSpan);
+
+    const closeBtn = document.createElement("span");
+    closeBtn.className = "ws-viewer-tab-close";
+    closeBtn.innerHTML = "&times;";
+    closeBtn.title = "Close";
+    closeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.closeTab(path);
+    });
+    tab.appendChild(closeBtn);
+
+    tab.addEventListener("click", () => this.switchTab(path));
+
+    this.setupDragDrop(tab, path);
+
+    return tab;
+  }
+
+  private setupDragDrop(tab: HTMLElement, path: string): void {
+    tab.draggable = true;
+
+    tab.addEventListener("dragstart", (e) => {
+      this.draggedPath = path;
+      tab.classList.add("dragging");
+      if (e.dataTransfer) {
+        e.dataTransfer.effectAllowed = "move";
+        e.dataTransfer.setData("text/plain", path);
+      }
+    });
+
+    tab.addEventListener("dragend", () => {
+      this.draggedPath = null;
+      tab.classList.remove("dragging");
+      this.container
+        .querySelectorAll(".ws-viewer-tab")
+        .forEach((t) => t.classList.remove("drag-over"));
+    });
+
+    tab.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      if (this.draggedPath && this.draggedPath !== path) {
+        tab.classList.add("drag-over");
+      }
+    });
+
+    tab.addEventListener("dragleave", () => tab.classList.remove("drag-over"));
+
+    tab.addEventListener("drop", (e) => {
+      e.preventDefault();
+      tab.classList.remove("drag-over");
+      if (this.draggedPath && this.draggedPath !== path) {
+        this.reorderTabs(this.draggedPath, path);
+      }
+    });
+  }
+
+  private reorderTabs(draggedPath: string, targetPath: string): void {
+    const entries = Array.from(this.tabs.entries());
+    const fromIdx = entries.findIndex(([p]) => p === draggedPath);
+    const toIdx = entries.findIndex(([p]) => p === targetPath);
+    if (fromIdx === -1 || toIdx === -1) return;
+
+    const [dragged] = entries.splice(fromIdx, 1);
+    const insertIdx = fromIdx < toIdx ? toIdx - 1 : toIdx;
+    entries.splice(insertIdx, 0, dragged);
+
+    this.tabs.clear();
+    entries.forEach(([p, info]) => this.tabs.set(p, info));
+
+    this.render();
+    this.saveState();
+  }
+}

--- a/static/shared/ts/components/workspace-viewer/ViewerRouter.ts
+++ b/static/shared/ts/components/workspace-viewer/ViewerRouter.ts
@@ -1,0 +1,64 @@
+/**
+ * ViewerRouter - Routes file types to dedicated viewer instances.
+ *
+ * Uses a simple factory pattern: one viewer instance per FileType is
+ * created lazily and reused for subsequent files of the same type.
+ * Text files are handled externally by Monaco; binary files are not viewable.
+ */
+
+import { detectFileType, type FileType, type Viewer } from "./types.ts";
+import {
+  ImageViewer,
+  PdfViewer,
+  CsvViewer,
+  MermaidViewer,
+  AudioViewer,
+  VideoViewer,
+} from "./viewers/index.ts";
+
+export class ViewerRouter {
+  private viewers: Map<FileType, Viewer> = new Map();
+
+  /**
+   * Return the appropriate Viewer for a file path, or null for text/binary.
+   * Viewer instances are reused across files of the same type.
+   */
+  getViewer(filePath: string): Viewer | null {
+    const fileType = detectFileType(filePath);
+
+    if (fileType === "text") return null;
+    if (fileType === "binary") return null;
+
+    if (!this.viewers.has(fileType)) {
+      const viewer = this.createViewer(fileType);
+      if (!viewer) return null;
+      this.viewers.set(fileType, viewer);
+    }
+
+    return this.viewers.get(fileType) ?? null;
+  }
+
+  destroyAll(): void {
+    this.viewers.forEach((v) => v.destroy());
+    this.viewers.clear();
+  }
+
+  private createViewer(fileType: FileType): Viewer | null {
+    switch (fileType) {
+      case "image":
+        return new ImageViewer();
+      case "pdf":
+        return new PdfViewer();
+      case "csv":
+        return new CsvViewer();
+      case "mermaid":
+        return new MermaidViewer();
+      case "audio":
+        return new AudioViewer();
+      case "video":
+        return new VideoViewer();
+      default:
+        return null;
+    }
+  }
+}

--- a/static/shared/ts/components/workspace-viewer/file-loader.ts
+++ b/static/shared/ts/components/workspace-viewer/file-loader.ts
@@ -1,0 +1,174 @@
+/**
+ * File loader for the shared Workspace Viewer component.
+ * Abstracts content fetching with strategy selection based on file type.
+ * Text-like files are fetched as JSON; binary media files use blob URLs.
+ */
+
+import { detectFileType, type FileType } from "./types.js";
+
+/** Result returned by loadFileContent */
+export interface FileLoadResult {
+  content: string;
+  mimeType: string;
+  isBase64: boolean;
+  blobUrl?: string;
+}
+
+/** File types that are fetched as raw binary and rendered via blob URL */
+const BINARY_MEDIA_TYPES = new Set<FileType>([
+  "image",
+  "pdf",
+  "audio",
+  "video",
+]);
+
+/** Default API endpoint for file content */
+const DEFAULT_API_ENDPOINT = "/console/api/file-content/";
+
+/** Configurable API endpoint — can be overridden for different apps */
+let apiEndpoint = DEFAULT_API_ENDPOINT;
+
+/**
+ * Override the API endpoint used by this loader.
+ * Call once at app initialization if the endpoint differs from the default.
+ */
+export function configureApiEndpoint(endpoint: string): void {
+  apiEndpoint = endpoint;
+}
+
+/**
+ * Build the URL for a file content request.
+ *
+ * @param filePath  - Path to the file within the project
+ * @param projectId - Project identifier
+ * @param raw       - When true, returns raw binary response (default: false)
+ */
+export function getFileUrl(
+  filePath: string,
+  projectId: string,
+  raw = false,
+): string {
+  const params = new URLSearchParams({ project_id: projectId });
+  if (raw) {
+    params.set("raw", "true");
+  }
+  return `${apiEndpoint}${encodeURIComponent(filePath)}?${params.toString()}`;
+}
+
+/**
+ * Load file content, choosing text-JSON or raw-binary strategy based on type.
+ *
+ * For text, csv, and mermaid files:
+ *   - Fetches JSON response with a `content` field.
+ *
+ * For image, pdf, audio, and video files:
+ *   - Fetches raw binary and creates an object URL (blob URL).
+ *   - Caller is responsible for revoking the blob URL when done.
+ *
+ * @throws Error when the HTTP request fails or the server returns an error.
+ */
+export async function loadFileContent(
+  filePath: string,
+  projectId: string,
+): Promise<FileLoadResult> {
+  const fileType = detectFileType(filePath);
+
+  if (BINARY_MEDIA_TYPES.has(fileType)) {
+    return loadBinaryMedia(filePath, projectId, fileType);
+  }
+
+  return loadTextContent(filePath, projectId);
+}
+
+/**
+ * Revoke a previously created blob URL to free browser memory.
+ */
+export function revokeFileUrl(blobUrl: string): void {
+  URL.revokeObjectURL(blobUrl);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function loadTextContent(
+  filePath: string,
+  projectId: string,
+): Promise<FileLoadResult> {
+  const url = getFileUrl(filePath, projectId, false);
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load file "${filePath}": HTTP ${response.status}`,
+    );
+  }
+
+  const json = await response.json();
+  const content: string = json.content ?? "";
+  const mimeType: string = response.headers.get("content-type") ?? "text/plain";
+
+  return { content, mimeType, isBase64: false };
+}
+
+async function loadBinaryMedia(
+  filePath: string,
+  projectId: string,
+  fileType: FileType,
+): Promise<FileLoadResult> {
+  const url = getFileUrl(filePath, projectId, true);
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load file "${filePath}": HTTP ${response.status}`,
+    );
+  }
+
+  const blob = await response.blob();
+  const mimeType = blob.type || inferMimeType(filePath, fileType);
+  const typedBlob =
+    mimeType !== blob.type ? blob.slice(0, blob.size, mimeType) : blob;
+  const blobUrl = URL.createObjectURL(typedBlob);
+
+  return { content: "", mimeType, isBase64: false, blobUrl };
+}
+
+/** Fallback MIME type inference when the server omits Content-Type */
+function inferMimeType(filePath: string, fileType: FileType): string {
+  const ext = filePath.substring(filePath.lastIndexOf(".")).toLowerCase();
+
+  const mimeMap: { [key: string]: string } = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".bmp": "image/bmp",
+    ".ico": "image/x-icon",
+    ".pdf": "application/pdf",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".ogg": "audio/ogg",
+    ".flac": "audio/flac",
+    ".m4a": "audio/mp4",
+    ".aac": "audio/aac",
+    ".wma": "audio/x-ms-wma",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".avi": "video/x-msvideo",
+    ".mov": "video/quicktime",
+    ".mkv": "video/x-matroska",
+    ".ogv": "video/ogg",
+  };
+
+  if (mimeMap[ext]) return mimeMap[ext];
+
+  // Broad fallback by category
+  if (fileType === "image") return "image/png";
+  if (fileType === "pdf") return "application/pdf";
+  if (fileType === "audio") return "audio/mpeg";
+  if (fileType === "video") return "video/mp4";
+  return "application/octet-stream";
+}

--- a/static/shared/ts/components/workspace-viewer/index.ts
+++ b/static/shared/ts/components/workspace-viewer/index.ts
@@ -1,0 +1,261 @@
+/**
+ * WorkspaceViewer - Coordinates tab management and file viewing.
+ *
+ * Responsibilities:
+ * - Open/close files via TabManager
+ * - Route to Monaco (text) or a dedicated media viewer (images, PDF, CSV, etc.)
+ * - Lazy-load Monaco editor; fall back to <pre> when unavailable
+ * - Manage show/hide of monacoContainer vs mediaContainer
+ */
+
+import { TabManager } from "./TabManager.ts";
+import { ViewerRouter } from "./ViewerRouter.ts";
+import { detectFileType, LANGUAGE_MAP, type TabInfo } from "./types.ts";
+
+export interface WorkspaceViewerConfig {
+  tabsContainer: HTMLElement;
+  monacoContainer: HTMLElement;
+  mediaContainer: HTMLElement;
+  /** Base localStorage key for tab state. Defaults to "ws-viewer-tabs". */
+  storageKey?: string;
+  /** Build the URL for loading file content (raw text or media). */
+  getFileUrl?: (filePath: string, raw?: boolean, download?: boolean) => string;
+}
+
+export class WorkspaceViewer {
+  private tabManager: TabManager;
+  private router: ViewerRouter;
+  private monacoContainer: HTMLElement;
+  private mediaContainer: HTMLElement;
+  private projectId: string = "";
+  private monacoEditor: any = null;
+  private getFileUrl: (
+    filePath: string,
+    raw?: boolean,
+    download?: boolean,
+  ) => string;
+
+  constructor(config: WorkspaceViewerConfig) {
+    this.monacoContainer = config.monacoContainer;
+    this.mediaContainer = config.mediaContainer;
+
+    this.getFileUrl =
+      config.getFileUrl ??
+      ((filePath, raw, _download) => {
+        const base = `/console/api/file-content/${filePath}`;
+        const params = new URLSearchParams();
+        if (this.projectId) params.set("project_id", this.projectId);
+        if (raw) params.set("raw", "true");
+        return `${base}?${params.toString()}`;
+      });
+
+    this.router = new ViewerRouter();
+
+    this.tabManager = new TabManager({
+      container: config.tabsContainer,
+      storageKey: config.storageKey ?? "ws-viewer-tabs",
+      onSwitch: (path) => this.handleTabSwitch(path),
+      onClose: (path) => this.handleTabClose(path),
+    });
+  }
+
+  setProjectId(id: string): void {
+    this.projectId = id;
+  }
+
+  /** Open a file: create a tab and display its content. */
+  async openFile(filePath: string): Promise<void> {
+    const fileType = detectFileType(filePath);
+    const title = filePath.split("/").pop() || filePath;
+
+    const tabInfo: TabInfo = { path: filePath, title, fileType };
+    this.tabManager.openTab(tabInfo);
+
+    // Rendering is triggered by TabManager's onSwitch callback,
+    // but if the tab was already active openTab won't fire onSwitch again.
+    // Re-render explicitly to make sure the content is shown.
+    await this.renderFile(filePath);
+  }
+
+  /** Close a file tab (content cleanup handled in handleTabClose). */
+  closeFile(filePath: string): void {
+    this.tabManager.closeTab(filePath);
+  }
+
+  destroy(): void {
+    this.router.destroyAll();
+    if (this.monacoEditor) {
+      try {
+        this.monacoEditor.dispose();
+      } catch {
+        // ignore
+      }
+      this.monacoEditor = null;
+    }
+  }
+
+  // --- Private ---
+
+  private async handleTabSwitch(path: string): Promise<void> {
+    await this.renderFile(path);
+  }
+
+  private handleTabClose(path: string): void {
+    const active = this.tabManager.getActiveTab();
+    if (!active) {
+      // No tabs remain — hide both panels
+      this.monacoContainer.style.display = "none";
+      this.mediaContainer.style.display = "none";
+    }
+    // The router keeps viewer instances alive for reuse; they are cleaned up on destroy().
+  }
+
+  private async renderFile(filePath: string): Promise<void> {
+    const fileType = detectFileType(filePath);
+
+    if (fileType === "text") {
+      await this.showTextFile(filePath);
+    } else {
+      await this.showMediaFile(filePath);
+    }
+  }
+
+  private async showTextFile(filePath: string): Promise<void> {
+    this.mediaContainer.style.display = "none";
+    this.monacoContainer.style.display = "block";
+
+    // Fetch raw content
+    let content = "";
+    try {
+      const url = this.getFileUrl(filePath, true, false);
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      content = await response.text();
+    } catch (err) {
+      console.error("[WorkspaceViewer] Failed to load file:", filePath, err);
+      content = `// Error loading file: ${filePath}\n// ${err}`;
+    }
+
+    const language =
+      LANGUAGE_MAP[
+        filePath.substring(filePath.lastIndexOf(".")).toLowerCase()
+      ] ?? "plaintext";
+
+    // Try Monaco first, fall back to <pre>
+    const monaco = (window as any).monaco;
+    if (monaco) {
+      await this.loadIntoMonaco(content, language);
+    } else {
+      // Attempt lazy load
+      const monacoLoaded = await this.tryLazyLoadMonaco();
+      if (monacoLoaded) {
+        await this.loadIntoMonaco(content, language);
+      } else {
+        this.showFallbackPre(content);
+      }
+    }
+  }
+
+  private async showMediaFile(filePath: string): Promise<void> {
+    this.monacoContainer.style.display = "none";
+    this.mediaContainer.style.display = "block";
+
+    const viewer = this.router.getViewer(filePath);
+    if (!viewer) {
+      // Binary or unrecognised — show a simple placeholder
+      this.mediaContainer.innerHTML = `
+        <div class="ws-viewer-placeholder">
+          <p>Cannot preview: <code>${filePath.split("/").pop()}</code></p>
+        </div>`;
+      return;
+    }
+
+    try {
+      await viewer.render(this.mediaContainer, filePath, this.projectId);
+    } catch (err) {
+      console.error("[WorkspaceViewer] Viewer render error:", err);
+      this.mediaContainer.innerHTML = `
+        <div class="ws-viewer-placeholder">
+          <p>Error rendering file: ${err instanceof Error ? err.message : String(err)}</p>
+        </div>`;
+    }
+  }
+
+  // --- Monaco helpers ---
+
+  private async loadIntoMonaco(
+    content: string,
+    language: string,
+  ): Promise<void> {
+    const monaco = (window as any).monaco;
+    if (!monaco) return;
+
+    if (!this.monacoEditor) {
+      this.monacoEditor = monaco.editor.create(this.monacoContainer, {
+        value: content,
+        language,
+        automaticLayout: true,
+        theme: this.resolveMonacoTheme(),
+        fontSize: 14,
+        fontFamily: "'JetBrains Mono', 'Monaco', 'Menlo', monospace",
+        minimap: { enabled: true },
+        scrollBeyondLastLine: false,
+        wordWrap: "on",
+        readOnly: true,
+      });
+    } else {
+      const model = this.monacoEditor.getModel();
+      if (model) {
+        monaco.editor.setModelLanguage(model, language);
+      }
+      this.monacoEditor.setValue(content);
+    }
+  }
+
+  private resolveMonacoTheme(): string {
+    const saved = localStorage.getItem("monaco-editor-theme");
+    if (saved) return saved;
+    return document.documentElement.getAttribute("data-theme") === "dark"
+      ? "vs-dark"
+      : "vs";
+  }
+
+  private async tryLazyLoadMonaco(): Promise<boolean> {
+    try {
+      // If the Monaco AMD loader is on the page, wait for the ready event
+      await new Promise<void>((resolve, reject) => {
+        if ((window as any).monaco) {
+          resolve();
+          return;
+        }
+        const timeout = setTimeout(
+          () => reject(new Error("Monaco timeout")),
+          3000,
+        );
+        window.addEventListener(
+          "monaco-ready",
+          () => {
+            clearTimeout(timeout);
+            resolve();
+          },
+          { once: true },
+        );
+      });
+      return !!(window as any).monaco;
+    } catch {
+      return false;
+    }
+  }
+
+  private showFallbackPre(content: string): void {
+    this.monacoContainer.innerHTML = "";
+    const pre = document.createElement("pre");
+    pre.className = "ws-viewer-fallback-pre";
+    pre.textContent = content;
+    this.monacoContainer.appendChild(pre);
+  }
+}
+
+// Named re-exports so consumers can import from this entry point.
+export { detectFileType } from "./types.ts";
+export type { FileType, TabInfo, Viewer } from "./types.ts";

--- a/static/shared/ts/components/workspace-viewer/init.ts
+++ b/static/shared/ts/components/workspace-viewer/init.ts
@@ -1,0 +1,100 @@
+/**
+ * Workspace Viewer - Auto Init
+ * Initializes the shared viewer pane and wires it to the file tree.
+ * Listens for file-select events from the worktree pane.
+ */
+
+import { WorkspaceViewer } from "./index.ts";
+
+declare global {
+  interface Window {
+    workspaceViewer?: WorkspaceViewer;
+  }
+}
+
+function getProjectId(): string {
+  // Try WRITER_CONFIG (writer page)
+  const writerConfig = (window as any).WRITER_CONFIG;
+  if (writerConfig?.projectId) return String(writerConfig.projectId);
+
+  // Try workspace-project-config (hub, scholar, clew) — has project_id data attr
+  const configEl = document.getElementById("workspace-project-config");
+  if (configEl?.dataset.projectId) return configEl.dataset.projectId;
+
+  // Try project-data (console, project detail)
+  const projectData = document.getElementById("project-data");
+  if (projectData?.dataset.projectId) return projectData.dataset.projectId;
+
+  // Try worktree tree element data attributes
+  const worktreeTree = document.getElementById("ws-worktree-tree");
+  if (worktreeTree?.dataset.projectId) return worktreeTree.dataset.projectId;
+
+  return "";
+}
+
+function initWorkspaceViewer(): void {
+  const tabsContainer = document.getElementById("ws-viewer-tabs");
+  const monacoContainer = document.getElementById("ws-viewer-monaco");
+  const mediaContainer = document.getElementById("ws-viewer-media");
+  const emptyState = document.getElementById("ws-viewer-empty");
+
+  if (!tabsContainer || !monacoContainer || !mediaContainer) return;
+
+  const viewer = new WorkspaceViewer({
+    tabsContainer,
+    monacoContainer,
+    mediaContainer,
+    storageKey: "ws-viewer",
+  });
+
+  const projectId = getProjectId();
+  if (projectId) viewer.setProjectId(projectId);
+
+  window.workspaceViewer = viewer;
+
+  // Listen for file-select events from the worktree pane
+  const worktreeTree = document.getElementById("ws-worktree-tree");
+  if (worktreeTree) {
+    worktreeTree.addEventListener("file-select", ((e: CustomEvent) => {
+      const path = e.detail?.path;
+      if (path) {
+        openFileInViewer(viewer, path, emptyState);
+      }
+    }) as EventListener);
+  }
+
+  // Also support double-click to open (more intentional action)
+  document.addEventListener("workspace-file-open", ((e: CustomEvent) => {
+    const path = e.detail?.path;
+    if (path) {
+      openFileInViewer(viewer, path, emptyState);
+    }
+  }) as EventListener);
+}
+
+function openFileInViewer(
+  viewer: WorkspaceViewer,
+  path: string,
+  emptyState: HTMLElement | null,
+): void {
+  // Hide empty state
+  if (emptyState) emptyState.style.display = "none";
+
+  // Auto-expand viewer pane if collapsed
+  const sidebar = document.getElementById("ws-viewer-sidebar");
+  if (sidebar?.classList.contains("collapsed")) {
+    sidebar.classList.remove("collapsed");
+    // Restore saved width or use default
+    const savedWidth = localStorage.getItem("ws-viewer-width");
+    sidebar.style.width = savedWidth ? `${savedWidth}px` : "480px";
+  }
+
+  void viewer.openFile(path);
+}
+
+// Auto-run on DOMContentLoaded
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
+    initWorkspaceViewer();
+  });
+}

--- a/static/shared/ts/components/workspace-viewer/types.ts
+++ b/static/shared/ts/components/workspace-viewer/types.ts
@@ -1,0 +1,136 @@
+/**
+ * Type definitions for the shared Workspace Viewer component.
+ * Extended from console_app workspace types with audio/video support.
+ */
+
+export type FileType =
+  | "text"
+  | "image"
+  | "pdf"
+  | "csv"
+  | "mermaid"
+  | "audio"
+  | "video"
+  | "binary";
+
+/** Interface for viewer components that render file content */
+export interface Viewer {
+  render(
+    container: HTMLElement,
+    filePath: string,
+    projectId: string,
+  ): Promise<void>;
+  destroy(): void;
+}
+
+/** Describes a single open tab in the workspace viewer */
+export interface TabInfo {
+  path: string;
+  title: string;
+  fileType: FileType;
+}
+
+export const LANGUAGE_MAP: { [key: string]: string } = {
+  ".py": "python",
+  ".js": "javascript",
+  ".ts": "typescript",
+  ".html": "html",
+  ".css": "css",
+  ".json": "json",
+  ".md": "markdown",
+  ".yaml": "yaml",
+  ".yml": "yaml",
+  ".sh": "shell",
+  ".bash": "shell",
+  ".r": "r",
+  ".R": "r",
+  ".tex": "latex",
+  ".bib": "bibtex",
+  ".txt": "plaintext",
+};
+
+/** Image file extensions */
+export const IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".svg",
+  ".bmp",
+  ".ico",
+]);
+
+/** PDF file extension */
+export const PDF_EXTENSIONS = new Set([".pdf"]);
+
+/** CSV/TSV file extensions for table view */
+export const CSV_EXTENSIONS = new Set([".csv", ".tsv"]);
+
+/** Mermaid diagram file extensions */
+export const MERMAID_EXTENSIONS = new Set([".mmd", ".mermaid"]);
+
+/** Audio file extensions */
+export const AUDIO_EXTENSIONS = new Set([
+  ".mp3",
+  ".wav",
+  ".ogg",
+  ".flac",
+  ".m4a",
+  ".aac",
+  ".wma",
+]);
+
+/** Video file extensions */
+export const VIDEO_EXTENSIONS = new Set([
+  ".mp4",
+  ".webm",
+  ".avi",
+  ".mov",
+  ".mkv",
+  ".ogv",
+]);
+
+/**
+ * Binary file extensions that cannot be rendered as text or media.
+ * Audio and video are intentionally excluded — they have dedicated viewers.
+ */
+export const BINARY_EXTENSIONS = new Set([
+  ".zip",
+  ".tar",
+  ".gz",
+  ".rar",
+  ".7z",
+  ".exe",
+  ".dll",
+  ".so",
+  ".dylib",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".ppt",
+  ".pptx",
+  ".woff",
+  ".woff2",
+  ".ttf",
+  ".eot",
+  ".otf",
+]);
+
+/**
+ * Detect file type from file path extension.
+ * Audio and video are checked before binary to ensure correct routing.
+ */
+export function detectFileType(filePath: string): FileType {
+  const ext = filePath.substring(filePath.lastIndexOf(".")).toLowerCase();
+
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  if (PDF_EXTENSIONS.has(ext)) return "pdf";
+  if (CSV_EXTENSIONS.has(ext)) return "csv";
+  if (MERMAID_EXTENSIONS.has(ext)) return "mermaid";
+  if (AUDIO_EXTENSIONS.has(ext)) return "audio";
+  if (VIDEO_EXTENSIONS.has(ext)) return "video";
+  if (BINARY_EXTENSIONS.has(ext)) return "binary";
+  return "text";
+}

--- a/static/shared/ts/components/workspace-viewer/viewers/AudioViewer.ts
+++ b/static/shared/ts/components/workspace-viewer/viewers/AudioViewer.ts
@@ -1,0 +1,64 @@
+/**
+ * AudioViewer - Simple HTML5 audio player for audio files.
+ */
+
+import type { Viewer } from "../types.ts";
+
+export class AudioViewer implements Viewer {
+  private audio: HTMLAudioElement | null = null;
+
+  async render(
+    container: HTMLElement,
+    filePath: string,
+    projectId: string,
+  ): Promise<void> {
+    const rawUrl = `/console/api/file-content/${filePath}?project_id=${projectId}&raw=true`;
+    const fileName = filePath.split("/").pop() || filePath;
+    const ext = fileName.includes(".")
+      ? fileName.split(".").pop()?.toUpperCase()
+      : "Audio";
+
+    container.innerHTML = "";
+
+    const wrapper = document.createElement("div");
+    wrapper.style.cssText =
+      "display:flex; flex-direction:column; align-items:center; justify-content:center; height:100%; gap:12px; padding:20px;";
+
+    const nameEl = document.createElement("div");
+    nameEl.style.cssText =
+      "font-size:0.9em; color:#aaa; text-align:center; word-break:break-all;";
+    nameEl.title = filePath;
+    nameEl.textContent = fileName;
+
+    const formatEl = document.createElement("div");
+    formatEl.style.cssText =
+      "font-size:0.75em; color:#666; text-transform:uppercase; letter-spacing:1px;";
+    formatEl.textContent = ext || "Audio";
+
+    this.audio = document.createElement("audio");
+    this.audio.controls = true;
+    this.audio.src = rawUrl;
+    this.audio.style.cssText = "width:100%; max-width:480px;";
+
+    this.audio.onerror = () => {
+      const err = document.createElement("div");
+      err.style.cssText = "color:#e55; font-size:0.9em; text-align:center;";
+      err.textContent = `Failed to load audio: ${fileName}`;
+      wrapper.replaceChild(err, this.audio!);
+      this.audio = null;
+    };
+
+    wrapper.appendChild(nameEl);
+    wrapper.appendChild(formatEl);
+    wrapper.appendChild(this.audio);
+    container.appendChild(wrapper);
+  }
+
+  destroy(): void {
+    if (this.audio) {
+      this.audio.pause();
+      this.audio.src = "";
+      this.audio = null;
+    }
+  }
+}

--- a/static/shared/ts/components/workspace-viewer/viewers/CsvViewer.ts
+++ b/static/shared/ts/components/workspace-viewer/viewers/CsvViewer.ts
@@ -1,0 +1,172 @@
+/**
+ * CsvViewer - Fetches CSV content and renders it as an HTML table.
+ * Supports a toggle between table view and raw text view.
+ * No DataTableManager dependency — simple and self-contained.
+ */
+
+import type { Viewer } from "../types.ts";
+
+export class CsvViewer implements Viewer {
+  private abortController: AbortController | null = null;
+
+  async render(
+    container: HTMLElement,
+    filePath: string,
+    projectId: string,
+  ): Promise<void> {
+    const apiUrl = `/console/api/file-content/${filePath}?project_id=${projectId}`;
+    const fileName = filePath.split("/").pop() || filePath;
+
+    container.innerHTML = "";
+    this.abortController = new AbortController();
+
+    const wrapper = document.createElement("div");
+    wrapper.style.cssText =
+      "display:flex; flex-direction:column; height:100%; overflow:hidden;";
+
+    const toolbar = document.createElement("div");
+    toolbar.style.cssText =
+      "display:flex; align-items:center; gap:8px; padding:6px 10px; border-bottom:1px solid #333; flex-shrink:0; font-size:0.85em;";
+
+    const nameSpan = document.createElement("span");
+    nameSpan.style.cssText = "color:#888; margin-right:auto;";
+    nameSpan.title = filePath;
+    nameSpan.textContent = fileName;
+
+    const toggleBtn = document.createElement("button");
+    toggleBtn.textContent = "Raw";
+    toggleBtn.style.cssText =
+      "cursor:pointer; padding:2px 8px; font-size:0.85em;";
+
+    toolbar.appendChild(nameSpan);
+    toolbar.appendChild(toggleBtn);
+    wrapper.appendChild(toolbar);
+
+    const content = document.createElement("div");
+    content.style.cssText = "flex:1; overflow:auto; padding:8px;";
+    wrapper.appendChild(content);
+    container.appendChild(wrapper);
+
+    content.innerHTML =
+      '<div style="color:#888; padding:10px;">Loading...</div>';
+
+    let rawText = "";
+    let showRaw = false;
+
+    try {
+      const resp = await fetch(apiUrl, { signal: this.abortController.signal });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      rawText = await resp.text();
+    } catch (err: any) {
+      if (err.name === "AbortError") return;
+      content.innerHTML = `<div style="color:#e55; padding:10px;">Failed to load: ${fileName}</div>`;
+      return;
+    }
+
+    const renderTable = () => {
+      content.innerHTML = "";
+      const rows = parseCsv(rawText);
+      if (rows.length === 0) {
+        content.innerHTML =
+          '<div style="color:#888; padding:10px;">Empty file</div>';
+        return;
+      }
+      const table = document.createElement("table");
+      table.style.cssText =
+        "border-collapse:collapse; font-size:0.85em; white-space:nowrap;";
+
+      const thead = document.createElement("thead");
+      const headerRow = document.createElement("tr");
+      for (const cell of rows[0]) {
+        const th = document.createElement("th");
+        th.textContent = cell;
+        th.style.cssText =
+          "padding:4px 8px; border:1px solid #444; background:#2a2a2a; font-weight:600; position:sticky; top:0;";
+        headerRow.appendChild(th);
+      }
+      thead.appendChild(headerRow);
+      table.appendChild(thead);
+
+      const tbody = document.createElement("tbody");
+      for (let i = 1; i < rows.length; i++) {
+        const tr = document.createElement("tr");
+        for (const cell of rows[i]) {
+          const td = document.createElement("td");
+          td.textContent = cell;
+          td.style.cssText = "padding:3px 8px; border:1px solid #333;";
+          tr.appendChild(td);
+        }
+        tbody.appendChild(tr);
+      }
+      table.appendChild(tbody);
+      content.appendChild(table);
+    };
+
+    const renderRaw = () => {
+      content.innerHTML = "";
+      const pre = document.createElement("pre");
+      pre.style.cssText =
+        "margin:0; font-size:0.85em; white-space:pre; color:#ccc;";
+      pre.textContent = rawText;
+      content.appendChild(pre);
+    };
+
+    renderTable();
+
+    toggleBtn.addEventListener("click", () => {
+      showRaw = !showRaw;
+      toggleBtn.textContent = showRaw ? "Table" : "Raw";
+      if (showRaw) renderRaw();
+      else renderTable();
+    });
+  }
+
+  destroy(): void {
+    this.abortController?.abort();
+    this.abortController = null;
+  }
+}
+
+/**
+ * Parse CSV text into a 2D array of strings.
+ * Handles double-quoted fields containing commas and escaped quotes.
+ */
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    rows.push(parseCsvLine(line));
+  }
+  return rows;
+}
+
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"' && line[i + 1] === '"') {
+        field += '"';
+        i++;
+      } else if (ch === '"') {
+        inQuotes = false;
+      } else {
+        field += ch;
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ",") {
+        fields.push(field);
+        field = "";
+      } else {
+        field += ch;
+      }
+    }
+  }
+  fields.push(field);
+  return fields;
+}

--- a/static/shared/ts/components/workspace-viewer/viewers/ImageViewer.ts
+++ b/static/shared/ts/components/workspace-viewer/viewers/ImageViewer.ts
@@ -1,0 +1,129 @@
+/**
+ * ImageViewer - Displays images with zoom (wheel) and pan (drag).
+ * Double-click resets to original position and scale.
+ */
+
+import type { Viewer } from "../types.ts";
+
+export class ImageViewer implements Viewer {
+  private listeners: Array<{
+    target: EventTarget;
+    type: string;
+    fn: EventListener;
+  }> = [];
+
+  async render(
+    container: HTMLElement,
+    filePath: string,
+    projectId: string,
+  ): Promise<void> {
+    const rawUrl = `/console/api/file-content/${filePath}?project_id=${projectId}&raw=true`;
+    const fileName = filePath.split("/").pop() || filePath;
+
+    container.innerHTML = "";
+
+    const wrapper = document.createElement("div");
+    wrapper.style.cssText =
+      "display:flex; flex-direction:column; height:100%; overflow:hidden;";
+
+    const toolbar = document.createElement("div");
+    toolbar.style.cssText =
+      "padding:6px 10px; font-size:0.85em; color:#888; border-bottom:1px solid #333; flex-shrink:0;";
+    toolbar.textContent = fileName;
+    wrapper.appendChild(toolbar);
+
+    const imageContainer = document.createElement("div");
+    imageContainer.style.cssText =
+      "flex:1; overflow:hidden; position:relative; cursor:grab; background:#1a1a1a;";
+
+    const img = document.createElement("img");
+    img.alt = fileName;
+    img.src = rawUrl;
+    img.style.cssText =
+      "position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); max-width:100%; max-height:100%; transform-origin:center center; user-select:none;";
+
+    img.onerror = () => {
+      img.remove();
+      const err = document.createElement("div");
+      err.style.cssText = "padding:20px; color:#e55; text-align:center;";
+      err.textContent = `Failed to load image: ${fileName}`;
+      imageContainer.appendChild(err);
+    };
+
+    imageContainer.appendChild(img);
+    wrapper.appendChild(imageContainer);
+    container.appendChild(wrapper);
+
+    this.setupZoomPan(img, imageContainer);
+  }
+
+  private setupZoomPan(img: HTMLImageElement, container: HTMLElement): void {
+    let scale = 1;
+    let isDragging = false;
+    let startX = 0;
+    let startY = 0;
+    let translateX = 0;
+    let translateY = 0;
+
+    const updateTransform = () => {
+      img.style.transform = `translate(calc(-50% + ${translateX}px), calc(-50% + ${translateY}px)) scale(${scale})`;
+    };
+
+    const onWheel = (e: Event) => {
+      e.preventDefault();
+      const we = e as WheelEvent;
+      const delta = we.deltaY > 0 ? 0.9 : 1.1;
+      scale = Math.max(0.1, Math.min(10, scale * delta));
+      updateTransform();
+    };
+
+    const onMouseDown = (e: Event) => {
+      const me = e as MouseEvent;
+      isDragging = true;
+      startX = me.clientX - translateX;
+      startY = me.clientY - translateY;
+      container.style.cursor = "grabbing";
+    };
+
+    const onMouseMove = (e: Event) => {
+      if (!isDragging) return;
+      const me = e as MouseEvent;
+      translateX = me.clientX - startX;
+      translateY = me.clientY - startY;
+      updateTransform();
+    };
+
+    const onMouseUp = () => {
+      isDragging = false;
+      container.style.cursor = "grab";
+    };
+
+    const onDblClick = () => {
+      scale = 1;
+      translateX = 0;
+      translateY = 0;
+      updateTransform();
+    };
+
+    container.addEventListener("wheel", onWheel, { passive: false });
+    img.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+    img.addEventListener("dblclick", onDblClick);
+
+    this.listeners.push(
+      { target: container, type: "wheel", fn: onWheel as EventListener },
+      { target: img, type: "mousedown", fn: onMouseDown as EventListener },
+      { target: document, type: "mousemove", fn: onMouseMove as EventListener },
+      { target: document, type: "mouseup", fn: onMouseUp as EventListener },
+      { target: img, type: "dblclick", fn: onDblClick as EventListener },
+    );
+  }
+
+  destroy(): void {
+    for (const { target, type, fn } of this.listeners) {
+      target.removeEventListener(type, fn);
+    }
+    this.listeners = [];
+  }
+}

--- a/static/shared/ts/components/workspace-viewer/viewers/MermaidViewer.ts
+++ b/static/shared/ts/components/workspace-viewer/viewers/MermaidViewer.ts
@@ -1,0 +1,73 @@
+/**
+ * MermaidViewer - Fetches .mmd file content and renders it as a Mermaid diagram.
+ * Uses lazy import of mermaid to avoid bundling overhead in other entry points.
+ */
+
+import type { Viewer } from "../types.ts";
+
+export class MermaidViewer implements Viewer {
+  private abortController: AbortController | null = null;
+
+  async render(
+    container: HTMLElement,
+    filePath: string,
+    projectId: string,
+  ): Promise<void> {
+    const apiUrl = `/console/api/file-content/${filePath}?project_id=${projectId}`;
+
+    container.innerHTML =
+      '<div style="color:#888; padding:10px;">Loading diagram...</div>';
+    this.abortController = new AbortController();
+
+    let code: string;
+    try {
+      const resp = await fetch(apiUrl, { signal: this.abortController.signal });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      code = (await resp.text()).trim();
+    } catch (err: any) {
+      if (err.name === "AbortError") return;
+      container.innerHTML = `<div style="color:#e55; padding:10px;">Failed to load: ${filePath}</div>`;
+      return;
+    }
+
+    if (!code) {
+      container.innerHTML =
+        '<div style="color:#888; padding:10px;">Empty diagram file</div>';
+      return;
+    }
+
+    try {
+      const { default: mermaid } = await import("mermaid");
+      mermaid.initialize({
+        startOnLoad: false,
+        theme:
+          document.documentElement.getAttribute("data-theme") === "dark"
+            ? "dark"
+            : "default",
+        securityLevel: "loose",
+      });
+
+      const id = `mmd-${Date.now()}`;
+      const wrapper = document.createElement("div");
+      wrapper.style.cssText = "padding:16px; overflow:auto; height:100%;";
+      wrapper.innerHTML = `<div class="mermaid" id="${id}">${code}</div>`;
+
+      container.innerHTML = "";
+      container.appendChild(wrapper);
+
+      await mermaid.run({ nodes: [wrapper.querySelector(".mermaid")!] });
+    } catch (err) {
+      console.error("[MermaidViewer] Render error:", err);
+      container.innerHTML = `
+        <div style="color:#e55; padding:10px;">
+          Failed to render diagram: ${err instanceof Error ? err.message : String(err)}
+        </div>
+      `;
+    }
+  }
+
+  destroy(): void {
+    this.abortController?.abort();
+    this.abortController = null;
+  }
+}

--- a/static/shared/ts/components/workspace-viewer/viewers/PdfViewer.ts
+++ b/static/shared/ts/components/workspace-viewer/viewers/PdfViewer.ts
@@ -1,0 +1,183 @@
+/**
+ * PdfViewer - Canvas-based PDF rendering via PDF.js CDN.
+ * State is stored as instance properties (not on window).
+ */
+
+import type { Viewer } from "../types.ts";
+
+const PDFJS_CDN =
+  "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js";
+const PDFJS_WORKER =
+  "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js";
+
+export class PdfViewer implements Viewer {
+  private pdf: any = null;
+  private currentPage = 1;
+  private scale = 1.0;
+  private canvas: HTMLCanvasElement | null = null;
+  private totalPagesEl: HTMLElement | null = null;
+  private pageInput: HTMLInputElement | null = null;
+  private zoomLevelEl: HTMLElement | null = null;
+  private pdfContainer: HTMLElement | null = null;
+
+  async render(
+    container: HTMLElement,
+    filePath: string,
+    projectId: string,
+  ): Promise<void> {
+    const rawUrl = `/console/api/file-content/${filePath}?project_id=${projectId}&raw=true`;
+    const fileName = filePath.split("/").pop() || filePath;
+
+    container.innerHTML = "";
+
+    const wrapper = document.createElement("div");
+    wrapper.style.cssText =
+      "display:flex; flex-direction:column; height:100%; overflow:hidden;";
+
+    wrapper.appendChild(this.buildToolbar(fileName));
+
+    this.pdfContainer = document.createElement("div");
+    this.pdfContainer.style.cssText =
+      "flex:1; overflow:auto; padding:10px; background:#2a2a2a; display:flex; justify-content:center;";
+
+    this.canvas = document.createElement("canvas");
+    this.canvas.style.cssText =
+      "display:block; box-shadow:0 2px 8px rgba(0,0,0,0.5);";
+    this.pdfContainer.appendChild(this.canvas);
+
+    wrapper.appendChild(this.pdfContainer);
+    container.appendChild(wrapper);
+
+    await this.loadPdf(rawUrl, fileName);
+  }
+
+  private buildToolbar(fileName: string): HTMLElement {
+    const toolbar = document.createElement("div");
+    toolbar.style.cssText =
+      "display:flex; align-items:center; gap:6px; padding:6px 10px; border-bottom:1px solid #333; flex-shrink:0; font-size:0.85em; flex-wrap:wrap;";
+
+    toolbar.innerHTML = `
+      <span style="color:#888; margin-right:auto;" title="${fileName}">${fileName}</span>
+      <button class="pdf-prev" title="Previous page" style="cursor:pointer;">&#8249;</button>
+      <input class="pdf-page-input" type="number" min="1" value="1"
+        style="width:3em; text-align:center; background:#1a1a1a; color:#ccc; border:1px solid #444; border-radius:3px; padding:2px;">
+      <span> / </span>
+      <span class="pdf-total-pages">-</span>
+      <button class="pdf-next" title="Next page" style="cursor:pointer;">&#8250;</button>
+      <span style="width:8px;"></span>
+      <button class="pdf-zoom-out" title="Zoom out" style="cursor:pointer;">&#8722;</button>
+      <span class="pdf-zoom-level" style="min-width:3.5em; text-align:center;">100%</span>
+      <button class="pdf-zoom-in" title="Zoom in" style="cursor:pointer;">&#43;</button>
+      <button class="pdf-fit-width" title="Fit width" style="cursor:pointer; font-size:0.8em;">Fit</button>
+    `;
+
+    this.totalPagesEl = toolbar.querySelector(".pdf-total-pages");
+    this.pageInput = toolbar.querySelector(".pdf-page-input");
+    this.zoomLevelEl = toolbar.querySelector(".pdf-zoom-level");
+
+    toolbar
+      .querySelector(".pdf-prev")
+      ?.addEventListener("click", () => this.goToPage(this.currentPage - 1));
+    toolbar
+      .querySelector(".pdf-next")
+      ?.addEventListener("click", () => this.goToPage(this.currentPage + 1));
+    this.pageInput?.addEventListener("change", () => {
+      if (this.pageInput) this.goToPage(parseInt(this.pageInput.value, 10));
+    });
+    toolbar
+      .querySelector(".pdf-zoom-in")
+      ?.addEventListener("click", () => this.setZoom(this.scale * 1.25));
+    toolbar
+      .querySelector(".pdf-zoom-out")
+      ?.addEventListener("click", () => this.setZoom(this.scale / 1.25));
+    toolbar
+      .querySelector(".pdf-fit-width")
+      ?.addEventListener("click", () => this.fitWidth());
+
+    return toolbar;
+  }
+
+  private async loadPdf(url: string, fileName: string): Promise<void> {
+    await this.ensurePdfJs();
+    const lib = (window as any).pdfjsLib;
+    if (!lib) {
+      this.showError(`PDF.js unavailable: ${fileName}`);
+      return;
+    }
+    try {
+      this.pdf = await lib.getDocument(url).promise;
+      if (this.totalPagesEl)
+        this.totalPagesEl.textContent = this.pdf.numPages.toString();
+      if (this.pageInput) this.pageInput.max = this.pdf.numPages.toString();
+      await this.renderPage(1, 1.0);
+    } catch (err) {
+      this.showError(`Failed to load PDF: ${fileName}`);
+    }
+  }
+
+  private ensurePdfJs(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if ((window as any).pdfjsLib) {
+        resolve();
+        return;
+      }
+      const script = document.createElement("script");
+      script.src = PDFJS_CDN;
+      script.onload = () => {
+        const lib = (window as any).pdfjsLib;
+        if (lib) lib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER;
+        resolve();
+      };
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+  }
+
+  private async renderPage(pageNum: number, scale: number): Promise<void> {
+    if (!this.pdf || !this.canvas) return;
+    const page = await this.pdf.getPage(pageNum);
+    const viewport = page.getViewport({ scale });
+    this.canvas.width = viewport.width;
+    this.canvas.height = viewport.height;
+    const ctx = this.canvas.getContext("2d");
+    if (!ctx) return;
+    await page.render({ canvasContext: ctx, viewport }).promise;
+    this.currentPage = pageNum;
+    this.scale = scale;
+    if (this.pageInput) this.pageInput.value = pageNum.toString();
+    if (this.zoomLevelEl)
+      this.zoomLevelEl.textContent = `${Math.round(scale * 100)}%`;
+  }
+
+  private goToPage(pageNum: number): void {
+    if (!this.pdf || pageNum < 1 || pageNum > this.pdf.numPages) return;
+    this.renderPage(pageNum, this.scale);
+  }
+
+  private setZoom(scale: number): void {
+    this.renderPage(this.currentPage, Math.max(0.1, Math.min(5, scale)));
+  }
+
+  private async fitWidth(): Promise<void> {
+    if (!this.pdf || !this.pdfContainer) return;
+    const page = await this.pdf.getPage(this.currentPage);
+    const viewport = page.getViewport({ scale: 1 });
+    const scale = (this.pdfContainer.clientWidth - 40) / viewport.width;
+    this.setZoom(scale);
+  }
+
+  private showError(message: string): void {
+    if (this.pdfContainer) {
+      this.pdfContainer.innerHTML = `<div style="padding:20px; color:#e55; text-align:center;">${message}</div>`;
+    }
+  }
+
+  destroy(): void {
+    if (this.pdf) {
+      this.pdf.destroy?.();
+      this.pdf = null;
+    }
+    this.canvas = null;
+    this.pdfContainer = null;
+  }
+}

--- a/static/shared/ts/components/workspace-viewer/viewers/VideoViewer.ts
+++ b/static/shared/ts/components/workspace-viewer/viewers/VideoViewer.ts
@@ -1,0 +1,62 @@
+/**
+ * VideoViewer - Simple HTML5 video player for video files.
+ */
+
+import type { Viewer } from "../types.ts";
+
+export class VideoViewer implements Viewer {
+  private video: HTMLVideoElement | null = null;
+
+  async render(
+    container: HTMLElement,
+    filePath: string,
+    projectId: string,
+  ): Promise<void> {
+    const rawUrl = `/console/api/file-content/${filePath}?project_id=${projectId}&raw=true`;
+    const fileName = filePath.split("/").pop() || filePath;
+
+    container.innerHTML = "";
+
+    const wrapper = document.createElement("div");
+    wrapper.style.cssText =
+      "display:flex; flex-direction:column; height:100%; overflow:hidden; background:#000;";
+
+    const nameEl = document.createElement("div");
+    nameEl.style.cssText =
+      "padding:6px 10px; font-size:0.85em; color:#888; border-bottom:1px solid #222; flex-shrink:0;";
+    nameEl.title = filePath;
+    nameEl.textContent = fileName;
+
+    const videoWrapper = document.createElement("div");
+    videoWrapper.style.cssText =
+      "flex:1; display:flex; align-items:center; justify-content:center; overflow:hidden;";
+
+    this.video = document.createElement("video");
+    this.video.controls = true;
+    this.video.src = rawUrl;
+    this.video.style.cssText =
+      "max-width:100%; max-height:100%; display:block;";
+
+    this.video.onerror = () => {
+      const err = document.createElement("div");
+      err.style.cssText =
+        "color:#e55; font-size:0.9em; text-align:center; padding:20px;";
+      err.textContent = `Failed to load video: ${fileName}`;
+      videoWrapper.replaceChild(err, this.video!);
+      this.video = null;
+    };
+
+    videoWrapper.appendChild(this.video);
+    wrapper.appendChild(nameEl);
+    wrapper.appendChild(videoWrapper);
+    container.appendChild(wrapper);
+  }
+
+  destroy(): void {
+    if (this.video) {
+      this.video.pause();
+      this.video.src = "";
+      this.video = null;
+    }
+  }
+}

--- a/static/shared/ts/components/workspace-viewer/viewers/index.ts
+++ b/static/shared/ts/components/workspace-viewer/viewers/index.ts
@@ -1,0 +1,6 @@
+export { ImageViewer } from "./ImageViewer.ts";
+export { PdfViewer } from "./PdfViewer.ts";
+export { CsvViewer } from "./CsvViewer.ts";
+export { MermaidViewer } from "./MermaidViewer.ts";
+export { AudioViewer } from "./AudioViewer.ts";
+export { VideoViewer } from "./VideoViewer.ts";

--- a/static/shared/ts/global-ai-chat.ts
+++ b/static/shared/ts/global-ai-chat.ts
@@ -12,10 +12,6 @@ import { AIPanelChatMode } from "./components/global-ai-chat/chat-mode";
 import { AIPanelJobsMode } from "./components/global-ai-chat/jobs-mode";
 import { fetchAndPopulateSttModels } from "./components/global-ai-chat/stt-models";
 import { fetchAndPopulateLlmModels } from "./components/global-ai-chat/llm-model-selector";
-import {
-  getAudioMode,
-  initAudioModeSelector,
-} from "./components/global-ai-chat/audio-settings";
 import { fetchMcpStatus } from "./components/global-ai-chat/mcp-status";
 import {
   MODEL_KEY,
@@ -52,12 +48,9 @@ class GlobalAIChat {
   private messagesEl: HTMLElement | null = null;
   private inputEl: HTMLTextAreaElement | null = null;
   private sendBtn: HTMLButtonElement | null = null;
-  private clearBtn: HTMLButtonElement | null = null;
-  private speakBtn: HTMLButtonElement | null = null;
   private micBtn: HTMLButtonElement | null = null;
   private sttModelSelect: HTMLSelectElement | null = null;
   private llmModelSelect: HTMLSelectElement | null = null;
-  private audioModeSelect: HTMLSelectElement | null = null;
   private mcpBadge: HTMLElement | null = null;
   private modelBadge: HTMLElement | null = null;
 
@@ -80,12 +73,6 @@ class GlobalAIChat {
     this.sendBtn = document.getElementById(
       "scitex-ai-send",
     ) as HTMLButtonElement;
-    this.clearBtn = document.getElementById(
-      "scitex-ai-clear",
-    ) as HTMLButtonElement;
-    this.speakBtn = document.getElementById(
-      "scitex-ai-speak",
-    ) as HTMLButtonElement;
     this.micBtn = document.getElementById("scitex-ai-mic") as HTMLButtonElement;
     this.sttModelSelect = document.getElementById(
       "scitex-ai-stt-model",
@@ -93,41 +80,32 @@ class GlobalAIChat {
     this.llmModelSelect = document.getElementById(
       "scitex-ai-llm-model",
     ) as HTMLSelectElement;
-    this.audioModeSelect = document.getElementById(
-      "scitex-ai-audio-mode",
-    ) as HTMLSelectElement;
     this.mcpBadge = document.getElementById("scitex-ai-mcp-badge");
     this.modelBadge = document.getElementById("scitex-ai-model-badge");
 
     if (!this.panel) return;
 
     // Initialise chat mode (encapsulates messaging logic)
-    const autoSpeak = getAudioMode() !== "off";
-    const volBars = Array.from(
-      document.querySelectorAll<HTMLElement>(".scitex-ai-vol-bar"),
-    );
     this.chatMode = new AIPanelChatMode();
     this.chatMode.init(
       {
         messagesEl: this.messagesEl,
         inputEl: this.inputEl,
         sendBtn: this.sendBtn,
-        speakBtn: this.speakBtn,
+        speakBtn: null,
         micBtn: this.micBtn,
         sttModelSelect: this.sttModelSelect,
         modelBadge: this.modelBadge,
-        volBars,
+        volBars: [],
       },
       this.context,
-      autoSpeak,
+      false,
     );
 
     if (this.sttModelSelect)
       fetchAndPopulateSttModels(this.sttModelSelect, this.micBtn);
     if (this.llmModelSelect)
       fetchAndPopulateLlmModels(this.llmModelSelect, this.modelBadge);
-    if (this.audioModeSelect)
-      initAudioModeSelector(this.audioModeSelect, this.speakBtn);
     fetchMcpStatus(this.mcpBadge);
 
     document.body.classList.add("scitex-ai-present");
@@ -151,15 +129,7 @@ class GlobalAIChat {
 
     this.setupModeToggle();
     this.fab?.addEventListener("click", () => this.toggle());
-    this.clearBtn?.addEventListener("click", () =>
-      this.chatMode?.clearConversation(),
-    );
     this.sendBtn?.addEventListener("click", () => void this.chatMode?.send());
-
-    if (autoSpeak) this.speakBtn?.classList.add("active");
-    this.speakBtn?.addEventListener("click", () =>
-      this.chatMode?.toggleSpeak(),
-    );
     this.micBtn?.addEventListener("click", () =>
       this.chatMode?.toggleRecording(),
     );

--- a/static/shared/ts/utils/main.ts
+++ b/static/shared/ts/utils/main.ts
@@ -122,7 +122,6 @@ function initModuleSwitcher(): void {
   const moduleRoutes: Record<string, string> = {
     f: "/files/",
     s: "/scholar/",
-    c: "/console/",
     v: "/vis/",
     w: "/writer/",
   };

--- a/templates/global_base.html
+++ b/templates/global_base.html
@@ -50,6 +50,7 @@
             {% if is_workspace_page and user.is_authenticated %}
                 {% include 'global_base_partials/workspace_ai_pane.html' %}
                 {% include 'global_base_partials/workspace_worktree_pane.html' %}
+                {% include 'global_base_partials/workspace_viewer_pane.html' %}
             {% endif %}
             <main id="main-content"
                   class="{% if is_workspace_page and user.is_authenticated %}ws-module-pane{% endif %}">

--- a/templates/global_base_partials/global_body_scripts.html
+++ b/templates/global_base_partials/global_body_scripts.html
@@ -221,6 +221,8 @@
 {% vite_script 'shared/components/product-tour' %}
 <!-- Workspace file tree auto-init (three-col shared worktree pane) -->
 {% vite_script 'shared/workspace-tree-init' %}
+<!-- Workspace viewer pane auto-init (file viewer/editor) -->
+{% vite_script 'shared/workspace-viewer-init' %}
 <!-- Global AI Chat floating panel -->
 {% vite_script 'shared/workspace-panel-resizer' %}
 {% vite_script 'shared/global-ai-chat' %}

--- a/templates/global_base_partials/global_head_styles.html
+++ b/templates/global_base_partials/global_head_styles.html
@@ -78,3 +78,9 @@
         <!-- Workspace Three-Column Layout (AI | Worktree | Module) -->
         <link rel="stylesheet"
               href="{% static 'shared/css/components/workspace-three-col.css' %}?v={{ build_id }}" />
+        <!-- Workspace Viewer Pane (collapsible file viewer/editor) -->
+        <link rel="stylesheet"
+              href="{% static 'shared/css/components/workspace-viewer.css' %}?v={{ build_id }}" />
+        <!-- Media viewer styles (shared across console and workspace viewer) -->
+        <link rel="stylesheet"
+              href="{% static 'shared/css/components/media-viewer.css' %}?v={{ build_id }}" />

--- a/templates/global_base_partials/global_header.html
+++ b/templates/global_base_partials/global_header.html
@@ -214,13 +214,6 @@
                     {% module_icon "vis" "nav" %}
                     <span class="nav-label">Visualizer</span>
                 </a>
-                <a href="/console/"
-                   class="header-nav-item {% if '/console/' in request.path %}active{% endif %}"
-                   data-tooltip="Console workspace (Alt+C)"
-                   data-shortcut="C">
-                    {% module_icon "console" "nav" %}
-                    <span class="nav-label">Console</span>
-                </a>
                 <a href="/clew/"
                    class="header-nav-item {% if 'clew' in request.path %}active{% endif %}"
                    data-tooltip="Reproducibility verification (Alt+R)"

--- a/templates/global_base_partials/workspace_ai_pane.html
+++ b/templates/global_base_partials/workspace_ai_pane.html
@@ -28,7 +28,6 @@
                 <span class="sidebar-title">AI Agent</span>
                 <span class="scitex-ai-panel-title">
                     <i class="fas fa-robot"></i> AI Agent
-                    <span id="scitex-ai-model-badge" class="scitex-ai-model-badge"></span>
                 </span>
                 <div class="scitex-ai-mode-toggle">
                     <button class="scitex-ai-mode-btn active" data-mode="chat" title="AI Chat">
@@ -39,17 +38,12 @@
                     </button>
                     <button class="scitex-ai-mode-btn" data-mode="jobs" title="SLURM Jobs">
                         <i class="fas fa-tasks"></i>
+                        <span id="ai-jobs-badge" class="ai-mode-badge" style="display: none;">0</span>
                     </button>
                 </div>
                 <div class="scitex-ai-panel-actions">
-                    <button id="scitex-ai-speak" class="scitex-ai-action-btn" title="Toggle auto-speak">
-                        <i class="fas fa-volume-up"></i>
-                    </button>
                     <button id="scitex-ai-settings-btn" class="scitex-ai-action-btn" title="Settings">
                         <i class="fas fa-cog"></i>
-                    </button>
-                    <button id="scitex-ai-clear" class="scitex-ai-action-btn" title="Clear conversation">
-                        <i class="fas fa-trash-alt"></i>
                     </button>
                 </div>
             </div>
@@ -60,6 +54,7 @@
                 <div class="ai-settings-row">
                     <label class="scitex-ai-settings-label">
                         <i class="fas fa-brain"></i> LLM Model
+                        <span id="scitex-ai-model-badge" class="scitex-ai-model-badge"></span>
                     </label>
                     <select id="scitex-ai-llm-model" class="ai-settings-select" title="LLM model for chat"></select>
                 </div>
@@ -72,17 +67,6 @@
                             class="ai-settings-select scitex-ai-stt-model"
                             title="STT model"
                             style="display:none"></select>
-                </div>
-                <!-- Audio Mode -->
-                <div class="ai-settings-row">
-                    <label class="scitex-ai-settings-label">
-                        <i class="fas fa-volume-up"></i> Auto-speak
-                    </label>
-                    <select id="scitex-ai-audio-mode" class="ai-settings-select" title="Auto-speak mode">
-                        <option value="off">Off</option>
-                        <option value="server">Server TTS</option>
-                        <option value="browser">Browser TTS</option>
-                    </select>
                 </div>
                 <!-- MCP Status -->
                 <div class="ai-settings-row ai-settings-mcp">
@@ -120,13 +104,6 @@
                                   rows="3"
                                   placeholder="Ask AI agent... (Enter to send)"
                                   autocomplete="off"></textarea>
-                        <div class="scitex-ai-vol">
-                            <span class="scitex-ai-vol-bar" hidden></span>
-                            <span class="scitex-ai-vol-bar" hidden></span>
-                            <span class="scitex-ai-vol-bar" hidden></span>
-                            <span class="scitex-ai-vol-bar" hidden></span>
-                            <span class="scitex-ai-vol-bar" hidden></span>
-                        </div>
                         <button id="scitex-ai-mic" class="scitex-ai-mic" title="Voice input">
                             <i class="fas fa-microphone"></i>
                         </button>

--- a/templates/global_base_partials/workspace_viewer_pane.html
+++ b/templates/global_base_partials/workspace_viewer_pane.html
@@ -1,0 +1,41 @@
+{% if user.is_authenticated %}
+    <div class="ws-viewer-pane" id="ws-viewer-pane">
+        <div class="workspace-sidebar collapsed" id="ws-viewer-sidebar">
+            <div id="ws-viewer-resizer"
+                 class="panel-resizer"
+                 data-panel-resizer
+                 data-target="#ws-viewer-sidebar"
+                 data-direction="left"
+                 data-min-width="40"
+                 data-default-width="480"
+                 data-storage-key="ws-viewer-width"
+                 data-collapse-key="ws-viewer-collapsed"
+                 data-toggle-btn="ws-viewer-toggle"
+                 style="position:absolute;
+                        right:0;
+                        top:0;
+                        bottom:0;
+                        z-index:1"></div>
+            <div class="sidebar-header">
+                <button class="panel-toggle-btn" id="ws-viewer-toggle" title="Toggle viewer">
+                    <i class="fas fa-chevron-right"></i>
+                </button>
+                <span class="sidebar-title">VIEWER</span>
+                <span class="sidebar-title-full"><i class="fas fa-eye"></i> Viewer</span>
+                <div class="sidebar-header-actions ws-viewer-header-actions">
+                    <div id="ws-viewer-tabs" class="ws-viewer-tabs"></div>
+                </div>
+            </div>
+            <div class="sidebar-content ws-viewer-body">
+                <div id="ws-viewer-content" class="ws-viewer-content">
+                    <div id="ws-viewer-monaco" class="ws-viewer-monaco" style="display:none"></div>
+                    <div id="ws-viewer-media" class="ws-viewer-media" style="display:none"></div>
+                    <div id="ws-viewer-empty" class="ws-viewer-empty">
+                        <i class="fas fa-file-alt"></i>
+                        <span>Click a file to open</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endif %}

--- a/templates/global_base_partials/workspace_worktree_pane.html
+++ b/templates/global_base_partials/workspace_worktree_pane.html
@@ -45,20 +45,6 @@
                         </div>
                     {% endif %}
                 </div>
-                <div class="ws-worktree-preview" id="ws-worktree-preview" style="display:none">
-                    <div class="ws-preview-header">
-                        <span class="ws-preview-title"></span>
-                        <a class="ws-preview-open" href="#" target="_blank" title="Open in Hub">
-                            <i class="fas fa-external-link-alt"></i>
-                        </a>
-                        <button class="ws-preview-close panel-toggle-btn"
-                                id="ws-preview-close"
-                                title="Close preview">
-                            <i class="fas fa-times"></i>
-                        </button>
-                    </div>
-                    <div class="ws-preview-content"></div>
-                </div>
             </div>
         </div>
     </div>

--- a/vite.entries.ts
+++ b/vite.entries.ts
@@ -296,6 +296,10 @@ export function getEntryPoints(rootDir: string): Record<string, string> {
       rootDir,
       "static/shared/ts/components/workspace-files-tree/auto-init.ts",
     ),
+    "shared/workspace-viewer-init": r(
+      rootDir,
+      "static/shared/ts/components/workspace-viewer/init.ts",
+    ),
     "shared/global-ai-chat": r(rootDir, "static/shared/ts/global-ai-chat.ts"),
     "shared/module-tab-switcher": r(
       rootDir,


### PR DESCRIPTION
## Summary
- Add collapsible viewer pane (between worktree and module area) supporting text (Monaco), image, PDF, CSV, mermaid, audio, video
- Tab management with localStorage persistence and drag reorder
- Remove FilePreviewPanel (replaced by full viewer pane)
- Move AI model badge to settings panel, add Quick Ref to hub, hide /console/ from nav

## Test plan
- [x] Click file in worktree → opens in viewer pane with correct content
- [x] Multiple files → tabs appear, switching works
- [x] Viewer pane auto-expands when collapsed
- [x] Vite build passes
- [x] Works on /writer/ page (project ID from WRITER_CONFIG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)