### PR TITLE
feat: AI agent enrichment, chat improvements, workspace viewer

### DIFF
--- a/apps/console_app/services/agents_config.py
+++ b/apps/console_app/services/agents_config.py
@@ -70,15 +70,32 @@ def _build_local_json() -> dict:
 
 
 def _build_agents_md(project_name: str) -> str:
-    """Build a minimal AGENTS.md for the project."""
+    """Build AGENTS.md with platform context for AI coding tools."""
     return (
         f"# {project_name}\n\n"
         "SciTeX Cloud project with access to 145+ MCP tools.\n\n"
-        "## Available Tools\n\n"
+        "## Platform\n\n"
+        "You are running inside an Apptainer container on SciTeX Cloud — a browser-based\n"
+        "scientific research platform. The web app has modules at these URL prefixes:\n\n"
+        "- `/hub/` — Project dashboard and activity feed\n"
+        "- `/scholar/` — Literature search (CrossRef/OpenAlex), bibliography, citation graphs\n"
+        "- `/console/` — File browser, terminal, code execution\n"
+        "- `/writer/` — LaTeX manuscript editor with live preview\n"
+        "- `/workspace/` — Unified 3-column layout (AI | worktree | module)\n"
+        "- `/vis/` — Data visualization and figure management\n"
+        "- `/clew/` — Pipeline DAG editor and execution\n\n"
+        "## MCP Tools\n\n"
+        "The `scitex` MCP server provides tools for:\n"
+        "- **PLT**: plotting, figure composition, cropping\n"
+        "- **STATS**: 23 statistical tests with effect sizes and power analysis\n"
+        "- **SCHOLAR**: paper search, PDF download, BibTeX enrichment\n"
+        "- **WRITER**: LaTeX compilation, figures, tables, bibliography\n"
+        "- **CLEW**: pipeline creation, chaining, execution\n"
+        "- **INTROSPECT**: Python API inspection (signatures, source, docstrings)\n"
+        "- **DIAGRAM**: Mermaid/Graphviz diagram creation\n"
+        "- **TEMPLATE**: project template cloning\n\n"
         "Run `agents sync` to push this config to your AI coding tool.\n"
-        "The SciTeX MCP server provides: plotting (plt), statistics (stats),\n"
-        "literature search (scholar/crossref/openalex), manuscript writing (writer),\n"
-        "dataset access, and more.\n"
+        "Run `/mcp` in Claude Code to list all available tools.\n"
     )
 
 
@@ -189,23 +206,20 @@ def _build_mcp_json(mcp_env: dict[str, str] | None = None) -> dict:
 
 
 def _build_claude_skill() -> str:
-    """Build Claude Code skill from the registered app skills."""
-    try:
-        from apps.llm_app.skills.export import export_claude_skill
+    """Build Claude Code skill from the registered app skills.
 
-        return export_claude_skill()
-    except Exception:
-        logger.exception("Failed to export Claude skill from registry")
-        # Fallback: minimal skill
-        return (
-            "---\n"
-            "name: scitex-cloud\n"
-            "description: SciTeX Cloud research platform with MCP tools\n"
-            "---\n\n"
-            "# SciTeX Cloud\n\n"
-            "Use `import scitex as stx` for scientific research.\n"
-            "MCP tools available: plt, stats, scholar, writer, clew, audio, diagram.\n"
+    Raises on failure — no silent fallback to a minimal stub.
+    """
+    from apps.llm_app.skills.export import export_claude_skill
+
+    skill = export_claude_skill()
+    if not skill or len(skill) < 200:
+        logger.warning(
+            "export_claude_skill() returned unexpectedly short content (%d chars). "
+            "Skills may not be registered yet. Check apps/*/skill.py.",
+            len(skill) if skill else 0,
         )
+    return skill
 
 
 def ensure_claude_config(
@@ -259,7 +273,19 @@ def ensure_claude_config(
             if not claude_md.exists():
                 claude_md.write_text(
                     f"# {project_name}\n\n"
-                    "SciTeX Cloud project. The `scitex` MCP server is connected.\n\n"
+                    "## Platform\n\n"
+                    "You are on **SciTeX Cloud** — a browser-based scientific research platform.\n"
+                    "This project runs inside an Apptainer container with Python 3.11 and the\n"
+                    "`scitex` package pre-installed. The MCP server is connected.\n\n"
+                    "## Web App Modules\n\n"
+                    "The platform URL structure:\n"
+                    "- `/hub/` — Project dashboard\n"
+                    "- `/scholar/` — Literature search & bibliography\n"
+                    "- `/console/` — File browser & terminal\n"
+                    "- `/writer/` — LaTeX manuscript editor\n"
+                    "- `/workspace/` — Unified 3-column layout\n"
+                    "- `/vis/` — Data visualization\n"
+                    "- `/clew/` — Pipeline DAG editor\n\n"
                     "## Usage\n\n"
                     "```python\n"
                     "import scitex as stx\n\n"
@@ -269,8 +295,9 @@ def ensure_claude_config(
                     "    return 0\n"
                     "```\n\n"
                     "## MCP Tools\n\n"
-                    "Run `/mcp` in Claude Code to see available tools.\n"
-                    "Run `/skills` to see SciTeX Cloud capabilities.\n"
+                    "145+ tools available. Run `/mcp` in Claude Code to list them.\n"
+                    "Run `/skills` to see full SciTeX Cloud capabilities.\n"
+                    "`stx-show <file>` in terminal displays images/plots in the browser.\n"
                 )
                 created = True
 

--- a/apps/console_app/views/terminal/consumer.py
+++ b/apps/console_app/views/terminal/consumer.py
@@ -406,7 +406,9 @@ class TerminalConsumer(AsyncWebsocketConsumer):
         """Create .mcp.json + skills if missing (runs in thread)."""
         from apps.console_app.services.agents_config import ensure_claude_config
 
-        ensure_claude_config(user_data_dir, project_dir, project_name=project_name)
+        ensure_claude_config(
+            user_data_dir, project_dir, project_name=project_name, force=True
+        )
 
     async def tts_speak(self, event):
         """Forward TTS speech request to browser via WebSocket.

--- a/apps/llm_app/skills/export.py
+++ b/apps/llm_app/skills/export.py
@@ -3,9 +3,63 @@ Export registered app skills as Claude Code skill files.
 
 Compiles all apps/*/skill.py registrations into a single SKILL.md
 suitable for placement in .claude/skills/scitex-cloud/.
+
+Includes:
+- Registered app skills (capabilities, tool prefixes)
+- Web app structure (URL patterns, module descriptions)
+- Platform navigation guidance
+- MCP tool interaction patterns
 """
 
 from .registry import get_all_skills
+
+# ---------------------------------------------------------------------------
+# Web app module descriptions — dynamically enriches the SKILL.md
+# These are keyed by URL prefix and describe each major web app module.
+# When a new app is added, add an entry here so the agent knows about it.
+# ---------------------------------------------------------------------------
+_WEB_APP_MODULES = {
+    "/hub/": {
+        "name": "Hub",
+        "description": "Project dashboard showing all user projects, activity feed, and quick actions.",
+    },
+    "/scholar/": {
+        "name": "Scholar",
+        "description": "Literature management: search papers (CrossRef/OpenAlex/Semantic Scholar), manage bibliography, explore citation graphs, download PDFs.",
+    },
+    "/console/": {
+        "name": "Console",
+        "description": "Development environment: file browser, terminal (SLURM + Apptainer), code execution, Jupyter notebooks.",
+    },
+    "/writer/": {
+        "name": "Writer",
+        "description": "Scientific manuscript editor: LaTeX editing with live preview, figure/table management, bibliography, PDF compilation.",
+    },
+    "/workspace/": {
+        "name": "Workspace",
+        "description": "Unified three-column layout: AI pane (left) | worktree (middle) | module content (right). Modules switch without losing AI/worktree state.",
+    },
+    "/vis/": {
+        "name": "Visualizer",
+        "description": "Data visualization and figure management: view plots, manage figure recipes, export publication-ready figures.",
+    },
+    "/clew/": {
+        "name": "Clew",
+        "description": "Pipeline DAG editor: create, chain, and run reproducible computational workflows with status tracking.",
+    },
+    "/marketplace/": {
+        "name": "Marketplace",
+        "description": "Discover and install community-shared templates, pipelines, and tools.",
+    },
+    "/modulemaker/": {
+        "name": "Module Maker",
+        "description": "Create custom scitex modules from templates with guided setup.",
+    },
+    "/example/": {
+        "name": "Examples",
+        "description": "Interactive examples demonstrating scitex features (plotting, stats, IO, sessions).",
+    },
+}
 
 
 def export_claude_skill() -> str:
@@ -24,41 +78,94 @@ def export_claude_skill() -> str:
         "",
         "# SciTeX Cloud",
         "",
-        "SciTeX Cloud is a browser-based scientific research platform. The `scitex` MCP server",
-        "provides tools for the full research workflow: data analysis, visualization, statistics,",
-        "literature search, manuscript writing, and reproducible pipelines.",
-        "",
-        "## Quick Start",
-        "",
-        "```python",
-        "import scitex as stx",
-        "",
-        "@stx.session",
-        "def main(plt=stx.INJECTED, logger=stx.INJECTED):",
-        "    fig, ax = stx.plt.subplots()",
-        "    ax.plot_line(x, y)",
-        '    stx.io.save(fig, "plot.png")  # Saves plot + CSV',
-        "    return 0",
-        "```",
-        "",
-        "## Available Modules",
+        "SciTeX Cloud is a browser-based scientific research platform.",
+        "You are running inside an Apptainer container with full terminal access.",
+        "The `scitex` MCP server is connected and provides 145+ tools.",
         "",
     ]
 
-    for name, skill in sorted(skills.items()):
-        parts.append(f"### {skill.display_name}")
-        parts.append("")
-        parts.append(skill.description)
-        parts.append("")
-        if skill.capabilities:
-            for cap in skill.capabilities:
-                parts.append(f"- {cap}")
-            parts.append("")
-        if skill.tool_prefixes:
-            prefixes = ", ".join(f"`{p}*`" for p in skill.tool_prefixes)
-            parts.append(f"MCP tool prefixes: {prefixes}")
-            parts.append("")
+    # ── Web App Structure ──────────────────────────────────────
+    parts.extend(
+        [
+            "## Web App Structure",
+            "",
+            "The platform is organized into modules, each at a URL prefix.",
+            "Projects follow GitHub-style URLs: `/{username}/{project}/`.",
+            "",
+        ]
+    )
 
+    for url, mod in sorted(_WEB_APP_MODULES.items()):
+        parts.append(f"- **{mod['name']}** (`{url}`) — {mod['description']}")
+    parts.append("")
+
+    parts.extend(
+        [
+            "### Navigation",
+            "",
+            "- Tab bar at top switches between modules (Hub, Scholar, Console, Writer, etc.)",
+            "- Workspace layout: AI pane (left) | worktree file tree (middle) | module content (right)",
+            "- AI pane has three modes: Chat (LLM), Console (terminal), Jobs (SLURM)",
+            "- Double-click AI panel header to toggle between Chat and Console",
+            "- `Alt+A` toggles the AI panel open/closed",
+            "",
+        ]
+    )
+
+    # ── Registered App Skills ──────────────────────────────────
+    parts.extend(
+        [
+            "## Registered App Skills",
+            "",
+        ]
+    )
+
+    if skills:
+        for name, skill in sorted(skills.items()):
+            parts.append(f"### {skill.display_name}")
+            parts.append("")
+            parts.append(skill.description)
+            parts.append("")
+            if skill.page_patterns:
+                patterns = ", ".join(f"`{p}`" for p in skill.page_patterns)
+                parts.append(f"Active on pages: {patterns}")
+                parts.append("")
+            if skill.capabilities:
+                for cap in skill.capabilities:
+                    parts.append(f"- {cap}")
+                parts.append("")
+            if skill.tool_prefixes:
+                prefixes = ", ".join(f"`{p}*`" for p in skill.tool_prefixes)
+                parts.append(f"MCP tool prefixes: {prefixes}")
+                parts.append("")
+    else:
+        parts.extend(
+            [
+                "(No app skills registered yet — check apps/*/skill.py)",
+                "",
+            ]
+        )
+
+    # ── Quick Start ────────────────────────────────────────────
+    parts.extend(
+        [
+            "## Quick Start",
+            "",
+            "```python",
+            "import scitex as stx",
+            "",
+            "@stx.session",
+            "def main(plt=stx.INJECTED, logger=stx.INJECTED):",
+            "    fig, ax = stx.plt.subplots()",
+            "    ax.plot_line(x, y)",
+            '    stx.io.save(fig, "plot.png")  # Saves plot + CSV',
+            "    return 0",
+            "```",
+            "",
+        ]
+    )
+
+    # ── Key Patterns ───────────────────────────────────────────
     parts.extend(
         [
             "## Key Patterns",
@@ -68,6 +175,46 @@ def export_claude_skill() -> str:
             "- `stx.stats.test_*(g1, g2)` — 23 statistical tests with effect sizes and power",
             "- `stx.plt.subplots()` — publication-ready figures with data tracking",
             "- `@stx.session` — reproducible experiment tracking with auto-CLI",
+            "",
+        ]
+    )
+
+    # ── MCP Tools ──────────────────────────────────────────────
+    parts.extend(
+        [
+            "## MCP Tools",
+            "",
+            "The `scitex` MCP server provides tools organized by group:",
+            "",
+            "| Group | Description | Example Tools |",
+            "|-------|-------------|---------------|",
+            "| PLT | Plotting & figures | `plt_plot`, `plt_compose`, `plt_crop` |",
+            "| STATS | Statistical tests | `stats_run_test`, `stats_power_analysis` |",
+            "| SCHOLAR | Literature search | `scholar_search_papers`, `scholar_fetch_papers` |",
+            "| WRITER | Manuscript editing | `writer_compile_manuscript`, `writer_add_figure` |",
+            "| CLEW | Pipeline execution | `clew_run`, `clew_chain`, `clew_status` |",
+            "| DIAGRAM | Mermaid/Graphviz | `plt_diagram_create`, `plt_diagram_render` |",
+            "| INTROSPECT | Python API inspection | `introspect_signature`, `introspect_source` |",
+            "| TEMPLATE | Project templates | `template_clone_template` |",
+            "| DATASET | Research datasets | `dataset_search`, `dataset_db_build` |",
+            "| AUDIO | Text-to-speech | `audio_speak` |",
+            "| CAPTURE | Screenshots | `capture_capture_screenshot` |",
+            "",
+            "Run `/mcp` in Claude Code to list all available tools.",
+            "",
+        ]
+    )
+
+    # ── Terminal Interaction ────────────────────────────────────
+    parts.extend(
+        [
+            "## Terminal & Container",
+            "",
+            "- You run inside an Apptainer container with Python 3.11, scitex, and AI CLI tools",
+            "- Terminal uses tmux for session persistence",
+            "- `stx-show <file>` displays images/plots in the browser overlay",
+            "- Project files are at `~/proj/{project_name}/`",
+            "- Output from `@stx.session` goes to `script_out/FINISHED_SUCCESS/{session_id}/`",
             "",
         ]
     )

--- a/static/shared/css/components/global-ai-chat/01-panel-layout.css
+++ b/static/shared/css/components/global-ai-chat/01-panel-layout.css
@@ -42,9 +42,17 @@
   padding: 0 !important;
   display: flex !important;
   flex-direction: column;
-  overflow: hidden;
+  overflow: hidden !important;
+  overflow-y: hidden !important;
   flex: 1;
   border-bottom: none !important;
+}
+
+/* Settings panel: shrinkable, scrollable, contained */
+.scitex-ai-panel .scitex-ai-settings-panel {
+  flex-shrink: 0;
+  max-height: 40%;
+  overflow-y: auto;
 }
 
 /* Expanded header: space-between layout for title + actions */

--- a/static/shared/css/components/global-ai-chat/06-console-mode.css
+++ b/static/shared/css/components/global-ai-chat/06-console-mode.css
@@ -2,6 +2,11 @@
    Console Terminal Container
    ============================================================ */
 
+/* Console view must not scroll — xterm handles its own scrollback */
+#scitex-ai-console-view {
+  overflow: hidden !important;
+}
+
 .scitex-ai-terminal {
   flex: 1;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- **Agent context enrichment**: SKILL.md expanded from ~41 tokens to ~900 tokens with full web app structure, MCP tool groups, navigation guidance, and platform context for visitor agents
- **CLAUDE.md/AGENTS.md enriched**: Generated config files now teach agents about the SciTeX web app modules, URL patterns, and container environment
- **AI chat improvements**: Clickable URLs, markdown rendering, media display, agent context download button, Ctrl+A fix
- **Panel scrolling fix**: Terminal/console in AI pane no longer scrolls past content
- **Workspace viewer**: Shared viewer pane with multi-format file viewing, scratch buffer, tabs
- **Scholar fix**: Removed duplicate FILES sidebar
- **Docker**: Unified staging/prod Dockerfiles, bumped scitex version
- **No silent fallbacks**: Removed silent fallback in `_build_claude_skill()` per project policy

## Test plan
- [ ] Open AI panel console mode — verify no unwanted scroll-up past terminal content
- [ ] Run `/skills` inside Apptainer container — verify >41 description tokens (should be ~900)
- [ ] Check generated CLAUDE.md in visitor project has platform context
- [ ] Click URLs in AI chat messages — verify they open correctly
- [ ] Verify workspace viewer tabs work across modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)