### PR TITLE
feat: add _skills/ with non-monolith skills layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 
 [tool.setuptools.package-data]
-scitex_cloud = ["skills/*.md", "skills/references/*.md"]
+scitex_cloud = ["skills/*.md", "skills/references/*.md", "_skills/**/*.md"]
 
 [tool.setuptools.package-dir]
 "" = "src"

--- a/src/scitex_cloud/_skills/scitex-cloud/SKILL.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: scitex-cloud
+description: SciTeX Cloud platform CLI — project management, Git hosting (Gitea), three-way sync, app deployment, cloud SDK, and infrastructure. Use when managing projects, syncing code, deploying apps, or running cloud operations.
+allowed-tools: mcp__scitex__cloud_*
+---
+
+# scitex-cloud Skills Index
+
+This directory contains focused skill files for the scitex-cloud package.
+
+## Sub-Skills
+
+| File | Topic |
+|------|-------|
+| [python-api.md](python-api.md) | Python API — CloudClient, project_*, health_check |
+| [project-management.md](project-management.md) | CLI project CRUD — create, list, delete, rename |
+| [sync-architecture.md](sync-architecture.md) | Three-way sync — push/pull (git) and sync-to/from (files) |
+| [gitea-cli.md](gitea-cli.md) | Gitea Git hosting — repos, PRs, issues, auth |
+| [app-management.md](app-management.md) | App plugins — init, validate, submit, prefs, containers |
+| [sdk.md](sdk.md) | Cloud SDK — DataStore, FileVault, JobQueue |
+| [infrastructure.md](infrastructure.md) | Docker, setup, deploy, MCP server |
+
+## Quick Navigation
+
+- Managing cloud projects -> [project-management.md](project-management.md)
+- Syncing code between local/workspace -> [sync-architecture.md](sync-architecture.md)
+- Git repo operations (clone, fork, PR, issue) -> [gitea-cli.md](gitea-cli.md)
+- Developing/publishing apps -> [app-management.md](app-management.md)
+- DataStore / FileVault / JobQueue -> [sdk.md](sdk.md)
+- Docker, deploy, MCP server -> [infrastructure.md](infrastructure.md)
+- Python API programmatic access -> [python-api.md](python-api.md)
+
+# EOF

--- a/src/scitex_cloud/_skills/scitex-cloud/SKILL.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/SKILL.md
@@ -19,6 +19,10 @@ This directory contains focused skill files for the scitex-cloud package.
 | [app-management.md](app-management.md) | App plugins — init, validate, submit, prefs, containers |
 | [sdk.md](sdk.md) | Cloud SDK — DataStore, FileVault, JobQueue |
 | [infrastructure.md](infrastructure.md) | Docker, setup, deploy, MCP server |
+| [deployment-staging.md](deployment-staging.md) | Deploy to staging — sync, build, verify |
+| [deployment-production.md](deployment-production.md) | Deploy to production — zero-downtime |
+| [version-management.md](version-management.md) | Ecosystem version sync and bump |
+| [refactoring-rules.md](refactoring-rules.md) | TS/Django refactoring conventions |
 
 ## Quick Navigation
 
@@ -29,5 +33,9 @@ This directory contains focused skill files for the scitex-cloud package.
 - DataStore / FileVault / JobQueue -> [sdk.md](sdk.md)
 - Docker, deploy, MCP server -> [infrastructure.md](infrastructure.md)
 - Python API programmatic access -> [python-api.md](python-api.md)
+- Deploy to staging -> [deployment-staging.md](deployment-staging.md)
+- Deploy to production -> [deployment-production.md](deployment-production.md)
+- Version sync across ecosystem -> [version-management.md](version-management.md)
+- Refactoring rules (TS/Django) -> [refactoring-rules.md](refactoring-rules.md)
 
 # EOF

--- a/src/scitex_cloud/_skills/scitex-cloud/app-management.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/app-management.md
@@ -1,0 +1,111 @@
+---
+name: app-management
+description: SciTeX app plugin management — scaffold new apps, validate, submit for review, manage preferences, check dependencies, build Apptainer containers. Apps must end in _app or -app.
+---
+
+# App Management CLI
+
+All commands under `scitex-cloud app`.
+
+## Scaffold a New App
+
+```bash
+scitex-cloud app init [target_dir] [options]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `target_dir` | `.` | Directory to scaffold in |
+| `-n / --name` | (dir name) | App module name (must end with `_app`) |
+| `-l / --label` | `""` | Human-readable label |
+| `-i / --icon` | `fas fa-puzzle-piece` | Font Awesome icon class |
+| `-d / --description` | `""` | Short description |
+| `-f / --frontend` | `html` | `html` or `react` (React+Vite+Zustand) |
+| `--overwrite` | (flag) | Overwrite existing files |
+
+Creates: `apps.py`, `views.py`, `urls.py`, `tests.py`, `skill.py`, `manifest.json`, templates, static, agents config, README, LICENSE.
+
+```bash
+scitex-cloud app init .
+scitex-cloud app init /path/to/my_app --name my_awesome_app
+scitex-cloud app init . -n demo_app -l "Demo" -i "fas fa-flask" -f react
+```
+
+## Validate
+
+```bash
+scitex-cloud app validate [app_dir]    # check structure, security, manifest
+```
+
+Exits 1 if any issue found. Run before submitting.
+
+## Development
+
+```bash
+scitex-cloud app dev [app_dir] [--port PORT]    # show dev server instructions
+```
+
+## Submit for Review
+
+```bash
+scitex-cloud app submit [app_dir] [--server URL]
+```
+
+Validates locally, authenticates via JWT, submits to server. Opens a PR on the central `scitex/apps` registry (MELPA-style: merge = approval).
+
+## Browse Apps
+
+```bash
+scitex-cloud app list [--server URL]    # list available apps
+scitex-cloud app info <app_name>        # detailed app info
+scitex-cloud app current                # show active app (SCITEX_CURRENT_APP)
+scitex-cloud app switch <app_name>      # switch active app
+```
+
+## Preferences
+
+```bash
+scitex-cloud app prefs get <app_name>               # show saved prefs
+scitex-cloud app prefs set <app_name> key=val ...   # set prefs
+scitex-cloud app prefs delete <app_name>            # clear prefs
+scitex-cloud app prefs list                         # list all saved prefs
+```
+
+```bash
+scitex-cloud app prefs set writer theme=dark font_size=14
+scitex-cloud app prefs set scholar engine=crossref
+```
+
+## Dependencies
+
+```bash
+scitex-cloud app check-deps [app_dir]                    # check deps from manifest.json
+scitex-cloud app install-deps [app_dir] -t python        # install python deps
+scitex-cloud app install-deps [app_dir] -t system        # install system deps
+scitex-cloud app install-deps [app_dir] -t node          # install node deps
+scitex-cloud app install-deps [app_dir] -t r             # install R deps
+```
+
+Reads `manifest.json` for dependency lists.
+
+## Containers
+
+```bash
+scitex-cloud app build-container [app_dir] [-o output_dir]
+```
+
+Reads `container` field from `manifest.json`, builds an Apptainer `.sif` image.
+
+## MCP Tools
+
+| Tool | What it does |
+|------|-------------|
+| `cloud_app_list_all` | List all apps |
+| `cloud_app_get_info` | App details |
+| `cloud_app_get_current` | Active app |
+| `cloud_app_switch_to` | Switch active app |
+| `cloud_app_get_prefs` | Get app preferences |
+| `cloud_app_set_prefs` | Set app preferences |
+| `cloud_app_check_deps` | Check dependencies |
+
+# EOF

--- a/src/scitex_cloud/_skills/scitex-cloud/deployment-production.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/deployment-production.md
@@ -1,0 +1,38 @@
+---
+name: deployment-production
+description: Deploy SciTeX Cloud to production — zero-downtime build, swap, verify.
+---
+
+# Deploy to Production
+
+**WARNING: This affects the live site (scitex.ai). Confirm with user before proceeding.**
+
+## Prerequisites
+- Staging MUST be deployed and verified first (see `deployment-staging.md`)
+- Ensure scitex version is released to PyPI
+- Ensure Dockerfile.prod pins correct scitex version
+
+## Step 1: Sync NAS repo
+```bash
+ssh nas "cd ~/proj/scitex-cloud && git -C ~/proj/scitex-cloud pull origin develop"
+```
+
+## Step 2: Build prod image (zero downtime — prod stays running during build)
+```bash
+ssh nas "cd ~/proj/scitex-cloud/deployment/docker/docker_prod && nohup docker compose build --no-cache > /tmp/prod-build.log 2>&1 &"
+```
+
+## Step 3: Monitor build
+```bash
+ssh nas "tail -f /tmp/prod-build.log"
+```
+
+## Step 4: Swap to new image
+```bash
+ssh nas "cd ~/proj/scitex-cloud/deployment/docker/docker_prod && docker compose up -d"
+```
+
+## Step 5: Verify production
+- Check https://scitex.ai
+- Verify all apps responsive
+- Check logs for errors

--- a/src/scitex_cloud/_skills/scitex-cloud/deployment-staging.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/deployment-staging.md
@@ -1,0 +1,42 @@
+---
+name: deployment-staging
+description: Deploy SciTeX Cloud to staging — sync versions, build Docker, verify.
+---
+
+# Deploy to Staging
+
+## Prerequisites
+- Ensure scitex packages are latest and synchronized (`scitex dev versions list --json`)
+- If scitex version was bumped locally, MUST be released to PyPI before Docker build
+  (Dockerfile.prod installs from PyPI, not local source)
+
+## Step 1: Sync versions
+```bash
+scitex dev versions list --json
+scitex dev versions sync --confirm --host nas
+```
+
+## Step 2: Verify Dockerfile pins correct version
+```bash
+grep 'scitex\[all\]==' ~/proj/scitex-cloud/deployment/docker/Dockerfile.prod
+```
+
+## Step 3: Sync NAS repo
+```bash
+ssh nas "cd ~/proj/scitex-cloud && git -C ~/proj/scitex-cloud pull origin develop"
+```
+
+## Step 4: Build staging container
+```bash
+ssh nas "cd ~/proj/scitex-cloud/deployment/docker/docker_staging && docker compose build --no-cache"
+```
+
+## Step 5: Start staging
+```bash
+ssh nas "cd ~/proj/scitex-cloud/deployment/docker/docker_staging && docker compose up -d"
+```
+
+## Step 6: Verify
+- Check staging URL
+- Run smoke tests
+- Verify all apps load

--- a/src/scitex_cloud/_skills/scitex-cloud/gitea-cli.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/gitea-cli.md
@@ -1,0 +1,83 @@
+---
+name: gitea-cli
+description: Gitea Git hosting CLI — repository management, fork, clone, PR, issue, push/pull, auth. Backend is git.scitex.ai via the `tea` CLI wrapper.
+---
+
+# Gitea CLI
+
+All commands under `scitex-cloud gitea`. Backend: `git.scitex.ai` (wraps the `tea` CLI).
+
+## Authentication
+
+```bash
+scitex-cloud gitea login    # authenticate with Gitea
+scitex-cloud gitea logout   # clear credentials
+```
+
+## Repository Management
+
+```bash
+scitex-cloud gitea create <name>           # create repo on Gitea
+scitex-cloud gitea list                    # list your repos
+scitex-cloud gitea search <query>          # search repos
+scitex-cloud gitea clone <user/repo>       # clone from Gitea
+scitex-cloud gitea fork <user/repo>        # fork a repo
+scitex-cloud gitea delete <user/repo>      # delete a repo
+scitex-cloud gitea status                  # show current repo status
+```
+
+## Collaboration
+
+```bash
+# Pull requests
+scitex-cloud gitea pr create               # open a PR
+scitex-cloud gitea pr list                 # list open PRs
+
+# Issues
+scitex-cloud gitea issue create            # create an issue
+scitex-cloud gitea issue list              # list issues
+
+# Sync committed changes
+scitex-cloud gitea push [remote] [branch]  # push to Gitea
+scitex-cloud gitea pull [remote] [branch]  # pull from Gitea
+```
+
+## MCP Tools
+
+| Tool | What it does |
+|------|-------------|
+| `cloud_repo_login` | Authenticate with Gitea |
+| `cloud_repo_create` | Create repository |
+| `cloud_repo_list` | List repositories |
+| `cloud_repo_search` | Search repositories |
+| `cloud_repo_clone` | Clone repository |
+| `cloud_repo_fork` | Fork repository |
+| `cloud_repo_delete` | Delete repository |
+| `cloud_repo_status` | Repository status |
+| `cloud_repo_push` | Push commits to Gitea |
+| `cloud_repo_pull` | Pull commits from Gitea |
+| `cloud_repo_pr_create` | Create pull request |
+| `cloud_repo_pr_list` | List pull requests |
+| `cloud_repo_issue_create` | Create issue |
+| `cloud_repo_issue_list` | List issues |
+
+## Notes
+
+- `push`/`pull` here are git-level operations on committed changes.
+  For uncommitted working file sync, see [sync-architecture.md](sync-architecture.md).
+- `tea` binary must be installed: `~/.local/bin/tea`
+  Install: `wget https://dl.gitea.com/tea/0.9.2/tea-0.9.2-linux-amd64 -O ~/.local/bin/tea && chmod +x ~/.local/bin/tea`
+
+## Examples
+
+```bash
+scitex-cloud gitea login
+scitex-cloud gitea create my-new-repo
+scitex-cloud gitea clone ywatanabe/my-new-repo
+cd my-new-repo
+# ... make changes, git commit ...
+scitex-cloud gitea push
+scitex-cloud gitea pr create
+```
+
+# EOF

--- a/src/scitex_cloud/_skills/scitex-cloud/infrastructure.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/infrastructure.md
@@ -1,0 +1,121 @@
+---
+name: infrastructure
+description: Infrastructure management — environment setup, Docker container management, deploy, logs, SSH, and MCP server start/diagnose.
+---
+
+# Infrastructure CLI
+
+## Setup
+
+```bash
+scitex-cloud setup [--env dev|prod] [--force]
+```
+
+Interactive wizard: checks prerequisites (docker, git), creates `.env` from template, validates docker-compose file.
+
+```bash
+scitex-cloud setup              # interactive, prompts for env
+scitex-cloud setup --env dev    # dev environment
+scitex-cloud setup --env prod   # production environment
+scitex-cloud setup --env dev --force   # overwrite existing .env
+```
+
+## Docker
+
+```bash
+scitex-cloud docker [--env dev|prod] build [--no-cache]
+scitex-cloud docker [--env dev|prod] up    [-d]           # start (detached default)
+scitex-cloud docker [--env dev|prod] down  [-v]           # stop (--volumes to remove)
+scitex-cloud docker [--env dev|prod] restart
+scitex-cloud docker [--env dev|prod] ps                   # show container status
+```
+
+## Deploy and Status
+
+```bash
+scitex-cloud deploy                   # deploy with current settings
+scitex-cloud status                   # show deployment health
+scitex-cloud logs [service]           # tail service logs
+scitex-cloud ssh                      # SSH into cloud
+```
+
+## MCP Server
+
+```bash
+# Start
+scitex-cloud mcp start                          # stdio (Claude Desktop default)
+scitex-cloud mcp start -t sse                   # SSE (deprecated, avoid)
+scitex-cloud mcp start -t http                  # HTTP streamable (recommended for remote)
+scitex-cloud mcp start -t http --host 0.0.0.0 --port 8086
+
+# Diagnose
+scitex-cloud mcp doctor                         # check deps, tea CLI, API key
+scitex-cloud mcp installation                   # show client config snippets
+scitex-cloud mcp list-tools [-v] [-vv] [--json] # list all MCP tools
+```
+
+### MCP Client Configuration
+
+Local (stdio, Claude Desktop):
+```json
+{
+  "mcpServers": {
+    "scitex-cloud": {
+      "command": "scitex-cloud",
+      "args": ["mcp", "start"],
+      "env": {
+        "SCITEX_CLOUD_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+Remote (HTTP):
+```json
+{
+  "mcpServers": {
+    "scitex-cloud-remote": {
+      "url": "http://your-server:8086/mcp"
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SCITEX_CLOUD_API_KEY` | API key for cloud operations |
+| `SCITEX_CLOUD_URL` | Cloud server URL (default: `https://scitex.cloud`) |
+| `SCITEX_CLOUD_MCP_HOST` | MCP server bind host |
+| `SCITEX_CLOUD_MCP_PORT` | MCP server port (default: 8086) |
+
+## DockerManager (Python API)
+
+```python
+from scitex_cloud import DockerManager, get_environment
+
+env = get_environment("dev")        # or "prod"
+docker = DockerManager(env)
+
+docker.build(no_cache=False)
+docker.up(detach=True)
+docker.down(volumes=False)
+docker.restart()
+docker.ps()
+```
+
+## MCP Onsite Tools (AI agent browser control)
+
+| Tool | What it does |
+|------|-------------|
+| `cloud_onsite_capture_page` | Screenshot current page |
+| `cloud_onsite_eval_js` | Execute JavaScript in browser |
+| `cloud_onsite_ui_action` | Drive UI actions (click, fill, navigate, scroll) |
+| `cloud_onsite_get_context` | Get page context for AI agents |
+| `cloud_onsite_check_permission` | Check API permissions |
+| `cloud_onsite_get_dev_app_url` | Get dev server URL for app |
+| `cloud_api_status` | Check cloud API status |
+
+# EOF

--- a/src/scitex_cloud/_skills/scitex-cloud/project-management.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/project-management.md
@@ -1,0 +1,83 @@
+---
+name: project-management
+description: CLI commands for SciTeX Cloud project CRUD — create, list, delete, rename. Each project gets a Gitea repo + Django project + workspace directory.
+---
+
+# Project Management CLI
+
+## Commands
+
+```bash
+scitex-cloud project create <name> [-d "description"] [-t template]
+scitex-cloud project list [--json]
+scitex-cloud project delete <slug> [--yes]
+scitex-cloud project rename <slug> <new-name>
+```
+
+## Options
+
+### project create
+| Option | Default | Description |
+|--------|---------|-------------|
+| `name` | (required) | Project name |
+| `-d / --description` | `""` | Short description |
+| `-t / --template` | `scitex_minimal` | Template ID |
+
+Creates in one step: Gitea repository + Django project record + workspace directory.
+
+### project list
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--json` | (flag) | Output as JSON |
+
+### project delete
+| Option | Default | Description |
+|--------|---------|-------------|
+| `slug` | (required) | URL-safe project name |
+| `--yes` | (flag) | Skip confirmation prompt |
+
+### project rename
+| Option | Default | Description |
+|--------|---------|-------------|
+| `slug` | (required) | Current URL-safe name |
+| `new-name` | (required) | New project name |
+
+## Python API
+
+```python
+from scitex_cloud.project import project_list, project_create, project_delete, project_rename
+
+projects = project_list()
+# -> [{"id": "abc123", "name": "my-project", "description": "...", "created_at": "...", "updated_at": "..."}, ...]
+
+result = project_create("my-research", description="Paper on X", template="scitex_minimal")
+# -> {"project_id": "abc123", "name": "my-research", "success": True}
+
+project_delete("my-research")   # raises RuntimeError on failure
+
+project_rename("my-research", "my-research-v2")
+```
+
+## MCP Tools
+
+| Tool | What it does |
+|------|-------------|
+| `cloud_project_create` | Create project (Gitea + workspace) |
+| `cloud_project_list` | List all projects |
+| `cloud_project_delete` | Delete project by slug |
+| `cloud_project_rename` | Rename project |
+| `cloud_project_switch` | Switch active project context |
+
+## Examples
+
+```bash
+# Create and verify
+scitex-cloud project create neural-dynamics -d "Spiking network paper"
+scitex-cloud project list
+
+# Rename then delete
+scitex-cloud project rename neural-dynamics neural-dynamics-v2
+scitex-cloud project delete neural-dynamics-v2 --yes
+```
+
+# EOF

--- a/src/scitex_cloud/_skills/scitex-cloud/python-api.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/python-api.md
@@ -1,0 +1,122 @@
+---
+name: python-api
+description: Python API for scitex-cloud — CloudClient class, project functions, and health_check. For programmatic access from Python scripts.
+---
+
+# Python API
+
+## CloudClient
+
+```python
+import scitex_cloud
+
+client = scitex_cloud.CloudClient(
+    api_key=None,    # or set SCITEX_CLOUD_API_KEY env var
+    base_url=None,   # or set SCITEX_CLOUD_URL env var (default: https://scitex.cloud)
+)
+```
+
+### Methods
+
+```python
+# Scholar / literature
+result = client.scholar_search(query: str, limit: int = 10) -> dict
+# Returns: {"papers": [...]}  (public, no auth required)
+
+result = client.crossref_search(query: str, rows: int = 10, offset: int = 0) -> dict
+result = client.crossref_by_doi(doi: str) -> dict
+
+enriched_bib = client.enrich_bibtex(
+    bibtex_content: str,
+    use_cache: bool = True,
+    timeout: int = 120,
+) -> str
+# Uploads bib, polls for job completion, returns enriched BibTeX string
+
+# Writer / LaTeX
+result = client.writer_compile(
+    project_id: str,
+    document_type: str = "manuscript",  # or "supplementary", "revision"
+) -> dict
+# Returns: {"pdf_url": ..., ...}
+
+# Project files
+result = client.project_list_files(project_id: str, path: str = "") -> dict
+
+# Browser / AI agent tools (onsite)
+result = client.get_context(page: str = "") -> dict
+# Returns: username, active_skill, all_skills, available_actions, context
+
+result = client.eval_js(code: str, timeout: int = 10) -> dict
+
+result = client.ui_action(
+    steps: list,    # each: {"action": "click"|"fill"|"navigate"|..., ...}
+    delay_ms: int = 900,
+) -> dict
+
+result = client.status() -> dict
+# Returns: {"base_url": ..., "api_key_configured": bool, "cloud_status": "online"|"error"|"unreachable"}
+```
+
+## Project Functions
+
+```python
+from scitex_cloud.project import project_list, project_create, project_delete, project_rename
+
+projects: list[dict] = project_list()
+# Each dict: id, name, description, created_at, updated_at
+
+new_project: dict = project_create(
+    name: str,
+    description: str = "",
+    template: str = "scitex_minimal",
+)
+# Returns: {"project_id": ..., "name": ..., "success": True}
+
+deleted: bool = project_delete(slug: str)
+
+updated: dict = project_rename(slug: str, new_name: str)
+```
+
+## Package-Level
+
+```python
+import scitex_cloud
+
+version: str = scitex_cloud.get_version()
+
+status: dict = scitex_cloud.health_check(endpoint: str | None = None)
+# endpoint=None -> local package info only
+# endpoint="https://scitex.cloud/api/health/" -> HTTP probe
+
+env = scitex_cloud.get_environment()          # current Environment object
+docker = scitex_cloud.DockerManager(env)      # container management
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SCITEX_CLOUD_API_KEY` | API key for authenticated endpoints |
+| `SCITEX_CLOUD_URL` | Cloud server base URL (default: https://scitex.cloud) |
+
+## Examples
+
+```python
+# Search and enrich
+client = scitex_cloud.CloudClient()
+papers = client.scholar_search("spiking neural networks", limit=5)
+
+with open("refs.bib") as f:
+    bib = f.read()
+enriched = client.enrich_bibtex(bib)
+with open("refs_enriched.bib", "w") as f:
+    f.write(enriched)
+
+# List projects
+from scitex_cloud.project import project_list
+for p in project_list():
+    print(p["name"], p["id"])
+```
+
+# EOF

--- a/src/scitex_cloud/_skills/scitex-cloud/refactoring-rules.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/refactoring-rules.md
@@ -1,0 +1,28 @@
+---
+name: refactoring-rules
+description: Refactoring rules for scitex-cloud Django/TypeScript codebase.
+---
+
+# Refactoring Rules
+
+## File Size
+- Keep files manageable — long files cause issues
+- Check: `./scripts/check_file_sizes.sh --verbose`
+
+## No Inline CSS/Script
+- NEVER use inline CSS or script tags
+- Always use external CSS and TypeScript files
+- Link them properly in templates
+
+## TypeScript Only
+- NEVER use JavaScript — always TypeScript
+- TS files are automatically built (see `tsconfig.json`)
+- Check TypeScript compilation before committing
+
+## Django Conventions
+- Follow Django project structure rules
+- See `./GITIGNORED/RULES/*.md` for detailed rules
+
+## Commit Strategy
+- Commit after each logical chunk of refactoring
+- Use descriptive commit messages

--- a/src/scitex_cloud/_skills/scitex-cloud/sdk.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/sdk.md
@@ -1,0 +1,115 @@
+---
+name: sdk
+description: Cloud SDK — DataStore (JSON CRUD), FileVault (file storage), JobQueue (background compute). CLI and Python API. SDK code lives in scitex-app but re-exported from scitex-cloud for backward compatibility.
+---
+
+# Cloud SDK
+
+Three services: DataStore (JSON records), FileVault (files), JobQueue (async jobs).
+
+## CLI
+
+All commands under `scitex-cloud sdk`.
+
+### DataStore
+
+```bash
+scitex-cloud sdk data list   <app> <schema> [--filter key=val ...] [--project ID]
+scitex-cloud sdk data get    <app> <schema> <record_id>
+scitex-cloud sdk data create <app> <schema> --json '{"title": "Experiment 1"}'
+scitex-cloud sdk data update <app> <schema> <record_id> --json '{"status": "done"}'
+scitex-cloud sdk data delete <app> <schema> <record_id>
+scitex-cloud sdk data search <app> <schema> -q "query string"
+```
+
+### FileVault
+
+```bash
+scitex-cloud sdk files list     <app> [--path subdir] [--project ID] [--ext .csv]
+scitex-cloud sdk files upload   <app> <local_path> <remote_path> [--project ID]
+scitex-cloud sdk files download <app> <remote_path> [--project ID]
+scitex-cloud sdk files delete   <app> <remote_path> [--project ID]
+```
+
+### JobQueue
+
+```bash
+scitex-cloud sdk jobs submit <app> <job_name> [--params '{"fmt":"xlsx"}'] [--project ID]
+scitex-cloud sdk jobs status <app> <job_id>
+scitex-cloud sdk jobs list   <app>
+scitex-cloud sdk jobs cancel <app> <job_id>
+```
+
+## Python API
+
+```python
+from scitex_cloud.sdk import data, files, jobs
+# (Preferred: from scitex_app.sdk import _cloud_data as data, ...)
+
+# DataStore
+records = data.list_records(app, schema, filters={"status": "active"}, project_id=None)
+record  = data.get(app, schema, record_id)
+created = data.create(app, schema, {"title": "Experiment 1", "params": {...}})
+updated = data.update(app, schema, record_id, {"status": "done"})
+data.delete(app, schema, record_id)
+results = data.search(app, schema, "query string")
+
+# FileVault
+listing = files.list_files(app, path="", project=None, extensions=None)
+result  = files.upload(app, remote_path, content: bytes, project=None)
+result  = files.download(app, remote_path, project=None)
+result  = files.delete(app, remote_path, project=None)
+
+# JobQueue
+job     = jobs.submit(app, job_name, params={"fmt": "xlsx"}, project_id=None)
+status  = jobs.status(app, job_id)
+all_jobs = jobs.list_jobs(app)
+result  = jobs.cancel(app, job_id)
+```
+
+## PlatformClient
+
+```python
+from scitex_cloud.sdk import PlatformClient, get_client, reset_client
+
+client = get_client()         # singleton
+client = PlatformClient(...)  # explicit
+reset_client()                # clear singleton
+```
+
+## MCP Tools
+
+| Tool | What it does |
+|------|-------------|
+| `cloud_cloud_sdk_data_list` | List DataStore records |
+| `cloud_cloud_sdk_data_create` | Create record |
+| `cloud_cloud_sdk_data_get` | Get record by ID |
+| `cloud_cloud_sdk_data_update` | Update record |
+| `cloud_cloud_sdk_data_delete` | Delete record |
+| `cloud_cloud_sdk_data_search` | Full-text search |
+| `cloud_cloud_sdk_files_list` | List files |
+| `cloud_cloud_sdk_files_upload` | Upload file |
+| `cloud_cloud_sdk_files_download` | Download file |
+| `cloud_cloud_sdk_files_delete` | Delete file |
+| `cloud_cloud_sdk_jobs_submit` | Submit job |
+| `cloud_cloud_sdk_jobs_status` | Get job status |
+| `cloud_cloud_sdk_jobs_list` | List jobs |
+| `cloud_cloud_sdk_jobs_cancel` | Cancel job |
+
+## Examples
+
+```bash
+# Store experiment results
+scitex-cloud sdk data create my_app Experiment \
+  --json '{"title": "Run 1", "accuracy": 0.95}'
+
+# Upload output CSV
+scitex-cloud sdk files upload my_app ./results.csv exports/results.csv
+
+# Submit background export job, then poll
+scitex-cloud sdk jobs submit my_app export_csv --params '{"fmt":"xlsx"}'
+# -> {"job_id": "j_abc123"}
+scitex-cloud sdk jobs status my_app j_abc123
+```
+
+# EOF

--- a/src/scitex_cloud/_skills/scitex-cloud/sync-architecture.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/sync-architecture.md
@@ -1,0 +1,131 @@
+---
+name: sync-architecture
+description: Three-way sync architecture between Local, Gitea, and Workspace. CLI commands for push/pull (git) and sync-to/sync-from (files). Conflict detection and resolution.
+---
+
+# Sync Architecture — Local ↔ Gitea ↔ Workspace
+
+## Three Nodes, Three Relationships
+
+```
+            Gitea
+           (source of truth)
+          ╱              ╲
+    push/pull          w2g/g2w
+    (git)              (server-side git)
+        ╱                  ╲
+     Local ──────────── Workspace
+  (dev machine)  sync-to/from  (server-side)
+                  (rsync/files)
+```
+
+Each relationship is independent and explicit. No hidden sync.
+
+## Commands
+
+### Git operations (committed changes)
+
+```bash
+scitex cloud push              # git push to Gitea
+scitex cloud push origin main  # push specific branch
+scitex cloud pull              # git pull from Gitea
+scitex cloud pull origin main  # pull specific branch
+```
+
+These are thin wrappers around `git push/pull`. They work from
+**anywhere** — laptop or workspace. "Push" always means "push to Gitea."
+
+### File sync (working tree, Dropbox-style)
+
+```bash
+scitex cloud sync-to                    # sync local → workspace
+scitex cloud sync-to ywatanabe/my-proj  # explicit repo
+scitex cloud sync-to --dry-run          # preview changes
+scitex cloud sync-from                  # sync workspace → local
+scitex cloud sync-from --dry-run        # preview changes
+```
+
+These sync **uncommitted working files** between local machine and workspace.
+
+**Conflict detection:** Both sides' checksums are compared against a saved
+`.scitex-sync-state.json` from the last successful sync:
+
+| Scenario | Action |
+|----------|--------|
+| Only one side changed | Overwrite stale copy |
+| Both sides changed | Keep both: original syncs, other saved as `.conflict-<timestamp>` |
+| Neither changed | Skip (already in sync) |
+
+**On workspace:** `sync-to` and `sync-from` error with a hint:
+```
+You're already on the workspace.
+Did you mean: scitex cloud push
+```
+
+### Status
+
+```bash
+scitex cloud sync-status  # show divergence across all three
+scitex cloud ss           # alias
+```
+
+Output:
+```
+┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Pair              ┃ Status                 ┃
+┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Local ↔ Gitea     │ ↑2 ahead, ↓0 behind    │
+│ Workspace ↔ Gitea │ in sync                │
+└───────────────────┴────────────────────────┘
+```
+
+## Typical Workflows
+
+### Developer edits locally, wants to see changes in workspace
+
+```bash
+# Edit files locally...
+scitex cloud sync-to          # files appear in workspace immediately
+# Verify in browser...
+scitex cloud push             # commit and push to Gitea when ready
+```
+
+### User edits in web UI, developer wants the changes
+
+```bash
+scitex cloud sync-from        # pull workspace files to local
+# If conflicts: resolve .conflict-* files manually
+scitex cloud push             # push resolved version to Gitea
+```
+
+### Full round-trip
+
+```bash
+scitex cloud ss               # check state
+scitex cloud sync-from        # get workspace changes
+# resolve any conflicts...
+git add -A && git commit -m "merge workspace edits"
+scitex cloud push             # push to Gitea
+```
+
+## Conflict Files
+
+When both sides change the same file:
+
+```
+data/config.yaml                              ← synced version (winner)
+data/config.conflict-20260324T120000.yaml     ← other side's version
+```
+
+The user must manually resolve and delete the `.conflict-*` file.
+This is the same model as Dropbox "conflicted copy."
+
+## Implementation
+
+- `_cli/sync.py` — CLI commands (push, pull, sync-to, sync-from, sync-status)
+- `_cli/_sync_engine.py` — Conflict-aware file sync engine
+- State tracking: `.scitex-sync-state.json` (checksums from last sync)
+- Remote file listing: SSH + `find` + `sha256sum`
+- File transfer: `scp` per file (not rsync — enables per-file conflict handling)
+
+# EOF

--- a/src/scitex_cloud/_skills/scitex-cloud/version-management.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/version-management.md
@@ -1,0 +1,36 @@
+---
+name: version-management
+description: Manage and sync versions across SciTeX ecosystem packages.
+---
+
+# Version Management
+
+## Dashboard
+```bash
+scitex dev versions list --json
+# Also: http://127.0.0.1:5000
+```
+
+## Version Sync
+Bidirectional sync between local and remote (NAS):
+```bash
+scitex dev versions sync --confirm --host nas
+scitex dev ecosystem list
+```
+
+## Ecosystem Package Order
+1. scitex (scitex-python) — core framework
+2. scitex-cloud — platform
+3. figrecipe — plotting
+4. openalex-local, crossref-local — literature
+5. scitex-writer — manuscripts
+6. scitex-dataset — data
+7. socialia — social media
+
+## Version Bump Checklist
+- `pyproject.toml`
+- `__init__.py`
+- Git tag
+- Push to origin/main and origin/develop
+- GitHub Release
+- PyPI Release


### PR DESCRIPTION
## Summary
- Add `_skills/<pkg>/` directory with non-monolith skills layout
- SKILL.md is index-only with links to focused sub-skill files
- Each sub-skill verified against actual source code
- pyproject.toml force-include for wheel bundling

## Test plan
- [ ] CI passes
- [ ] Skills files included in wheel

Generated with [Claude Code](https://claude.com/claude-code)