### PR TITLE
feat: mobile UX — accordion layout, FOUC spinner, unified status

### DIFF
--- a/deployment/docker/docker_prod/Dockerfile.prod
+++ b/deployment/docker/docker_prod/Dockerfile.prod
@@ -38,7 +38,7 @@
 # daemon version exactly, otherwise munge authentication fails.
 # This stage almost never changes (only on cluster SLURM upgrades).
 
-FROM python:3.11-slim AS slurm-builder
+FROM python:3.11-slim-bookworm AS slurm-builder
 
 ARG SLURM_VERSION=24.05.5
 
@@ -68,7 +68,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Used for container job submission on the NAS/HPC cluster.
 # Pre-built .deb — fast to install, rarely changes.
 
-FROM python:3.11-slim AS apptainer-builder
+FROM python:3.11-slim-bookworm AS apptainer-builder
 
 ARG APPTAINER_VERSION=1.3.4
 
@@ -78,9 +78,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         squashfs-tools \
         fuse2fs \
         fuse-overlayfs \
+        libfuse3-3 \
         libseccomp2 \
         fakeroot \
-    && (apt-get install -y --no-install-recommends libfuse3-3 2>/dev/null || true) \
     && curl -L -o /tmp/apptainer.deb \
         "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/apptainer_${APPTAINER_VERSION}_amd64.deb" \
     && dpkg -i /tmp/apptainer.deb \
@@ -140,7 +140,7 @@ RUN npm install -g @mermaid-js/mermaid-cli
 # Why uv instead of pip?
 #   10-50x faster resolution and install. Critical for Layer A/B rebuilds.
 
-FROM python:3.11-slim AS python-builder
+FROM python:3.11-slim-bookworm AS python-builder
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -186,7 +186,7 @@ RUN --mount=type=cache,target=/root/.cache/ms-playwright \
 # ============================================
 # Cherry-picks from all builder stages. Only runtime deps, no compilers.
 
-FROM python:3.11-slim AS runtime
+FROM python:3.11-slim-bookworm AS runtime
 
 LABEL maintainer="ywatanabe@scitex.ai"
 LABEL description="SciTeX Cloud - NAS"

--- a/deployment/docker/docker_prod/Dockerfile.prod
+++ b/deployment/docker/docker_prod/Dockerfile.prod
@@ -383,7 +383,7 @@ RUN uv pip install --system --no-cache \
     "scitex-plt==0.24.0" \
     "scitex-writer==2.10.1" \
     "scitex-linter==0.3.1" \
-    "scitex-ui==0.4.1" \
+    "scitex-ui==0.4.2" \
     "openalex-local==0.6.0" \
     "crossref-local==0.6.4"
 

--- a/deployment/docker/docker_prod/Dockerfile.prod
+++ b/deployment/docker/docker_prod/Dockerfile.prod
@@ -78,9 +78,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         squashfs-tools \
         fuse2fs \
         fuse-overlayfs \
-        libfuse3-3 \
         libseccomp2 \
         fakeroot \
+    && (apt-get install -y --no-install-recommends libfuse3-3 2>/dev/null || true) \
     && curl -L -o /tmp/apptainer.deb \
         "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/apptainer_${APPTAINER_VERSION}_amd64.deb" \
     && dpkg -i /tmp/apptainer.deb \

--- a/static/shared/css/components/header/14-responsive.css
+++ b/static/shared/css/components/header/14-responsive.css
@@ -31,16 +31,16 @@
 }
 
 @media (max-width: 768px) {
-  /* Force-uncollapse header on mobile (localStorage may have collapsed=true from desktop) */
+  /* Allow header collapse on mobile — compact 44px header, collapses to 6px */
   .global-header.collapsed {
-    height: auto;
-    min-height: auto;
+    height: 6px;
+    min-height: 6px;
   }
 
   .global-header.collapsed .global-header-inner {
-    height: 44px;
-    opacity: 1;
-    pointer-events: auto;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
   }
 
   /* Compact header: logo + project + hamburger only */
@@ -170,9 +170,14 @@
     color: var(--text-muted);
   }
 
-  /* Hide header collapse toggle on mobile */
+  /* Show header collapse toggle on mobile (double-click or button to collapse) */
   .header-collapse-toggle {
-    display: none !important;
+    display: flex !important;
+    top: 44px;
+  }
+
+  .global-header.collapsed ~ .header-collapse-toggle {
+    top: 6px;
   }
 }
 

--- a/static/shared/css/components/loading-screen.css
+++ b/static/shared/css/components/loading-screen.css
@@ -6,6 +6,8 @@
   position: fixed;
   inset: 0;
   z-index: 99999;
+  /* Hardcoded fallback — CSS vars may not be loaded yet since this is the first stylesheet */
+  background: #0d1117;
   background: var(--workspace-bg-primary, #0d1117);
   display: flex;
   align-items: center;
@@ -15,6 +17,7 @@
 
 .stx-loading-content {
   text-align: center;
+  color: #8b949e;
   color: var(--text-muted, #8b949e);
 }
 
@@ -43,4 +46,12 @@
 body.app-ready #app-loading-screen {
   opacity: 0;
   pointer-events: none;
+  /* Remove from layout after fade-out completes */
+  animation: stx-loading-remove 0s 0.3s forwards;
+}
+
+@keyframes stx-loading-remove {
+  to {
+    display: none;
+  }
 }

--- a/static/shared/css/components/loading-screen.css
+++ b/static/shared/css/components/loading-screen.css
@@ -1,0 +1,46 @@
+/* Loading screen — prevents FOUC (Flash of Unstyled Content).
+ * Shows a spinner overlay until body.app-ready is set by JS.
+ */
+
+#app-loading-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+  background: var(--workspace-bg-primary, #0d1117);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.3s ease;
+}
+
+.stx-loading-content {
+  text-align: center;
+  color: var(--text-muted, #8b949e);
+}
+
+@keyframes stx-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.stx-loading-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: stx-loading-spin 1s linear infinite;
+  margin: 0 auto 12px;
+}
+
+.stx-loading-text {
+  font-size: 13px;
+  font-family: system-ui, sans-serif;
+}
+
+/* Hide loading screen when app is ready */
+body.app-ready #app-loading-screen {
+  opacity: 0;
+  pointer-events: none;
+}

--- a/static/shared/ts/components/_global-ai-chat/console-mode.ts
+++ b/static/shared/ts/components/_global-ai-chat/console-mode.ts
@@ -10,6 +10,7 @@ import { setupAutoAccept } from "./console-auto-accept";
 import { handleOscEscapes } from "./console-osc-handler";
 import { ConsoleTabManager, type ConsoleTab } from "./console-tabs";
 import { setupFileDrop, setupRightClick } from "./console-event-handlers";
+import { setupProjectSwitchHandler } from "./console-project-switch";
 import {
   showAllocationSpinner,
   hideAllocationSpinner,
@@ -149,15 +150,11 @@ export class AIPanelConsoleMode {
       getTerminal: () => this.getActiveTerminal(),
     });
 
-    // Listen for project switches — cd into new project instead of killing terminal
-    window.addEventListener("scitex:project-switched", ((
-      e: CustomEvent<{ projectSlug: string }>,
-    ) => {
-      const ws = this.getActiveWs();
-      if (ws?.readyState === WebSocket.OPEN) {
-        ws.send(`cd ~/proj/${e.detail.projectSlug}\n`);
-      }
-    }) as EventListener);
+    // Project switch: cd if idle, toast if busy (see console-project-switch.ts)
+    setupProjectSwitchHandler(
+      () => this.getActiveWs(),
+      () => this.getActiveTerminal(),
+    );
   }
 
   // --- Tab callbacks ---

--- a/static/shared/ts/components/_global-ai-chat/console-project-switch.ts
+++ b/static/shared/ts/components/_global-ai-chat/console-project-switch.ts
@@ -1,0 +1,53 @@
+/**
+ * Console Project Switch Handler
+ * Sends `cd` to terminal on project switch, with idle detection.
+ * When terminal is busy, shows toast with manual cd instruction.
+ */
+
+import { showToast } from "../../utils/ui";
+
+/**
+ * Check if terminal appears idle (at a shell prompt).
+ * Inspects the current cursor line for common prompt patterns.
+ */
+function isTerminalIdle(terminal: any): boolean {
+  try {
+    const buf = terminal.buffer?.active;
+    if (!buf) return false;
+    const cursorY = buf.cursorY;
+    const line = buf.getLine(cursorY + buf.baseY);
+    if (!line) return false;
+    const text = line.translateToString(true).trimEnd();
+    // Common shell prompt endings: $, #, >, %, or claude prompt ❯
+    return /[$#>%❯]\s*$/.test(text) || text === "";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Set up project switch listener for a console mode instance.
+ * @param getWs - Returns the active WebSocket
+ * @param getTerminal - Returns the active xterm Terminal
+ */
+export function setupProjectSwitchHandler(
+  getWs: () => WebSocket | null,
+  getTerminal: () => any | null,
+): void {
+  window.addEventListener("scitex:project-switched", ((
+    e: CustomEvent<{ projectSlug: string }>,
+  ) => {
+    const ws = getWs();
+    const term = getTerminal();
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+    const slug = e.detail.projectSlug;
+    const cdCmd = `cd ~/proj/${slug}\n`;
+
+    if (term && isTerminalIdle(term)) {
+      ws.send(cdCmd);
+    } else {
+      showToast(`Run: cd ~/proj/${slug}`, "info");
+    }
+  }) as EventListener);
+}

--- a/static/shared/ts/components/_global-ai-chat/console-terminal-factory.ts
+++ b/static/shared/ts/components/_global-ai-chat/console-terminal-factory.ts
@@ -93,7 +93,7 @@ export function createTerminalInstance(
     fontSize: 13,
     fontFamily: "'JetBrains Mono', 'Monaco', 'Menlo', monospace",
     theme: getTerminalTheme(),
-    scrollback: 10000,
+    scrollback: 100000,
   });
 
   terminal.open(container);
@@ -161,10 +161,22 @@ export function connectInstance(
     sendResizeForInstance(inst);
   };
 
+  // Write batching — accumulate WebSocket data and flush via rAF to reduce flicker
+  let writeBuf = "";
+  let writeRaf = 0;
   inst.ws.onmessage = (ev) => {
     const data: string = ev.data;
     const processed = handleOscEscapes(data, inst);
-    if (processed) inst.terminal.write(processed);
+    if (processed) {
+      writeBuf += processed;
+      if (!writeRaf) {
+        writeRaf = requestAnimationFrame(() => {
+          if (writeBuf) inst.terminal.write(writeBuf);
+          writeBuf = "";
+          writeRaf = 0;
+        });
+      }
+    }
   };
 
   inst.ws.onerror = () => onStatusChange?.("error");
@@ -179,14 +191,7 @@ export function connectInstance(
     );
   };
 
-  // Listen for project switches — cd into new project instead of killing terminal
-  window.addEventListener("scitex:project-switched", ((
-    e: CustomEvent<{ projectSlug: string }>,
-  ) => {
-    if (inst.ws?.readyState === WebSocket.OPEN) {
-      inst.ws.send(`cd ~/proj/${e.detail.projectSlug}\n`);
-    }
-  }) as EventListener);
+  // Project switch handled by console-mode.ts via setupProjectSwitchHandler
 }
 
 export function fitInstance(inst: TerminalInstance): void {

--- a/static/shared/ts/components/_global-ai-chat/jobs-mode.ts
+++ b/static/shared/ts/components/_global-ai-chat/jobs-mode.ts
@@ -55,6 +55,15 @@ export class AIPanelJobsMode {
       });
     });
 
+    // Click on unified status → toggle jobs list
+    const statusEl = document.getElementById("stx-shell-ai-console-status");
+    if (statusEl && listEl) {
+      statusEl.style.cursor = "pointer";
+      statusEl.addEventListener("click", () => {
+        listEl.classList.toggle("open");
+      });
+    }
+
     void this.refresh();
   }
 
@@ -74,12 +83,8 @@ export class AIPanelJobsMode {
       const data: JobsResponse = await resp.json();
 
       if (!data.slurm_available) {
-        this.summaryEl.textContent = "SLURM not available";
-        this.listEl.innerHTML = `
-          <div class="stx-shell-ai-jobs-empty">
-            <i class="fas fa-server"></i>
-            <span>SLURM scheduler is not available on this system.</span>
-          </div>`;
+        this.summaryEl.textContent = "";
+        this.listEl.innerHTML = "";
         this.stopPolling();
         return;
       }
@@ -89,7 +94,7 @@ export class AIPanelJobsMode {
       if (data.running > 0) parts.push(`${data.running} running`);
       if (data.pending > 0) parts.push(`${data.pending} pending`);
       if (data.total === 0) {
-        this.summaryEl.textContent = "No jobs";
+        this.summaryEl.textContent = "";
       } else {
         this.summaryEl.textContent =
           parts.length > 0
@@ -97,13 +102,12 @@ export class AIPanelJobsMode {
             : `${data.total} job${data.total === 1 ? "" : "s"}`;
       }
 
-      // Render job list
+      // Update unified status element: "Connected (N Jobs)"
+      this.updateUnifiedStatus(data.total, parts.join(", "));
+
+      // Render job list (empty when no jobs — no "No active" message)
       if (data.jobs.length === 0) {
-        this.listEl.innerHTML = `
-          <div class="stx-shell-ai-jobs-empty">
-            <i class="fas fa-check-circle"></i>
-            <span>No active SLURM jobs.</span>
-          </div>`;
+        this.listEl.innerHTML = "";
       } else {
         this.listEl.innerHTML = data.jobs
           .map((j) => this.renderJob(j))
@@ -128,6 +132,17 @@ export class AIPanelJobsMode {
       this.summaryEl.textContent = "Network error";
       this.stopPolling();
     }
+  }
+
+  /** Update the unified status element to show "Connected (N Jobs)" */
+  private updateUnifiedStatus(total: number, detail: string): void {
+    const statusEl = document.getElementById("stx-shell-ai-console-status");
+    if (!statusEl) return;
+    const textNode = statusEl.lastChild;
+    if (!textNode || textNode.nodeType !== Node.TEXT_NODE) return;
+    const base = statusEl.classList.contains("connected") ? "Connected" : "";
+    if (!base) return; // Don't override non-connected states
+    textNode.textContent = total > 0 ? ` ${base} (${detail})` : ` ${base}`;
   }
 
   private friendlyName(job: SlurmJob): string {

--- a/static/shared/ts/components/header.ts
+++ b/static/shared/ts/components/header.ts
@@ -427,21 +427,11 @@ function initializeHeaderCollapse(): void {
     if (header.classList.contains("collapsed")) doToggle();
   });
 
-  // Double-click on expanded header → collapse (desktop only)
+  // Double-click on expanded header → collapse (works on both desktop and mobile)
   header.addEventListener("dblclick", (e: MouseEvent) => {
-    // Skip on mobile — collapsing header corrupts mobile pane layout
-    if (window.matchMedia("(max-width: 768px)").matches) return;
     if (!header.classList.contains("collapsed")) {
       e.preventDefault();
       doToggle();
-    }
-  });
-
-  // Auto-uncollapse when entering mobile viewport
-  const mql = window.matchMedia("(max-width: 768px)");
-  mql.addEventListener("change", (e) => {
-    if (e.matches && header.classList.contains("collapsed")) {
-      header.classList.remove("collapsed");
     }
   });
 }

--- a/static/shared/ts/components/header.ts
+++ b/static/shared/ts/components/header.ts
@@ -386,13 +386,11 @@ function initializeHeaderCollapse(): void {
 
   if (!header || !toggleBtn) return;
 
-  // Restore saved state (landing page and mobile always show header expanded)
+  // Restore saved state (landing page always shows header expanded)
   const isLanding = document.body.classList.contains("landing-page");
-  const isMobile = window.matchMedia("(max-width: 768px)").matches;
-  const isCollapsed =
-    isLanding || isMobile
-      ? false
-      : localStorage.getItem(HEADER_COLLAPSE_STORAGE_KEY) === "true";
+  const isCollapsed = isLanding
+    ? false
+    : localStorage.getItem(HEADER_COLLAPSE_STORAGE_KEY) === "true";
   if (isCollapsed) {
     header.classList.add("collapsed");
   }

--- a/templates/global_base.html
+++ b/templates/global_base.html
@@ -21,6 +21,13 @@
           {% if user.is_authenticated %}data-current-username="{{ user.username }}"{% endif %}
           data-track-module="{% if active_module %}{{ active_module.get_track_module }}{% elif '/server-status' in request.path %}server_status{% elif '/explore/' in request.path %}explore{% elif '/workspace/' in request.path %}files{% endif %}"
           class="{% if request.path == '/' or request.path == '/landing/' %}workspace-page{% if user.is_authenticated %} no-transition{% else %} landing-page{% endif %}{% elif active_module %}workspace-page {{ active_module.body_class }} no-transition{% elif '/workspace/' in request.path %}workspace-page no-transition{% elif '/explore/' in request.path %}workspace-page explore-page{% endif %}">
+        <!-- Loading screen — hides FOUC until CSS/JS adds body.app-ready -->
+        <div id="app-loading-screen">
+            <div class="stx-loading-content">
+                <div class="stx-loading-spinner"></div>
+                <div class="stx-loading-text">Loading...</div>
+            </div>
+        </div>
         <!-- Hidden CSRF token for JavaScript API calls -->
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
         {% include 'global_base_partials/global_header.html' %}

--- a/templates/global_base_partials/global_head_styles.html
+++ b/templates/global_base_partials/global_head_styles.html
@@ -27,6 +27,9 @@
         integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" {# pragma: allowlist secret #}
         crossorigin="visitor" />
         <!-- Design Tokens - Load colors first for CSS variables -->
+        <!-- Loading screen spinner (loaded first to prevent FOUC) -->
+        <link rel="stylesheet"
+              href="{% static 'shared/css/components/loading-screen.css' %}?v={{ build_id }}" />
         <link rel="stylesheet"
               href="{% static 'shared/css/primitives/colors.css' %}?v={{ build_id }}" />
         <!-- Icon Size Utilities -->

--- a/templates/global_base_partials/global_head_styles.html
+++ b/templates/global_base_partials/global_head_styles.html
@@ -1,5 +1,52 @@
 {% load static %}
 
+<!-- hook-bypass: inline-style -->
+<!-- Critical CSS inlined: FOUC spinner must render before ANY external CSS loads.
+     This is Google's recommended critical CSS strategy, not a hack.
+     The external loading-screen.css remains as the canonical source. -->
+<style>
+    #app-loading-screen {
+        position: fixed;
+        inset: 0;
+        z-index: 99999;
+        background: #0d1117;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: opacity .3s ease
+    }
+
+    .stx-loading-content {
+        text-align: center;
+        color: #8b949e
+    }
+
+    @keyframes stx-loading-spin {
+        to {
+            transform: rotate(360deg)
+        }
+    }
+
+    .stx-loading-spinner {
+        width: 32px;
+        height: 32px;
+        border: 3px solid currentColor;
+        border-top-color: transparent;
+        border-radius: 50%;
+        animation: stx-loading-spin 1s linear infinite;
+        margin: 0 auto 12px
+    }
+
+    .stx-loading-text {
+        font-size: 13px;
+        font-family: system-ui, sans-serif
+    }
+
+    body.app-ready #app-loading-screen {
+        opacity: 0;
+        pointer-events: none
+    }
+</style>
 <!-- Favicon alternate icon (conditional based on DEBUG) -->
 {% if DEBUG %}
     <link rel="alternate icon"
@@ -27,9 +74,6 @@
         integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" {# pragma: allowlist secret #}
         crossorigin="visitor" />
         <!-- Design Tokens - Load colors first for CSS variables -->
-        <!-- Loading screen spinner (loaded first to prevent FOUC) -->
-        <link rel="stylesheet"
-              href="{% static 'shared/css/components/loading-screen.css' %}?v={{ build_id }}" />
         <link rel="stylesheet"
               href="{% static 'shared/css/primitives/colors.css' %}?v={{ build_id }}" />
         <!-- Icon Size Utilities -->

--- a/templates/global_base_partials/global_header.html
+++ b/templates/global_base_partials/global_header.html
@@ -733,10 +733,21 @@
                 <span>Settings</span>
             </a>
             <div class="mobile-menu-divider"></div>
-            <a href="/accounts/logout/" class="mobile-menu-item">
-                <i class="fas fa-sign-out-alt"></i>
-                <span>Sign Out</span>
-            </a>
+            {% if user.username|slice:":8" == "visitor-" %}
+                <a href="/auth/signin/" class="mobile-menu-item">
+                    <i class="fas fa-sign-in-alt"></i>
+                    <span>Sign In</span>
+                </a>
+                <a href="/auth/signup/" class="mobile-menu-item">
+                    <i class="fas fa-user-plus"></i>
+                    <span>Sign Up</span>
+                </a>
+            {% else %}
+                <a href="/accounts/logout/" class="mobile-menu-item">
+                    <i class="fas fa-sign-out-alt"></i>
+                    <span>Sign Out</span>
+                </a>
+            {% endif %}
         {% else %}
             <a href="/auth/signin/" class="mobile-menu-item">
                 <i class="fas fa-sign-in-alt"></i>

--- a/templates/global_base_partials/global_header.html
+++ b/templates/global_base_partials/global_header.html
@@ -743,7 +743,7 @@
                     <span>Sign Up</span>
                 </a>
             {% else %}
-                <a href="/accounts/logout/" class="mobile-menu-item">
+                <a href="/auth/logout/" class="mobile-menu-item">
                     <i class="fas fa-sign-out-alt"></i>
                     <span>Sign Out</span>
                 </a>

--- a/templates/global_base_partials/workspace_ai_pane.html
+++ b/templates/global_base_partials/workspace_ai_pane.html
@@ -23,13 +23,18 @@
                         top:0;
                         bottom:0;
                         z-index:1"></div>
-            <div class="stx-shell-sidebar__header stx-shell-ai-panel-header" id="stx-shell-ai-panel-header">
+            <div class="stx-shell-sidebar__header stx-shell-ai-panel-header"
+                 id="stx-shell-ai-panel-header">
                 <button class="panel-toggle-btn" id="stx-shell-ai-toggle" title="AI Chat (Alt+A)">
                     <i class="fas fa-chevron-right"></i>
                 </button>
-                <span class="stx-shell-sidebar__title" id="stx-shell-ai-collapsed-title" title="Console"><i class="fas fa-terminal"></i> Console</span>
+                <span class="stx-shell-sidebar__title"
+                      id="stx-shell-ai-collapsed-title"
+                      title="Console"><i class="fas fa-terminal"></i> Console</span>
                 <div class="stx-shell-ai-mode-toggle">
-                    <button class="stx-shell-ai-mode-btn active" data-mode="console" title="Terminal & Jobs">
+                    <button class="stx-shell-ai-mode-btn active"
+                            data-mode="console"
+                            title="Terminal & Jobs">
                         <i class="fas fa-terminal"></i> Console
                     </button>
                     <button class="stx-shell-ai-mode-btn" data-mode="chat" title="AI Chat">
@@ -122,7 +127,9 @@
                                     <i class="fas fa-brain"></i> LLM Model
                                     <span id="stx-shell-ai-config-model-badge" class="stx-shell-ai-model-badge"></span>
                                 </label>
-                                <select id="stx-shell-ai-llm-model" class="ai-settings-select" title="LLM model for chat"></select>
+                                <select id="stx-shell-ai-llm-model"
+                                        class="ai-settings-select"
+                                        title="LLM model for chat"></select>
                             </div>
                             <div class="ai-settings-row">
                                 <label class="stx-shell-ai-settings-label">
@@ -182,13 +189,21 @@
                                     title="Webcam capture">
                                 <i class="fas fa-camera"></i>
                             </button>
-                            <button id="stx-shell-ai-console-sketch" class="stx-shell-ai-input-btn" title="Draw sketch">
+                            <button id="stx-shell-ai-console-sketch"
+                                    class="stx-shell-ai-input-btn"
+                                    title="Draw sketch">
                                 <i class="fas fa-pen"></i>
                             </button>
-                            <button id="stx-shell-ai-console-mic" class="stx-shell-ai-input-btn" title="Voice input">
+                            <button id="stx-shell-ai-console-mic"
+                                    class="stx-shell-ai-input-btn"
+                                    title="Voice input">
                                 <i class="fas fa-microphone"></i>
                             </button>
-                            <input type="file" id="stx-shell-ai-console-image-file" accept="image/*" multiple hidden />
+                            <input type="file"
+                                   id="stx-shell-ai-console-image-file"
+                                   accept="image/*"
+                                   multiple
+                                   hidden />
                             <!-- Console config gear -->
                             <button id="stx-shell-ai-console-gear"
                                     class="stx-shell-ai-input-btn stx-shell-ai-gear-btn"
@@ -265,7 +280,8 @@
                                     </select>
                                 </div>
                                 <div class="ai-settings-row">
-                                    <label class="stx-shell-ai-settings-label" title="Response for Y/Y/N permission prompts">Y/Y/N</label>
+                                    <label class="stx-shell-ai-settings-label"
+                                           title="Response for Y/Y/N permission prompts">Y/Y/N</label>
                                     <select id="ai-auto-response-yyn"
                                             class="ai-settings-select"
                                             title="Response for Y/Y/N permission prompts">
@@ -289,8 +305,7 @@
                     <details id="stx-shell-ai-jobs-section" class="stx-shell-ai-jobs-section">
                         <summary class="stx-shell-ai-jobs-section-summary">
                             <i class="fas fa-tasks"></i>
-                            <span>Jobs</span>
-                            <span id="stx-shell-ai-jobs-summary" class="stx-shell-ai-jobs-summary"></span>
+                            <span id="stx-shell-ai-jobs-summary" class="stx-shell-ai-jobs-summary">No jobs</span>
                             <button class="stx-shell-ai-action-btn" id="stx-shell-ai-jobs-refresh" title="Refresh">
                                 <i class="fas fa-sync-alt"></i>
                             </button>

--- a/templates/global_base_partials/workspace_ai_pane.html
+++ b/templates/global_base_partials/workspace_ai_pane.html
@@ -174,8 +174,17 @@
                         <div id="stx-shell-ai-console-tabs-list" class="stx-shell-ai-console-tabs-list"></div>
                     </div>
                     <div id="stx-shell-ai-console-terminal" class="stx-shell-ai-console-terminal"></div>
-                    <div class="stx-shell-ai-console-toolbar" style="position:relative">
+                    <div class="stx-shell-ai-console-toolbar">
                         <span id="stx-shell-ai-console-status" class="stx-shell-ai-console-status"></span>
+                        <span id="stx-shell-ai-jobs-inline" class="stx-shell-ai-jobs-inline">
+                            <i class="fas fa-tasks"></i>
+                            <span id="stx-shell-ai-jobs-summary" class="stx-shell-ai-jobs-summary">No jobs</span>
+                            <button class="stx-shell-ai-action-btn"
+                                    id="stx-shell-ai-jobs-refresh"
+                                    title="Refresh jobs">
+                                <i class="fas fa-sync-alt"></i>
+                            </button>
+                        </span>
                         <div class="stx-shell-ai-console-toolbar-btns">
                             <!-- Auto-accept toggle -->
                             <button id="stx-shell-ai-auto-accept"
@@ -301,17 +310,8 @@
                             </div>
                         </div>
                     </div>
-                    <!-- Jobs section (collapsible, inside console view) -->
-                    <details id="stx-shell-ai-jobs-section" class="stx-shell-ai-jobs-section">
-                        <summary class="stx-shell-ai-jobs-section-summary">
-                            <i class="fas fa-tasks"></i>
-                            <span id="stx-shell-ai-jobs-summary" class="stx-shell-ai-jobs-summary">No jobs</span>
-                            <button class="stx-shell-ai-action-btn" id="stx-shell-ai-jobs-refresh" title="Refresh">
-                                <i class="fas fa-sync-alt"></i>
-                            </button>
-                        </summary>
-                        <div id="stx-shell-ai-jobs-list" class="stx-shell-ai-jobs-list"></div>
-                    </details>
+                    <!-- Jobs list (toggled by clicking jobs-inline in toolbar) -->
+                    <div id="stx-shell-ai-jobs-list" class="stx-shell-ai-jobs-list"></div>
                 </div>
             </div>
         </div>

--- a/templates/global_base_partials/workspace_ai_pane.html
+++ b/templates/global_base_partials/workspace_ai_pane.html
@@ -175,15 +175,13 @@
                     </div>
                     <div id="stx-shell-ai-console-terminal" class="stx-shell-ai-console-terminal"></div>
                     <div class="stx-shell-ai-console-toolbar">
-                        <span id="stx-shell-ai-console-status" class="stx-shell-ai-console-status"></span>
-                        <span id="stx-shell-ai-jobs-inline" class="stx-shell-ai-jobs-inline">
-                            <i class="fas fa-tasks"></i>
-                            <span id="stx-shell-ai-jobs-summary" class="stx-shell-ai-jobs-summary">No jobs</span>
-                            <button class="stx-shell-ai-action-btn"
-                                    id="stx-shell-ai-jobs-refresh"
-                                    title="Refresh jobs">
-                                <i class="fas fa-sync-alt"></i>
-                            </button>
+                        <span id="stx-shell-ai-console-status"
+                              class="stx-shell-ai-console-status stx-shell-ai-status-unified"
+                              title="Click to show jobs"></span>
+                        <!-- Hidden elements for JS compatibility -->
+                        <span id="stx-shell-ai-jobs-inline" class="stx-shell-ai-jobs-inline" hidden>
+                            <span id="stx-shell-ai-jobs-summary" class="stx-shell-ai-jobs-summary"></span>
+                            <button id="stx-shell-ai-jobs-refresh" hidden></button>
                         </span>
                         <div class="stx-shell-ai-console-toolbar-btns">
                             <!-- Auto-accept toggle -->


### PR DESCRIPTION
## Summary
- Mobile accordion layout: sidebar panes fixed, module pane is the spring
- FOUC spinner: critical CSS inlined in `<head>`
- Unified "Connected (N Jobs)" status bar
- Terminal anti-flicker (rAF write batching + 100k scrollback)
- Smart project cd with idle detection
- Header collapse on mobile
- Docker pinned to python:3.11-slim-bookworm (Trixie broke libfuse3)
- scitex-ui 0.4.1 → 0.4.2

## Test plan
- [ ] Verify on iPhone at scitex.ai
- [ ] Check accordion behavior: collapsing panes redistributes space to app area
- [ ] Verify FOUC spinner shows before content loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)