### PR TITLE
fix(public_status): cache + celery cache warming for /status page

### DIFF
--- a/apps/infra/public_app/tasks/__init__.py
+++ b/apps/infra/public_app/tasks/__init__.py
@@ -17,6 +17,7 @@ from .health import (
     check_site_health,
     cleanup_expired_visitor_allocations,
     check_request_flood,
+    warm_public_status_cache,
 )
 from .metrics import collect_server_metrics
 from .utils import check_port
@@ -31,6 +32,7 @@ __all__ = [
     "cleanup_expired_visitor_allocations",
     "check_site_health",
     "check_request_flood",
+    "warm_public_status_cache",
     "HEALTH_CHECK_CACHE_KEY",
     "HEALTH_CHECK_FAILURE_COUNT_KEY",
     "HEALTH_CHECK_LAST_NOTIFICATION_KEY",

--- a/apps/infra/public_app/tasks/health.py
+++ b/apps/infra/public_app/tasks/health.py
@@ -331,4 +331,40 @@ Recommended actions:
         raise
 
 
+@shared_task(
+    name="apps.infra.public_app.tasks.warm_public_status_cache",
+    ignore_result=True,
+    soft_time_limit=60,
+    time_limit=90,
+)
+def warm_public_status_cache():
+    """Periodically refresh the /status page cache.
+
+    The synchronous health checks (DB, Redis, SSH, API) take ~15-20s on a
+    cold path which is intolerable for the user-facing /status page. We
+    keep the cache hot by recomputing every 60s in the background, so
+    visitors essentially never hit the cold path.
+
+    Refs scitex-orochi#82 (TTFB 17s regression).
+    """
+    try:
+        from apps.infra.public_app.views.status.public_status import (
+            PUBLIC_STATUS_CACHE_KEY,
+            PUBLIC_STATUS_CACHE_TTL,
+            _compute_status_data,
+        )
+
+        data = _compute_status_data()
+        cache.set(PUBLIC_STATUS_CACHE_KEY, data, PUBLIC_STATUS_CACHE_TTL)
+        logger.debug(
+            "[StatusCacheWarm] cached overall=%s in TTL=%ss",
+            data.get("overall"),
+            PUBLIC_STATUS_CACHE_TTL,
+        )
+        return {"status": "ok", "overall": data.get("overall")}
+    except Exception as e:
+        logger.error(f"[StatusCacheWarm] failed: {e}", exc_info=True)
+        return {"status": "error", "error": str(e)}
+
+
 # EOF

--- a/apps/infra/public_app/views/status/public_status.py
+++ b/apps/infra/public_app/views/status/public_status.py
@@ -135,8 +135,17 @@ def _compute_overall(services):
     return "operational"
 
 
-def _get_status_data():
-    """Run all public health checks and return structured data."""
+PUBLIC_STATUS_CACHE_KEY = "public_status_v1"
+PUBLIC_STATUS_CACHE_TTL = 120  # seconds
+
+
+def _compute_status_data():
+    """Run all public health checks and return structured data.
+
+    Pure computation, no caching. Called by ``_get_status_data`` (lazy)
+    and by the celery cache warmer (periodic) — see
+    apps.infra.public_app.tasks.health.warm_public_status_cache.
+    """
     status_data = {
         "services": [],
         "ssh_services": [],
@@ -166,6 +175,33 @@ def _get_status_data():
         "services": services,
         "checked_at": checked_at,
     }
+
+
+def _get_status_data():
+    """Cached wrapper around ``_compute_status_data``.
+
+    The user-facing /status page must be fast. The synchronous health
+    checks (DB, Redis, SSH, API) take ~15-20s on a cold path, which is
+    intolerable for casual visitors. We serve from a 120s cache; a
+    separate celery beat task (warm_public_status_cache, every 60s)
+    keeps the cache hot so visitors essentially never hit the cold
+    path. On the rare cache miss the user pays the cold cost once and
+    primes the cache for the next visitor.
+
+    Refs scitex-orochi#82 (TTFB 17s regression).
+    """
+    from django.core.cache import cache
+
+    cached = cache.get(PUBLIC_STATUS_CACHE_KEY)
+    if cached is not None:
+        return cached
+    data = _compute_status_data()
+    try:
+        cache.set(PUBLIC_STATUS_CACHE_KEY, data, PUBLIC_STATUS_CACHE_TTL)
+    except Exception:
+        # Cache backend unavailable — still serve fresh data, just slow.
+        pass
+    return data
 
 
 def public_status_view(request):

--- a/config/settings/settings_celery.py
+++ b/config/settings/settings_celery.py
@@ -80,6 +80,15 @@ CELERY_BEAT_SCHEDULE = {
             "expires": 55.0,  # Expire after 55 seconds if not started
         },
     },
+    # Warm /status page cache every 1 minute so user-facing visitors
+    # never hit the ~17s cold path (scitex-orochi#82).
+    "warm-public-status-cache": {
+        "task": "apps.infra.public_app.tasks.warm_public_status_cache",
+        "schedule": 60.0,  # Every 1 minute
+        "options": {
+            "expires": 55.0,
+        },
+    },
 }
 
 # EOF


### PR DESCRIPTION
Refs scitex-orochi#82.

Cold path /status TTFB was ~17-18s (4 sequential SSH/API health checks). head-nas identified the gap. Fix:

1. Wrap `_get_status_data` in 120s django.core.cache layer
2. Add celery beat task `warm_public_status_cache` (1 min) that recomputes in background

Visitors should see <100ms TTFB. Existing `check_site_health` unchanged.

Verified locally: `python -m py_compile` clean on all 4 files.