### PR TITLE
fix(apps): correct profile relation name (v0.12.12)

### DIFF
--- a/apps/accounts_app/management/commands/sync_unix_users.py
+++ b/apps/accounts_app/management/commands/sync_unix_users.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         User = get_user_model()
         dry_run = options["dry_run"]
 
-        users = User.objects.select_related("profile").order_by("pk")
+        users = User.objects.select_related("auth_profile").order_by("pk")
         total = users.count()
 
         self.stdout.write(

--- a/apps/apps_app/views/helpers.py
+++ b/apps/apps_app/views/helpers.py
@@ -104,7 +104,7 @@ def browse_context(request, current_project=None):
     )
     modules = (
         AppsModule.objects.filter(visibility="public")
-        .select_related("author", "author__profile")
+        .select_related("author", "author__auth_profile")
         .annotate(latest_version=Subquery(latest_ver_sq))
         .order_by("-star_count", "-install_count")
     )
@@ -164,7 +164,7 @@ def browse_context(request, current_project=None):
             owner_users = {
                 u.username: u
                 for u in User.objects.filter(username__in=owner_names).select_related(
-                    "profile"
+                    "auth_profile"
                 )
             }
             for d in dev_installs:

--- a/apps/search_app/views.py
+++ b/apps/search_app/views.py
@@ -78,18 +78,18 @@ def search_users(query, current_user=None, limit=20):
             Q(username__icontains=query)
             | Q(first_name__icontains=query)
             | Q(last_name__icontains=query)
-            | Q(profile__institution__icontains=query)
-            | Q(profile__research_interests__icontains=query)
-            | Q(profile__bio__icontains=query)
+            | Q(auth_profile__institution__icontains=query)
+            | Q(auth_profile__research_interests__icontains=query)
+            | Q(auth_profile__bio__icontains=query)
         )
-        .select_related("profile")
+        .select_related("auth_profile")
         .distinct()[:limit]
     )
 
     # Format results
     results = []
     for user in users:
-        profile = getattr(user, "profile", None)
+        profile = getattr(user, "auth_profile", None)
         results.append(
             {
                 "username": user.username,
@@ -176,7 +176,7 @@ def autocomplete(request):
         Q(username__istartswith=query)
         | Q(first_name__istartswith=query)
         | Q(last_name__istartswith=query)
-    ).select_related("profile")[:5]
+    ).select_related("auth_profile")[:5]
 
     for user in users:
         suggestions.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scitex-cloud"
-version = "0.12.11"
+version = "0.12.12"
 description = "SciTeX Cloud - Deployment and management CLI for SciTeX"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
- Fixed FieldError causing 500 on /apps and search pages
- User.profile does not exist - corrected to User.auth_profile
- Bump version to 0.12.12

## Changes
- `apps_app/views/helpers.py`: fix select_related calls
- `search_app/views.py`: fix Q filters and select_related
- `accounts_app`: fix sync_unix_users command

## Test plan
- [x] Verified /apps returns 200
- [x] Deployed to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)