### PR TITLE
fix(ui): Files pane not loading — missing data-username attribute

### DIFF
--- a/apps/workspace_app/templates/workspace_app/shell.html
+++ b/apps/workspace_app/templates/workspace_app/shell.html
@@ -112,7 +112,8 @@
                 </div>
                 <div class="sidebar-content">
                     <div data-workspace-tree
-                         {% if current_project %}data-project-slug="{{ current_project.slug }}"{% endif %}></div>
+                         {% if current_project %}data-project-slug="{{ current_project.slug }}" data-username="{{ current_project.owner.username }}"{% endif %}>
+                    </div>
                 </div>
             </div>
         </div>

--- a/static/shared/ts/components/workspace-files-tree/auto-init.ts
+++ b/static/shared/ts/components/workspace-files-tree/auto-init.ts
@@ -132,60 +132,74 @@ export async function autoInitWorktreePanes(): Promise<void> {
 
     const slug = pane.dataset.projectSlug;
     const username = pane.dataset.username;
-    if (!slug || !username) continue;
-
-    // Delegate to custom handler if set; file viewing handled by workspace-viewer pane
-    const onFileSelect = window.scitexOnFileSelect || (() => {});
-
-    const tree = new WorkspaceFilesTree({
-      mode: "hub" as WorkspaceMode,
-      containerId: pane.id,
-      ownerUsername: username,
-      projectSlug: slug,
-      showFolderActions: true,
-      showGitStatus: true,
-      onFileSelect,
-    });
-
-    await tree.initialize();
-
-    initHiddenFilesToggle(tree);
-    initGitStatusToggle(tree);
-    initSortToggle(tree);
-    initModuleFilterButtons(tree, "hub");
-
-    window.workspaceFilesTree = tree;
-
-    // Notify modules that tree is ready
-    if (window.scitexOnTreeDataLoaded) {
-      const data = tree.getTreeData?.() ?? [];
-      window.scitexOnTreeDataLoaded(data);
-    }
 
     // Initialize repository monitor toggle (always — collapse/expand + localStorage)
     initMonitorToggle();
 
-    // Wire repo monitor → tree refresh (replaces polling)
-    let currentMonitorClient = initRepoMonitorForTree(tree, username, slug);
+    let currentMonitorClient: RepoMonitorClient | null = null;
 
-    // Listen for project switch — reinitialize tree + repo monitor
+    // Initialize tree if project is already selected
+    if (slug && username) {
+      const onFileSelect = window.scitexOnFileSelect || (() => {});
+
+      const tree = new WorkspaceFilesTree({
+        mode: "hub" as WorkspaceMode,
+        containerId: pane.id,
+        ownerUsername: username,
+        projectSlug: slug,
+        showFolderActions: true,
+        showGitStatus: true,
+        onFileSelect,
+      });
+
+      await tree.initialize();
+
+      initHiddenFilesToggle(tree);
+      initGitStatusToggle(tree);
+      initSortToggle(tree);
+      initModuleFilterButtons(tree, "hub");
+
+      window.workspaceFilesTree = tree;
+
+      // Notify modules that tree is ready
+      if (window.scitexOnTreeDataLoaded) {
+        const data = tree.getTreeData?.() ?? [];
+        window.scitexOnTreeDataLoaded(data);
+      }
+
+      // Wire repo monitor → tree refresh (replaces polling)
+      currentMonitorClient = initRepoMonitorForTree(tree, username, slug);
+    }
+
+    // Listen for project switch — (re)initialize tree + repo monitor
+    // Registered unconditionally so switching works even when no initial project is set
     window.addEventListener("scitex:project-switched", (async (
       e: CustomEvent<ProjectSwitchedDetail>,
     ) => {
       const newProjectSlug = e.detail.projectSlug;
-      const newOwnerUsername = e.detail.ownerUsername || username;
+      const newOwnerUsername = e.detail.ownerUsername || username || "";
       if (!newProjectSlug) return;
 
       // Update DOM data attributes
       pane.dataset.projectSlug = newProjectSlug;
       pane.dataset.username = newOwnerUsername;
 
-      // Update sidebar title
-      const titleFull = document.querySelector(
-        ".sidebar-title-full",
+      // Update sidebar title (worktree pane)
+      const worktreePane =
+        pane.closest(".ws-worktree-pane") || pane.parentElement?.parentElement;
+      const titleSelectors = [".sidebar-title-expanded", ".sidebar-title-full"];
+      for (const sel of titleSelectors) {
+        const titleEl = worktreePane?.querySelector(sel) as HTMLElement;
+        if (titleEl) {
+          titleEl.innerHTML = `<i class="fas fa-folder-open"></i> ${newOwnerUsername}/${newProjectSlug}`;
+        }
+      }
+      // Also update collapsed title
+      const collapsedTitle = worktreePane?.querySelector(
+        ".sidebar-title",
       ) as HTMLElement;
-      if (titleFull) {
-        titleFull.innerHTML = `<i class="fas fa-folder-open"></i> ${newOwnerUsername}/${newProjectSlug}`;
+      if (collapsedTitle) {
+        collapsedTitle.textContent = `${newOwnerUsername}/${newProjectSlug}`;
       }
 
       // Update project ID on config elements (used by viewer's getProjectId())


### PR DESCRIPTION
## Summary
- **Files pane broken**: `[data-workspace-tree]` element was missing `data-username`, causing `autoInitWorktreePanes()` to bail out entirely
- Project-switch event listener now registered unconditionally, so switching projects works even without an initial project
- Sidebar title selector updated to match workspace shell layout (`.sidebar-title-expanded`)

## Test plan
- [ ] Open workspace — Files pane shows file tree for current project
- [ ] Switch projects via dropdown — Files pane updates to new project's files
- [ ] Open workspace with no project selected — switching to a project populates Files pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)