### PR TITLE
docs: refresh skills, README, MANIFEST (skills rollout)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.md
+include LICENSE
+include pyproject.toml
+recursive-include src/scitex_cloud/_skills *.md
+recursive-include src/scitex_cloud/skills *.md

--- a/README.md
+++ b/README.md
@@ -129,9 +129,15 @@ make start                    # Start development environment
 import scitex_cloud
 
 # Version and health
-scitex_cloud.__version__        # "0.15.0"
+scitex_cloud.__version__        # read from pyproject.toml (e.g. "0.17.0-alpha")
 scitex_cloud.get_version()      # Version string
-scitex_cloud.health_check()     # Service health status
+scitex_cloud.health_check()     # Local package info
+scitex_cloud.health_check("https://scitex.ai/api/health/")  # Remote endpoint
+
+# Clients / helpers
+client = scitex_cloud.CloudClient()            # HTTP client
+env = scitex_cloud.get_environment()           # Environment config
+docker = scitex_cloud.DockerManager()          # Container helpers
 ```
 
 > **[Full API reference](https://scitex-cloud.readthedocs.io/)**
@@ -156,8 +162,11 @@ scitex-cloud gitea pr create           # Create pull request
 scitex-cloud gitea issue create        # Create issue
 
 # Docker management
-scitex-cloud docker status             # Container status
-scitex-cloud docker logs               # View logs
+scitex-cloud docker up                 # Start containers
+scitex-cloud docker down               # Stop containers
+scitex-cloud docker ps                 # Container status
+scitex-cloud docker build              # Build images
+scitex-cloud docker restart            # Restart services
 
 # MCP server
 scitex-cloud mcp start                 # Start MCP server
@@ -184,10 +193,17 @@ AI agents can interact with the SciTeX Cloud platform autonomously via MCP (Mode
 
 | Category | Tools | Description |
 |----------|-------|-------------|
-| cloud | 14 | Git operations (clone, push, pull, PR, issues) |
+| gitea | 14 | Git operations (clone, push, pull, PR, issues, auth) |
+| sdk | 14 | DataStore, FileVault, JobQueue operations |
 | api | 9 | Scholar search, CrossRef, BibTeX enrichment |
+| app | 7 | App plugin lifecycle (init, validate, submit) |
+| onsite | 6 | On-site platform operations |
+| project_crud | 5 | Project create, list, rename, delete |
 
-<sub><b>Table 2.</b> MCP tool categories. All tools accept JSON parameters and return JSON results. Use <code>scitex-cloud mcp list-tools</code> for the full list.</sub>
+<sub><b>Table 2.</b> MCP tool categories — 55 tools total registered via
+<code>register_all_tools</code> in
+<code>_mcp_tools/__init__.py</code>. Use <code>scitex-cloud mcp list-tools</code>
+for the live list.</sub>
 
 **Claude Desktop** (`~/.config/claude/claude_desktop_config.json`):
 

--- a/src/scitex_cloud/_skills/scitex-cloud/SKILL.md
+++ b/src/scitex_cloud/_skills/scitex-cloud/SKILL.md
@@ -1,25 +1,89 @@
 ---
-description: SciTeX Cloud platform CLI — project management, Git hosting (Gitea), three-way sync, app deployment, cloud SDK, and infrastructure. Use when managing projects, syncing code, deploying apps, or running cloud operations.
-allowed-tools: mcp__scitex__cloud_*
+description: SciTeX Cloud platform — Django web app + CLI + MCP server + Python SDK. Covers project management, Git hosting (Gitea), three-way sync, app deployment, DataStore/FileVault/JobQueue SDK, and infrastructure. Use when managing cloud projects, syncing code, deploying apps, or running cloud operations.
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
-# scitex-cloud Skills Index
+# scitex-cloud Skill
+
+## What this package is
+
+`scitex-cloud` provides the operational surface for a SciTeX Cloud
+deployment. It ships:
+
+- A **Django web platform** (under `apps/`) with Scholar, Writer,
+  FigRecipe, Console, Hub, Clew modules — run with
+  `make start` / `make ENV=prod start`.
+- A **CLI** (`scitex-cloud`) covering project management, Gitea Git
+  hosting, sync, docker, deploy, MCP, workspace, SDK, and status.
+- An **MCP server** (`scitex-cloud-mcp` / `scitex-cloud mcp start`)
+  exposing ~55 tools across 6 categories for AI agents.
+- A small **Python API** (`CloudClient`, `health_check`,
+  `get_environment`, `DockerManager`).
 
 ## Installation
 
 ```bash
-pip install scitex-cloud
+pip install scitex-cloud               # CLI only
+pip install scitex-cloud[mcp]          # CLI + MCP server
+pip install scitex-cloud[all]          # Everything (django, test, gui, mcp, dev)
 # Development:
 pip install -e /home/ywatanabe/proj/scitex-cloud
 ```
 
-This directory contains focused skill files for the scitex-cloud package.
+## CLI surface (actual, from `src/scitex_cloud/_cli/main.py`)
 
-## Sub-Skills
+Top-level command groups registered on `main`:
+
+| Command | Module | Notes |
+|---------|--------|-------|
+| `app` | `_cli/app.py` | App plugin scaffolding |
+| `setup` | `_cli/setup.py` | Environment setup |
+| `deploy` | `_cli/deploy.py` | Deploy helpers |
+| `docker` | `_cli/docker.py` | Container mgmt |
+| `gitea` | `_cli/gitea.py` | Gitea Git hosting (repos, PRs, issues, auth) |
+| `mcp` | `_cli/mcp.py` | `start`, `list-tools`, `doctor`, `installation` |
+| `context` | `_cli/context.py` | Context group |
+| `status` / `logs` | `_cli/status.py` | Deployment status + logs |
+| `completion` | `_cli/completion.py` | Shell completion |
+| `workspace` | `_cli/workspace.py` | Workspace auth + commands |
+| `sdk` | `_cli/sdk.py` | SDK subcommands |
+| `project` | `_cli/project.py` | Project CRUD |
+| `skills` | `scitex_dev` plugin | Registered when `scitex-dev` is installed |
+
+Use `scitex-cloud --help-recursive` to list every sub-command.
+
+## MCP tools (actual, from `src/scitex_cloud/_mcp_tools/`)
+
+| Category | Tools | File |
+|----------|-------|------|
+| gitea | 14 | `_mcp_tools/gitea.py` |
+| sdk | 14 | `_mcp_tools/sdk.py` |
+| api | 9 | `_mcp_tools/api.py` |
+| app | 7 | `_mcp_tools/app.py` |
+| onsite | 6 | `_mcp_tools/onsite.py` |
+| project_crud | 5 | `_mcp_tools/project_crud.py` |
+
+Registration: `_mcp_tools/__init__.py::register_all_tools`.
+Entry point: `scitex-cloud-mcp` → `scitex_cloud._mcp_server:main`.
+
+## Python API (actual, from `src/scitex_cloud/__init__.py`)
+
+```python
+import scitex_cloud
+
+scitex_cloud.__version__
+scitex_cloud.get_version()
+scitex_cloud.health_check(endpoint=None)       # local or remote
+client = scitex_cloud.CloudClient()            # from _api.py
+env = scitex_cloud.get_environment()           # from _config/_environments.py
+docker = scitex_cloud.DockerManager()          # from _utils/_docker.py
+```
+
+## Sub-skill files
 
 | File | Topic |
 |------|-------|
-| [python-api.md](python-api.md) | Python API — CloudClient, project_*, health_check |
+| [python-api.md](python-api.md) | CloudClient, project_*, health_check |
 | [project-management.md](project-management.md) | CLI project CRUD — create, list, delete, rename |
 | [sync-architecture.md](sync-architecture.md) | Three-way sync — push/pull (git) and sync-to/from (files) |
 | [gitea-cli.md](gitea-cli.md) | Gitea Git hosting — repos, PRs, issues, auth |
@@ -28,29 +92,35 @@ This directory contains focused skill files for the scitex-cloud package.
 | [infrastructure.md](infrastructure.md) | Docker, setup, deploy, MCP server |
 | [deployment-staging.md](deployment-staging.md) | Deploy to staging — sync, build, verify |
 | [deployment-production.md](deployment-production.md) | Deploy to production — NAS safety, cgroup limits |
+| [scitex-deploy-staging.md](scitex-deploy-staging.md) | Legacy staging deploy recipe |
+| [scitex-deploy-prod.md](scitex-deploy-prod.md) | Legacy production deploy recipe |
+| [scitex-cloud-stage.md](scitex-cloud-stage.md) | Ecosystem staging prerequisites |
+| [ship-scitex-cloud.md](ship-scitex-cloud.md) | Ship-to-prod one-liner recipe |
 | [version-management.md](version-management.md) | Ecosystem version sync and bump |
+| [scitex-versions.md](scitex-versions.md) | Detailed version-sync walkthrough (bidirectional) |
 | [refactoring-rules.md](refactoring-rules.md) | File size thresholds, extraction patterns |
+| [cloud-refactor.md](cloud-refactor.md) | Refactor request template |
 | [development-environment.md](development-environment.md) | Docker dev setup, hot reload, access URLs |
 | [django-conventions.md](django-conventions.md) | 1:1:1:1 full-stack conventions, naming |
 | [vite-frontend.md](vite-frontend.md) | Vite HMR, entry points, template tags |
 | [mobile-testing.md](mobile-testing.md) | Mobile responsive testing — Playwright, viewport, auth selectors |
 
-## Quick Navigation
+## Quick navigation
 
-- Managing cloud projects -> [project-management.md](project-management.md)
-- Syncing code between local/workspace -> [sync-architecture.md](sync-architecture.md)
-- Git repo operations (clone, fork, PR, issue) -> [gitea-cli.md](gitea-cli.md)
-- Developing/publishing apps -> [app-management.md](app-management.md)
-- DataStore / FileVault / JobQueue -> [sdk.md](sdk.md)
-- Docker, deploy, MCP server -> [infrastructure.md](infrastructure.md)
-- Python API programmatic access -> [python-api.md](python-api.md)
-- Deploy to staging -> [deployment-staging.md](deployment-staging.md)
-- Deploy to production -> [deployment-production.md](deployment-production.md)
-- Version sync across ecosystem -> [version-management.md](version-management.md)
-- Refactoring rules (file sizes, extraction) -> [refactoring-rules.md](refactoring-rules.md)
-- Dev environment setup -> [development-environment.md](development-environment.md)
-- Django conventions (1:1:1:1) -> [django-conventions.md](django-conventions.md)
-- Vite/TypeScript frontend -> [vite-frontend.md](vite-frontend.md)
-- Mobile responsive testing -> [mobile-testing.md](mobile-testing.md)
+- Managing cloud projects → [project-management.md](project-management.md)
+- Syncing code between local/workspace → [sync-architecture.md](sync-architecture.md)
+- Git repo operations (clone, fork, PR, issue) → [gitea-cli.md](gitea-cli.md)
+- Developing/publishing apps → [app-management.md](app-management.md)
+- DataStore / FileVault / JobQueue → [sdk.md](sdk.md)
+- Docker, deploy, MCP server → [infrastructure.md](infrastructure.md)
+- Python API programmatic access → [python-api.md](python-api.md)
+- Deploy to staging → [deployment-staging.md](deployment-staging.md)
+- Deploy to production → [deployment-production.md](deployment-production.md)
+- Version sync across ecosystem → [version-management.md](version-management.md) / [scitex-versions.md](scitex-versions.md)
+- Refactoring rules → [refactoring-rules.md](refactoring-rules.md)
+- Dev environment setup → [development-environment.md](development-environment.md)
+- Django conventions (1:1:1:1) → [django-conventions.md](django-conventions.md)
+- Vite/TypeScript frontend → [vite-frontend.md](vite-frontend.md)
+- Mobile responsive testing → [mobile-testing.md](mobile-testing.md)
 
 # EOF


### PR DESCRIPTION
## Summary

Part of the fleet skills-rollout pass. Three edits in this package:

- **SKILL.md** (`src/scitex_cloud/_skills/scitex-cloud/SKILL.md`) —
  audited against the current code. Now documents every CLI group
  actually registered in `_cli/main.py`, the real MCP tool surface
  (55 tools across `gitea`/`sdk`/`api`/`app`/`onsite`/`project_crud`
  per `_mcp_tools/__init__.py::register_all_tools`), the Python API
  exposed from `__init__.py`, and all 21 sub-skill files under
  `_skills/scitex-cloud/` (index previously listed 15).
- **README.md** — removed stale claims. The old MCP table said
  "cloud 14 / api 9"; reality is 6 categories totalling 55. Docker
  examples showed `docker status / docker logs` which don't exist;
  replaced with the real subcommands (`up / down / ps / build /
  restart`). Dropped the hardcoded `"0.15.0"` string since version
  comes from `pyproject.toml` via `_get_version()`.
- **MANIFEST.in** (new) — `recursive-include src/scitex_cloud/_skills
  *.md` as belt-and-braces for sdist. The existing
  `[tool.setuptools.package-data]` glob `_skills/**/*.md` already
  covers wheels.

## Verification

- `scitex_cloud` imports cleanly; `__version__` resolves to
  `0.17.0-alpha`.
- Counted MCP tools via `grep -c "@mcp.tool()"` on each file in
  `_mcp_tools/` → gitea=14, sdk=14, api=9, app=7, onsite=6,
  project_crud=5.
- Sphinx docs build clean (`sphinx-build -b html docs/sphinx /tmp/...`
  → "build succeeded, 1 warning" — the one warning is an env-local SSL
  issue on intersphinx, not a content problem).

## Known limitations in this environment

- **pytest**: can't run here — this machine's `libssl.so.1.1` is
  missing, so `import ssl` fails under pytest before collection.
  Unrelated to the package. Re-run on any normal dev box.
- **`python -m build`**: couldn't run because `build` isn't
  installable offline and setuptools 65.5.0 in `~/.venv` rejects the
  PEP 639 SPDX `license = "AGPL-3.0-only"` string (needs
  setuptools >=77). Config itself is correct — the `_skills/**/*.md`
  glob already matches all 22 skill files, confirmed via
  `glob.glob(...)`.

## GitHub About

Description + topics updated via `gh api PATCH` on the repo. Topics
now include `scitex`, `scitex-ecosystem`, `claude-code`, plus
`mcp`, `mcp-server`, `ai-agents`, `self-hosted`, `gitea`.

## Do not merge

Per fleet rules — fleet-lead's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)