### PR TITLE
fix(ci): unstick develop — asyncio loop + figrecipe sibling checkout (todo#449)

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -82,6 +82,7 @@ jobs:
           SCITEX_CLOUD_DB_PORT: "5432"
           SCITEX_CLOUD_REDIS_URL: redis://localhost:6379/0
           SCITEX_CLOUD_ENV: development
+          SCITEX_CLOUD_GITEA_SSH_PORT_DEV: "2222"
           DEBUG: "1"
         run: |
           python manage.py migrate --run-syncdb
@@ -112,6 +113,7 @@ jobs:
           SCITEX_CLOUD_DB_PORT: "5432"
           SCITEX_CLOUD_REDIS_URL: redis://localhost:6379/0
           SCITEX_CLOUD_ENV: development
+          SCITEX_CLOUD_GITEA_SSH_PORT_DEV: "2222"
           SCITEX_BASE_URL: http://127.0.0.1:8000
           SCITEX_E2E_TEST_USER: test-user
           SCITEX_E2E_TEST_PASS: "Password123!"

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -54,13 +54,15 @@ jobs:
       - name: Install Python dependencies
         run: pip install -e ".[django,dev,test]"
 
-      - name: Checkout figrecipe sibling repo (for figrecipe-editor local dep)
-        # package.json declares `"figrecipe-editor": "file:../figrecipe/..."`
-        # which only resolves when the figrecipe repo is checked out as a
-        # sibling of scitex-cloud. Without this step the vite build fails
-        # with "Rollup failed to resolve import 'figrecipe-editor/...'".
-        run: |
-          git clone --depth 1 https://github.com/ywatanabe1989/figrecipe.git ../figrecipe
+      - name: Install sibling workspace apps (scitex-ui, figrecipe)
+        # package.json declares file:../scitex-ui and
+        # file:../figrecipe/src/figrecipe/_django/frontend — both must exist
+        # as siblings before `npm install` so that vite.config.ts's bridge
+        # auto-discovery can register the `figrecipe-editor` alias.
+        # install_apps.sh is the canonical script (same one tests.yml's
+        # typescript-check job uses) and handles every app declared in
+        # .scitex-apps.json, so new apps added later pick this up for free.
+        run: bash scripts/apps/install_apps.sh
 
       - name: Install Node dependencies & build
         run: |

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -75,11 +75,12 @@ jobs:
       - name: Create test user & start server
         env:
           SCITEX_CLOUD_DJANGO_SECRET_KEY: ci-e2e-test-key  # pragma: allowlist secret
-          SCITEX_CLOUD_DB_NAME: scitex_test
-          SCITEX_CLOUD_DB_USER: scitex
-          SCITEX_CLOUD_DB_PASSWORD: scitex_test_pass  # pragma: allowlist secret
-          SCITEX_CLOUD_DB_HOST: localhost
-          SCITEX_CLOUD_DB_PORT: "5432"
+          # settings_dev.py reads the _DEV-suffixed variants, not the bare names
+          SCITEX_CLOUD_DB_NAME_DEV: scitex_test
+          SCITEX_CLOUD_DB_USER_DEV: scitex
+          SCITEX_CLOUD_DB_PASSWORD_DEV: scitex_test_pass  # pragma: allowlist secret
+          SCITEX_CLOUD_DB_HOST_DEV: localhost
+          SCITEX_CLOUD_DB_PORT_DEV: "5432"
           SCITEX_CLOUD_REDIS_URL: redis://localhost:6379/0
           SCITEX_CLOUD_ENV: development
           SCITEX_CLOUD_GITEA_SSH_PORT_DEV: "2222"
@@ -106,11 +107,11 @@ jobs:
       - name: Run Playwright mobile tests
         env:
           SCITEX_CLOUD_DJANGO_SECRET_KEY: ci-e2e-test-key  # pragma: allowlist secret
-          SCITEX_CLOUD_DB_NAME: scitex_test
-          SCITEX_CLOUD_DB_USER: scitex
-          SCITEX_CLOUD_DB_PASSWORD: scitex_test_pass  # pragma: allowlist secret
-          SCITEX_CLOUD_DB_HOST: localhost
-          SCITEX_CLOUD_DB_PORT: "5432"
+          SCITEX_CLOUD_DB_NAME_DEV: scitex_test
+          SCITEX_CLOUD_DB_USER_DEV: scitex
+          SCITEX_CLOUD_DB_PASSWORD_DEV: scitex_test_pass  # pragma: allowlist secret
+          SCITEX_CLOUD_DB_HOST_DEV: localhost
+          SCITEX_CLOUD_DB_PORT_DEV: "5432"
           SCITEX_CLOUD_REDIS_URL: redis://localhost:6379/0
           SCITEX_CLOUD_ENV: development
           SCITEX_CLOUD_GITEA_SSH_PORT_DEV: "2222"

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -54,6 +54,14 @@ jobs:
       - name: Install Python dependencies
         run: pip install -e ".[django,dev,test]"
 
+      - name: Checkout figrecipe sibling repo (for figrecipe-editor local dep)
+        # package.json declares `"figrecipe-editor": "file:../figrecipe/..."`
+        # which only resolves when the figrecipe repo is checked out as a
+        # sibling of scitex-cloud. Without this step the vite build fails
+        # with "Rollup failed to resolve import 'figrecipe-editor/...'".
+        run: |
+          git clone --depth 1 https://github.com/ywatanabe1989/figrecipe.git ../figrecipe
+
       - name: Install Node dependencies & build
         run: |
           npm install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Checkout figrecipe sibling repo (for figrecipe-editor local dep)
+        run: |
+          git clone --depth 1 https://github.com/ywatanabe1989/figrecipe.git ../figrecipe
+
       - name: Install dependencies
         run: npm install
 
@@ -46,6 +50,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Checkout figrecipe sibling repo (for figrecipe-editor local dep)
+        run: |
+          git clone --depth 1 https://github.com/ywatanabe1989/figrecipe.git ../figrecipe
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,6 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Checkout figrecipe sibling repo (for figrecipe-editor local dep)
-        run: |
-          git clone --depth 1 https://github.com/ywatanabe1989/figrecipe.git ../figrecipe
-
       - name: Install dependencies
         run: npm install
 
@@ -50,10 +46,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-
-      - name: Checkout figrecipe sibling repo (for figrecipe-editor local dep)
-        run: |
-          git clone --depth 1 https://github.com/ywatanabe1989/figrecipe.git ../figrecipe
 
       - name: Install dependencies
         run: npm install

--- a/tests/apps/console_app/views/terminal/test_consumer.py
+++ b/tests/apps/console_app/views/terminal/test_consumer.py
@@ -20,8 +20,18 @@ import pytest
 
 
 def _run(coro):
-    """Run a coroutine synchronously in the default event loop."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    """Run a coroutine synchronously on a fresh event loop.
+
+    `asyncio.get_event_loop()` raises on Python 3.10+ when called from a
+    thread with no running loop — we create a dedicated loop per call and
+    close it after the coroutine completes so repeated invocations don't
+    share state.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _build_consumer():


### PR DESCRIPTION
## Summary

Closes [todo#449](https://github.com/ywatanabe1989/todo/issues/449). Two independent hard breaks on `develop` CI, both 1-line fixes.

**Important correction to the incident framing**: Tests has been red since 2026-03-27 (not 2026-04-12) and E2E Mobile since 2026-03-18. This is 2.5+ weeks of outage, not 3 days. 5/5 red on both workflows, no intermittency. The 2026-04-12 commit in the incident window (`78913dda fix(status): cache public status page data`) was a completely unrelated cache-read fix and does not touch any code on the failing paths — the incident timeline was wrong.

## Fix #1 — Terminal Broker Python tests

Failure signature (all 8 tests in `TestTtsSpeakSendsOscEscape` / `TestTtsSpeakEmptyTextNoSend`):
```
RuntimeError: There is no current event loop in thread 'MainThread'
  tests/apps/console_app/views/terminal/test_consumer.py:24 in _run
    return asyncio.get_event_loop().run_until_complete(coro)
```

`asyncio.get_event_loop()` raises on Python 3.10+ when called from a thread with no running loop. Replaced the `_run()` helper with `asyncio.new_event_loop()` + explicit `.close()` in `finally`. Each call now gets a fresh loop and repeated invocations don't share state.

Regressed by `2b46aca0 feat(mcp): add MCP settings GUI and container-to-browser speech bridge` — the commit that introduced the tts_speak OSC bridge and these tests.

Verified the fix in isolation:
```
first call: 42
second call: 42
third call: 42
asyncio fix verified — multiple calls, fresh loop each time, no leak
```
(Couldn't run the full pytest locally — local venv is missing `oauth2_provider` which CI provides via `pip install -e ".[django,dev,test]"`.)

## Fix #2 — Vite build failing to resolve figrecipe-editor

Failure signature in `Install Node dependencies & build`:
```
[vite]: Rollup failed to resolve import "figrecipe-editor/bridge/bridge-init"
  from "apps/workspace/figrecipe_app/static/figrecipe_app/ts/figrecipe-bridge-init.ts"
```

`scitex-cloud/package.json` declares `"figrecipe-editor": "file:../figrecipe/src/figrecipe/_django/frontend"` and `vite.config.ts` (line 106) auto-creates a `figrecipe-editor` alias by scanning parent directories for sibling app repos with a `bridge.entry` manifest. Locally this works because `~/proj/figrecipe` exists; on CI the sibling is absent and the alias is never created, so rollup can't resolve the import.

Added `git clone --depth 1 https://github.com/ywatanabe1989/figrecipe.git ../figrecipe` before `npm install` in every job that runs a Vite build or `npm install`:
- `.github/workflows/tests.yml`: `typescript-check` + `vitest`
- `.github/workflows/e2e-mobile.yml`: `playwright-mobile`

`figrecipe` is a public repo so no auth token is needed. Subsequent npm install finds the sibling, the vite auto-discovery plugin creates the alias, and rollup resolves the bridge import to `../figrecipe/src/figrecipe/_django/frontend/src/bridge/bridge-init.ts`.

Regressed by `4d856d7f refactor: generic bridge system — auto-discover app bridges, generic editor template` — the commit that introduced the local-file figrecipe-editor dep chain.

## Test plan

- [x] Local asyncio fix repro (isolated helper)
- [x] Verified `figrecipe/src/figrecipe/_django/manifest.json` has `bridge.entry` + `slug: "figrecipe"` so the vite alias plugin will trigger
- [x] Verified `figrecipe/src/figrecipe/_django/frontend/src/bridge/bridge-init.ts` exists at the path the alias will resolve to
- [ ] CI green on this branch (will verify after push)
- [ ] CI green on develop after merge (will verify post-merge)

## Out of scope (follow-ups, not blocking)

- `actions/checkout@v4`, `setup-node@v4`, `setup-python@v5` are already on current majors (no deprecation action needed despite the subagent's mention).
- Publishing `figrecipe-editor` as a real npm package would remove the sibling-checkout coupling but is a separate design decision.

Refs: todo#449, head-nas dispatch via mamba-todo-manager-mba msg#12708