### PR TITLE
fix(writer): section selector + AI chat improvements + terminal fixes

### DIFF
--- a/apps/writer_app/static/writer_app/css/components/sidebar-controls.css
+++ b/apps/writer_app/static/writer_app/css/components/sidebar-controls.css
@@ -120,22 +120,21 @@
   flex-shrink: 0;
 }
 
-/* Section Selector Dropdown */
+/* Section Selector Dropdown
+   Position is set to 'fixed' by JS when opened to escape
+   overflow:hidden on .header-left and .collapsible-panel ancestors */
 .section-selector-dropdown {
   display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
   z-index: 1000;
   background: var(--workspace-bg-primary, #1a1d24);
   border: 1px solid var(--workspace-border-default, #2d3139);
   border-radius: 4px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-  margin-top: 0.25rem;
   min-width: 200px;
-  max-width: 280px;
+  max-width: 320px;
   max-height: 300px;
   overflow-y: auto;
+  flex-direction: column;
 }
 
 /* Show dropdown when open */

--- a/apps/writer_app/static/writer_app/ts/utils/section-dropdown/SectionDropdown.ts
+++ b/apps/writer_app/static/writer_app/ts/utils/section-dropdown/SectionDropdown.ts
@@ -55,7 +55,17 @@ export async function populateSectionDropdownDirect(
       e.stopPropagation();
       const computed = window.getComputedStyle(dropdownContainer).display;
       const isVisible = computed !== "none";
-      dropdownContainer.style.display = isVisible ? "none" : "flex";
+      if (isVisible) {
+        dropdownContainer.style.display = "none";
+      } else {
+        // Use position:fixed to escape overflow:hidden on .header-left and .collapsible-panel
+        const rect = toggleBtn.getBoundingClientRect();
+        dropdownContainer.style.position = "fixed";
+        dropdownContainer.style.top = `${rect.bottom + 4}px`;
+        dropdownContainer.style.left = `${rect.left}px`;
+        dropdownContainer.style.width = `${Math.max(rect.width, 240)}px`;
+        dropdownContainer.style.display = "flex";
+      }
     });
 
     // Close dropdown when clicking outside


### PR DESCRIPTION
## Summary
- **Writer section selector**: Fixed dropdown not opening (first-click bug via getComputedStyle) and dropdown invisible due to overflow:hidden clipping (switched to position:fixed)
- **AI chat**: Clickable error link to settings when no provider configured, daily cost limit (USD) for LLM providers, markdown rendering in chat
- **Terminal**: Fixed scroll support via tmux mouse mode, agent SKILL.md enrichment
- **Docker**: Added BUILD_ID for CSS/JS cache busting in production

## Test plan
- [ ] Open Writer, click section selector dropdown — verify it opens and sections are selectable
- [ ] Open AI chat with no provider configured — verify clickable link to settings
- [ ] Set a daily cost limit in AI Providers settings — verify it's enforced
- [ ] Check terminal scrolling works in AI pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)