### PR TITLE
fix(visitor-pool): free slots before expensive cleanup + fix LLMUsageLog ORM error

### DIFF
--- a/apps/infra/project_app/services/visitor_pool/pool_cleanup.py
+++ b/apps/infra/project_app/services/visitor_pool/pool_cleanup.py
@@ -60,11 +60,30 @@ class PoolCleanup:
             )
         )
 
+        # Snapshot the expiry reason before we flip is_active (for logging).
+        to_clean = [
+            (
+                alloc,
+                "expired" if alloc.expires_at < now else "idle",
+            )
+            for alloc in expired_or_idle
+        ]
+
+        # Free the slots FIRST in a single bulk update, BEFORE the expensive
+        # per-visitor workspace reset. If the celery task hits its time limit
+        # (60s) mid-loop, the slots are already marked inactive and available
+        # for new visitors — previously, a timeout left slots "active" forever
+        # because is_active was only set at the end of each iteration.
+        allocation_ids = [alloc.id for alloc, _ in to_clean]
+        VisitorAllocation.objects.filter(id__in=allocation_ids).update(is_active=False)
+
         count = 0
-        for allocation in expired_or_idle:
+        for allocation, reason in to_clean:
             visitor_username = (
                 f"{cls.VISITOR_USER_PREFIX}{allocation.visitor_number:03d}"
             )
+            count += 1
+            logger.info(f"[VisitorPool] Freed {reason} slot: {visitor_username}")
 
             try:
                 visitor_user = User.objects.get(username=visitor_username)
@@ -78,7 +97,11 @@ class PoolCleanup:
                         f"[VisitorPool] Deleted {project_count} projects for {visitor_username}"
                     )
 
-                # Reset workspace to clean state with fresh default-project
+                # Reset workspace to clean state with fresh default-project.
+                # This is the expensive step (filesystem + template clone +
+                # Gitea repo recreation). If it fails or times out, the slot
+                # is already freed — the next visitor will simply run through
+                # reset_visitor_workspace themselves.
                 WorkspaceManager.reset_visitor_workspace(visitor_user)
 
             except User.DoesNotExist:
@@ -88,14 +111,6 @@ class PoolCleanup:
                     f"[VisitorPool] Error cleaning up {visitor_username}: {e}",
                     exc_info=True,
                 )
-
-            allocation.is_active = False
-            allocation.save()
-            count += 1
-
-            # Log with reason
-            reason = "expired" if allocation.expires_at < now else "idle"
-            logger.info(f"[VisitorPool] Freed {reason} slot: {visitor_username}")
 
         return count
 

--- a/apps/infra/project_app/services/visitor_pool/workspace_manager.py
+++ b/apps/infra/project_app/services/visitor_pool/workspace_manager.py
@@ -103,7 +103,9 @@ class WorkspaceManager:
 
             chat_count = ChatSession.objects.filter(user=visitor_user).count()
             ChatSession.objects.filter(user=visitor_user).delete()
-            LLMUsageLog.objects.filter(user=visitor_user).delete()
+            # LLMUsageLog has no direct user FK — it links to IntegrationConnection.
+            # Filter via the connection relationship to delete this visitor's logs.
+            LLMUsageLog.objects.filter(connection__user=visitor_user).delete()
             if chat_count > 0:
                 logger.info(
                     f"[VisitorPool] Cleared {chat_count} chat sessions for {visitor_user.username}"


### PR DESCRIPTION
## Summary

Visitor pool on scitex.ai was exhausted — all 16 slots stuck `is_active=True`, some with `last_activity` 20+ days old. Two bugs found and fixed.

### Bug 1: Stale-active slots after celery task timeout

`PoolCleanup.cleanup_expired_allocations` set `is_active=False` **after** the expensive per-visitor workspace reset (filesystem delete, template clone, Gitea recreate). When the task hit its 60s hard time limit mid-loop, the remaining slots had their cleanup aborted but `is_active` was never flipped → stuck active forever.

**Fix**: bulk-update `is_active=False` for the entire expired-or-idle set BEFORE the per-visitor loop. Slots are freed immediately; workspace reset runs opportunistically. A timeout now only loses the reset work, not the slot release — the next visitor that lands on the slot runs `reset_visitor_workspace` themselves.

### Bug 2: `LLMUsageLog` ORM keyword error

`WorkspaceManager._clear_visitor_data` ran `LLMUsageLog.objects.filter(user=visitor_user)` — but `LLMUsageLog` has no direct user FK. It has `connection` (FK to `IntegrationConnection`), and `IntegrationConnection.user` is where the user lives. Every per-visitor cleanup raised `Cannot resolve keyword 'user' into field. Choices are: app_name, completion_tokens, connection, ...`, caught by the broad except, aborting the remainder of that visitor's cleanup.

**Fix**: filter via `connection__user=visitor_user`.

## Verification

Production scitex.ai pool state before patch: 11/16 active, oldest `last_activity` = 2026-03-23 (20 days).

After hot-patching both files into django-1 and celery_worker-1 containers, restarting the worker, and waiting one cleanup cycle: **15/16 free**.

Celery logs before showed:
```
[VisitorPool] Error clearing visitor data for visitor-013: Cannot resolve keyword 'user' into field
...
Hard time limit (60s) exceeded for apps.infra.public_app.tasks.cleanup_expired_visitor_allocations
```

After the patch, the keyword error is gone and cleanup no longer needs to finish all N visitors in one run to free their slots.

## Follow-ups (not in this PR)

- Raise `time_limit` on `cleanup_expired_visitor_allocations` (currently 60s) or split workspace reset into its own async task chain
- Consider a DB index on `(is_active, last_activity)` to keep the filter fast as the table grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)