### PR TITLE
fix(docker): bypass SCITEX_CLOUD_DB_USER shell override for gitea + pgbouncer, add Experiment B CPU limits

### DIFF
--- a/deployment/docker/docker_prod/docker-compose.yml
+++ b/deployment/docker/docker_prod/docker-compose.yml
@@ -16,6 +16,14 @@ services:
         BUILDKIT_INLINE_CACHE: 1
     image: scitex-cloud-prod-django:latest
     entrypoint: ["/root-init.sh", "/entrypoint.sh"]
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 8G
+        reservations:
+          cpus: '0.5'
+          memory: 2G
     command: ["daphne", "-b", "0.0.0.0", "-p", "8000", "--access-log", "-", "--verbosity", "1", "config.asgi:application"]
     volumes:
       - static_volume:/app/staticfiles
@@ -136,11 +144,14 @@ services:
     image: edoburu/pgbouncer:v1.25.1-p0
     volumes:
       - ../common/pgbouncer/pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
-      - ../common/pgbouncer/userlist.txt:/etc/pgbouncer/userlist.txt
+      - ../common/pgbouncer/userlist.txt:/etc/pgbouncer/userlist.txt:ro
     env_file:
       - .env
     environment:
       - DATABASE_URL=postgresql://${SCITEX_CLOUD_POSTGRES_USER}:${SCITEX_CLOUD_POSTGRES_PASSWORD}@postgres:5432/${SCITEX_CLOUD_POSTGRES_DB}
+      - DB_USER=${SCITEX_CLOUD_POSTGRES_USER}
+      - DB_PASSWORD=${SCITEX_CLOUD_POSTGRES_PASSWORD}
+      - AUTH_TYPE=plain
     depends_on:
       postgres:
         condition: service_healthy
@@ -177,6 +188,14 @@ services:
       --queues=celery,ai_queue,search_queue,compute_queue,vis_queue
       --concurrency=8
       --prefetch-multiplier=1
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 6G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
 
     volumes:
       - static_volume:/app/staticfiles
@@ -327,9 +346,15 @@ services:
       - USER_GID=1000
       - GITEA__database__DB_TYPE=postgres
       - GITEA__database__HOST=postgres:5432
-      - GITEA__database__NAME=${SCITEX_CLOUD_POSTGRES_DB}
-      - GITEA__database__USER=${SCITEX_CLOUD_POSTGRES_USER}
-      - GITEA__database__PASSWD=${SCITEX_CLOUD_POSTGRES_PASSWORD}
+      # Hardcoded to avoid SCITEX_CLOUD_POSTGRES_DB=scitex_cloud shell override
+      # (01_cloud.src:20) which doesn't match the actual postgres DB scitex_cloud_nas
+      - GITEA__database__NAME=scitex_cloud_nas
+      # NOTE: using GITEA_DB_* aliases (from docker_prod/.env) instead of
+      # SCITEX_CLOUD_POSTGRES_USER/PASSWORD because the shell env exports
+      # SCITEX_CLOUD_POSTGRES_USER=admin (dotfiles#34) which collides and
+      # breaks gitea auth to postgres. The alias vars are NOT shell-exported.
+      - GITEA__database__USER=${GITEA_DB_USER:-scitex_nas}
+      - GITEA__database__PASSWD=${GITEA_DB_PASSWORD}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Consolidates three interrelated `docker_prod/docker-compose.yml` changes that have been running live on NAS for several hours during the 2026-04-15 NAS instability investigation sequence. Committing now that Gitea is back online and the fleet is stable.

All three changes address the same class of production-stability issue: subordinate containers crashing in restart loops due to latent misconfiguration that was exposed when Experiment B triggered container recreation. Full incident trail is in the commit message and in Orochi `#escalation` msgs #11865 (pgbouncer), #12193 (Gitea), and #12205 (Gitea recovery).

## Shared root cause

`~/.dotfiles/src/.bash.d/secrets/010_scitex/01_cloud.src:18` exports `SCITEX_CLOUD_DB_USER=admin`, which bleeds through into docker compose variable substitution of `${SCITEX_CLOUD_POSTGRES_USER}`. Subordinate services that reference that variable end up trying to authenticate to postgres as \`admin\`, a role that does not exist in the actual database (real user is \`scitex_nas\`), and crash in a restart loop. Upstream fix is tracked at [dotfiles#34](https://github.com/ywatanabe1989/.dotfiles/issues/34).

Until dotfiles#34 lands, each affected compose service needs a scoped workaround. This PR provides that for pgbouncer and Gitea.

## Changes

### Experiment B: django + celery_worker hard CPU/memory limits

Part of the 2026-04-14 NAS instability investigation (Orochi msg #11554 → Option C, Experiments B + A). Adds kernel-enforced CPU caps so that scitex-cloud visitor traffic cannot starve fleet daemon services on the NAS.

| Container | cpus limit | memory limit |
|---|---|---|
| django | 2.0 | 8G |
| celery_worker | 4.0 | 6G |

Verified stable for ~8h before this commit: user.slice cpu.pressure avg300 = 0.64% (vs baseline median 0.9%), django NanoCpus=2000000000, celery_worker NanoCpus=4000000000.

### pgbouncer: pin DB env + make userlist.txt read-only

Pins \`DB_USER\`, \`DB_PASSWORD\`, \`AUTH_TYPE=plain\` via compose \`environment:\` so the entrypoint's \`generate_userlist_if_needed\` path takes the expected branch. Also flips the \`userlist.txt\` bind mount to \`:ro\` so a future attempted write fails loudly instead of silently.

Note: this patch alone was NOT sufficient on 2026-04-15 morning. The live workaround that actually restored service was appending an \`\"admin\"\` entry to \`common/pgbouncer/userlist.txt\` (host-local, outside this repo, documented in Orochi msg #11876 and scitex-cloud#142). A wider refactor of pgbouncer container recreate behavior is still open at #142.

### Gitea: bypass shell override via GITEA_DB_USER / GITEA_DB_PASSWORD aliases

Adds two new compose env references \`\${GITEA_DB_USER}\` and \`\${GITEA_DB_PASSWORD}\`, sourced from \`docker_prod/.env\` (gitignored). These alias variable names are NOT shell-exported, so docker compose variable substitution resolves them from the project .env file instead of falling through to the polluted shell env.

Also hardcodes \`GITEA__database__NAME=scitex_cloud_nas\` because the shell ALSO exports \`SCITEX_CLOUD_POSTGRES_DB=scitex_cloud\`, which does not match the real postgres database name (\`scitex_cloud_nas\`, confirmed via \`docker exec postgres psql -U scitex_nas -l\`).

**Deploy requirement**: each host that pulls this PR and runs Gitea must add matching entries to their own \`docker_prod/.env\`:

\`\`\`
GITEA_DB_USER=scitex_nas
GITEA_DB_PASSWORD=<same value as SCITEX_CLOUD_POSTGRES_PASSWORD>
\`\`\`

Once dotfiles#34 lands upstream, this workaround can be reverted to \`\${SCITEX_CLOUD_POSTGRES_USER/PASSWORD}\` in a follow-up PR.

## Verification

- \`docker inspect scitex-cloud-prod-django-1 | jq '.[].HostConfig | {NanoCpus, Memory}'\` → \`{NanoCpus: 2000000000, Memory: 8589934592}\` ✅
- \`docker inspect scitex-cloud-prod-celery_worker-1 | jq '.[].HostConfig | {NanoCpus, Memory}'\` → \`{NanoCpus: 4000000000, Memory: 6442450944}\` ✅
- \`docker exec scitex-cloud-prod-pgbouncer-1 pg_isready -h localhost -p 6432\` → \`accepting connections\` ✅
- \`docker exec scitex-cloud-prod-gitea-1 wget -qO- http://localhost:3000/api/v1/version\` → \`{\"version\":\"1.25.2\"}\` ✅
- \`curl https://scitex.ai/healthz/\` → 200 ✅
- \`curl https://gitea.scitex.ai/api/v1/version\` → 200 via Cloudflare tunnel ✅
- host-level user.slice cpu.pressure avg300 = 0.64% ✅ (probe data, comparable to pre-investigation baseline)

## Test plan

- [x] Experiment B CPU limits do not throttle django during normal traffic (verified, 8h live)
- [x] pgbouncer starts clean with the \`admin\` userlist.txt workaround (live on NAS since morning)
- [x] Gitea starts clean with the alias env vars (live on NAS since this afternoon)
- [ ] Reviewer verifies the compose diff is scoped to the three services + .env alias pattern
- [ ] Reviewer confirms the deploy requirement (GITEA_DB_USER/PASSWORD in docker_prod/.env) is documented for other hosts

## Related

- dotfiles#34 — root-cause shell export (required upstream fix)
- scitex-cloud#142 — pgbouncer container recreate fragility (wider refactor still open)
- todo#444 — Gitea migration epic for per-agent fleet accounts (Gitea online is a prerequisite)
- Orochi msg#11865, #11876, #12193, #12205 — incident recovery records
- Orochi msg#12204 — ywatanabe's E2E probe daemon proposal (motivated by the same silent-failure pattern)

## Out of scope

- umami restart-loop (same class of bug, separate PR follow-up)
- dotfiles#34 upstream fix (different repo, different lane)
- fleet-health-daemon Phase 2 E2E probe design (different repo)
- docker_prod/.env.example update (no .env.example currently exists at this path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)