### PR TITLE
fix(terminal): enable tmux mouse mode for scroll support

### DIFF
--- a/apps/console_app/views/terminal/dotfiles.py
+++ b/apps/console_app/views/terminal/dotfiles.py
@@ -29,8 +29,9 @@ export HISTCONTROL=ignoredups:erasedups
 # Prompt: {username}@scitex:~/path $
 PS1='\\[\\033[01;32m\\]{username}@scitex\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\] \\$ '
 
-# Disable tmux mouse mode for normal text selection
-tmux set -g mouse off 2>/dev/null
+# Enable tmux mouse mode for scroll support
+# Hold Shift to bypass and do normal text selection
+tmux set -g mouse on 2>/dev/null
 
 # AI CLI tools (npm global prefix + nvm)
 export NVM_DIR="$HOME/.nvm"
@@ -180,8 +181,9 @@ silent! colorscheme desert
 # set -g prefix C-a
 # bind C-a send-prefix
 
-# Mouse support (off = normal text selection with mouse drag)
-set -g mouse off
+# Mouse support (scroll, click, resize panes)
+# Hold Shift to bypass and do normal text selection
+set -g mouse on
 
 # 256 colors
 set -g default-terminal "xterm-256color"

--- a/apps/console_app/views/terminal/workspace.py
+++ b/apps/console_app/views/terminal/workspace.py
@@ -35,6 +35,9 @@ async def ensure_workspace(user_data_dir: Path, username: str, project_slug: str
         # Patch existing bashrc with AI CLI tools section if missing
         _patch_bashrc_ai_tools(dotfiles_dir)
 
+        # Enable tmux mouse mode for scroll support (migrates old "mouse off")
+        _patch_tmux_mouse(dotfiles_dir)
+
         logger.info(f"Workspace ready: {user_data_dir}")
 
     await asyncio.to_thread(setup)
@@ -60,7 +63,7 @@ def _patch_bashrc_ai_tools(dotfiles_dir: Path):
     has_all_sections = all(
         marker in content
         for marker in [
-            "tmux set -g mouse off",
+            "tmux set -g mouse on",
             ".ai-cli-installed",
             "agents sync",
             "# Aliases",
@@ -82,6 +85,30 @@ def _patch_bashrc_ai_tools(dotfiles_dir: Path):
         # Regenerate from canonical template
         create_dotfiles_repo(dotfiles_dir, username)
         logger.info(f"Regenerated bashrc for {username} (was corrupted/outdated)")
+
+
+def _patch_tmux_mouse(dotfiles_dir: Path):
+    """Migrate tmux mouse off → on for scroll support in both bashrc and tmux.conf."""
+    for filename in ("bashrc", "tmux.conf"):
+        path = dotfiles_dir / filename
+        if not path.exists():
+            continue
+        content = path.read_text()
+        if "mouse off" in content:
+            content = content.replace("mouse off", "mouse on")
+            # Update comment to match
+            content = content.replace(
+                "Disable tmux mouse mode for normal text selection",
+                "Enable tmux mouse mode for scroll support\n"
+                "# Hold Shift to bypass and do normal text selection",
+            )
+            content = content.replace(
+                "Mouse support (off = normal text selection with mouse drag)",
+                "Mouse support (scroll, click, resize panes)\n"
+                "# Hold Shift to bypass and do normal text selection",
+            )
+            path.write_text(content)
+            logger.info(f"Migrated tmux mouse on in {filename}")
 
 
 # EOF


### PR DESCRIPTION
## Summary
- **Root cause**: tmux mouse mode was set to `off` in dotfiles, making terminal scrolling impossible (xterm.js has no scrollback when tmux controls the screen)
- **Fix**: Set `mouse on` in both bashrc and tmux.conf templates
- **Migration**: `_patch_tmux_mouse()` auto-fixes existing users on next terminal connect
- **Text selection**: Hold Shift to bypass mouse mode for text selection

## Test plan
- [ ] Open AI panel console mode, generate lots of output, verify mouse wheel scrolling works
- [ ] Hold Shift and drag to verify text selection still works
- [ ] New visitor account gets `mouse on` in dotfiles
- [ ] Existing visitor reconnects and gets migrated to `mouse on`

🤖 Generated with [Claude Code](https://claude.com/claude-code)