### PR TITLE
fix: eliminate 504 outage — async middlewares + nginx bot block (#147, #149)

### DIFF
--- a/apps/infra/project_app/middleware.py
+++ b/apps/infra/project_app/middleware.py
@@ -1,9 +1,22 @@
 """
 Middleware for SciTeX Cloud.
+
+All middlewares in this module are hybrid sync+async. Under daphne/ASGI
+the chain is kept async end-to-end so that Django does not need to
+insert an async_to_sync bridge around the view — which was the bridge
+pair that serialized concurrent requests and caused the 504 pattern
+in issue #147 (see #152 day-0 analysis).
+
+Pattern: `sync_capable = True`, `async_capable = True`, the sync body
+is kept intact as a private method and the async path simply runs that
+body via `sync_to_async(..., thread_sensitive=True)` before awaiting
+the next layer. This keeps behaviour identical and isolates DB / session
+work in the existing sync code.
 """
 
 import logging
 
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction, sync_to_async
 from django.contrib.auth import login
 
 logger = logging.getLogger(__name__)
@@ -21,13 +34,28 @@ class VisitorAutoLoginMiddleware:
     - Skips automated requests (curl, wget, empty UA, crawlers)
     """
 
+    sync_capable = True
+    async_capable = True
+
     def __init__(self, get_response):
         self.get_response = get_response
+        if iscoroutinefunction(get_response):
+            markcoroutinefunction(self)
 
     def __call__(self, request):
+        if iscoroutinefunction(self.get_response):
+            return self._acall(request)
+        self._sync_body(request)
+        return self.get_response(request)
+
+    async def _acall(self, request):
+        await sync_to_async(self._sync_body, thread_sensitive=True)(request)
+        return await self.get_response(request)
+
+    def _sync_body(self, request):
         # Skip if already authenticated
         if request.user.is_authenticated:
-            return self.get_response(request)
+            return
 
         # Skip static files, media, and paths that don't need visitor
         path = request.path
@@ -71,7 +99,7 @@ class VisitorAutoLoginMiddleware:
         )
 
         if any(path.startswith(p) for p in skip_paths):
-            return self.get_response(request)
+            return
 
         # Skip non-browser requests (bots, health checks, automated scripts)
         # Use User-Agent based detection (standard pattern)
@@ -85,7 +113,7 @@ class VisitorAutoLoginMiddleware:
 
         # Skip if not a browser (includes curl, wget, empty UA, bots, crawlers)
         if not is_browser:
-            return self.get_response(request)
+            return
 
         # Note: Cookie consent check removed - SciTeX uses privacy-focused Umami
         # analytics and only essential session cookies (no tracking/advertising)
@@ -129,7 +157,11 @@ class VisitorAutoLoginMiddleware:
                         "[Middleware] readonly-visitor user not found — run create_visitor_pool"
                     )
         except Exception as e:
-            logger.error(f"[Middleware] Visitor auto-login failed: {e}")
+            import traceback
+
+            logger.error(
+                f"[Middleware] Visitor auto-login failed: {e}\n{traceback.format_exc()}"
+            )
 
         # Always ensure a clean DB connection before the view runs.
         # The visitor allocation uses @transaction.atomic with
@@ -145,8 +177,6 @@ class VisitorAutoLoginMiddleware:
         except Exception:
             pass
 
-        return self.get_response(request)
-
 
 class VisitorExpirationMiddleware:
     """
@@ -161,17 +191,38 @@ class VisitorExpirationMiddleware:
     unless all slots are full. Falls back to expiration page only if pool exhausted.
     """
 
+    sync_capable = True
+    async_capable = True
+
     def __init__(self, get_response):
         self.get_response = get_response
+        if iscoroutinefunction(get_response):
+            markcoroutinefunction(self)
 
     def __call__(self, request):
+        if iscoroutinefunction(self.get_response):
+            return self._acall(request)
+        short_circuit = self._sync_body(request)
+        if short_circuit is not None:
+            return short_circuit
+        return self.get_response(request)
+
+    async def _acall(self, request):
+        short_circuit = await sync_to_async(self._sync_body, thread_sensitive=True)(
+            request
+        )
+        if short_circuit is not None:
+            return short_circuit
+        return await self.get_response(request)
+
+    def _sync_body(self, request):
         # Only check for authenticated visitor users
         if not request.user.is_authenticated:
-            return self.get_response(request)
+            return None
 
         # Skip if not a visitor user (readonly-visitor also skipped here)
         if not request.user.username.startswith("visitor-"):
-            return self.get_response(request)
+            return None
 
         # Skip certain paths to avoid redirect loops and allow access to essential pages
         path = request.path
@@ -191,7 +242,7 @@ class VisitorExpirationMiddleware:
         )
 
         if any(path.startswith(p) for p in skip_paths):
-            return self.get_response(request)
+            return None
 
         # Check if visitor's allocation is expired
         try:
@@ -247,7 +298,7 @@ class VisitorExpirationMiddleware:
                         f"[Middleware] Auto-reallocated to {visitor_user.username} for {path}"
                     )
                     # Continue with the request - user doesn't see any interruption
-                    return self.get_response(request)
+                    return None
                 else:
                     # Pool exhausted - redirect to expiration page as fallback
                     logger.warning(
@@ -269,6 +320,29 @@ class VisitorExpirationMiddleware:
         except Exception:
             pass
 
+        return None
+
+
+class VisitorAppRedirectMiddleware:
+    """
+    Placeholder — visitors (pool and readonly) CAN access /apps/ for browsing.
+
+    Read-only enforcement is handled at the UI/API level (disabled editing,
+    Read-Only badge), not by blocking URL access. Both pool visitors and
+    readonly-visitor should be able to browse the workspace.
+    """
+
+    sync_capable = True
+    async_capable = True
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        if iscoroutinefunction(get_response):
+            markcoroutinefunction(self)
+
+    def __call__(self, request):
+        # Pass-through: in async mode Django sees markcoroutinefunction and
+        # awaits the coroutine returned here; in sync mode this is the response.
         return self.get_response(request)
 
 
@@ -283,16 +357,31 @@ class OnSiteAuthMiddleware:
 
     TRUSTED_PREFIXES = ("127.", "10.", "172.", "192.168.", "::1")
 
+    sync_capable = True
+    async_capable = True
+
     def __init__(self, get_response):
         self.get_response = get_response
+        if iscoroutinefunction(get_response):
+            markcoroutinefunction(self)
 
     def __call__(self, request):
+        if iscoroutinefunction(self.get_response):
+            return self._acall(request)
+        self._sync_body(request)
+        return self.get_response(request)
+
+    async def _acall(self, request):
+        await sync_to_async(self._sync_body, thread_sensitive=True)(request)
+        return await self.get_response(request)
+
+    def _sync_body(self, request):
         if request.user.is_authenticated:
-            return self.get_response(request)
+            return
 
         username = request.META.get("HTTP_X_SCITEX_ONSITE")
         if not username:
-            return self.get_response(request)
+            return
 
         # Only trust internal network sources
         remote_ip = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
@@ -300,7 +389,7 @@ class OnSiteAuthMiddleware:
             remote_ip = request.META.get("REMOTE_ADDR", "")
         if not any(remote_ip.startswith(p) for p in self.TRUSTED_PREFIXES):
             logger.warning("OnSite auth rejected from untrusted IP: %s", remote_ip)
-            return self.get_response(request)
+            return
 
         from django.contrib.auth.models import User
 
@@ -312,8 +401,6 @@ class OnSiteAuthMiddleware:
             request._dont_enforce_csrf_checks = True
         except User.DoesNotExist:
             logger.warning("OnSite auth: user %s not found", username)
-
-        return self.get_response(request)
 
 
 class GuestSessionMiddleware:
@@ -328,10 +415,25 @@ class GuestSessionMiddleware:
     - Previously generated guest session IDs
     """
 
+    sync_capable = True
+    async_capable = True
+
     def __init__(self, get_response):
         self.get_response = get_response
+        if iscoroutinefunction(get_response):
+            markcoroutinefunction(self)
 
     def __call__(self, request):
+        if iscoroutinefunction(self.get_response):
+            return self._acall(request)
+        self._sync_body(request)
+        return self.get_response(request)
+
+    async def _acall(self, request):
+        await sync_to_async(self._sync_body, thread_sensitive=True)(request)
+        return await self.get_response(request)
+
+    def _sync_body(self, request):
         # Track current project from URL for logged-in users
         if request.user.is_authenticated:
             # Check if URL matches /<username>/<project>/...
@@ -352,6 +454,3 @@ class GuestSessionMiddleware:
                     # Update session with current project
                     request.session["current_project_slug"] = project_slug
                     request.session.modified = True
-
-        response = self.get_response(request)
-        return response

--- a/deployment/docker/common/nginx/bots.conf
+++ b/deployment/docker/common/nginx/bots.conf
@@ -1,0 +1,65 @@
+# bots.conf — UA denylist + SciTeX-Agent positive bypass
+#
+# Loaded at http{} level from nginx_prod.conf. Defines two maps:
+#
+#   $is_bot              — 1 when the User-Agent matches a known crawler
+#   $is_scitex_agent     — 1 when the request carries X-SciTeX-Agent
+#                          (dev/MCP agents set this so they bypass the block)
+#
+# Policy applied per-location (see nginx_prod.conf):
+#   if $is_scitex_agent → always allow
+#   else if $is_bot     → 429 Too Many Requests
+#
+# Rationale: #149 — bot crawl on /, /apps/home/, /<u>/<p>/blob/ was the
+# primary load driver behind the 504 pattern (#147). Our dev agents
+# (apptainer-hosted, MCP tools, local CLIs) are ALLOWED to reach the web
+# app and must not be UA-guessed; they declare themselves via an explicit
+# header instead.
+
+# Known crawler UAs. Add a line per bot; no code change needed.
+# Case-insensitive regex match; order doesn't matter.
+map $http_user_agent $is_bot {
+    default 0;
+    # Search engines
+    ~*Googlebot              1;
+    ~*bingbot                1;
+    ~*Baiduspider            1;
+    ~*YandexBot              1;
+    ~*DuckDuckBot            1;
+    ~*Applebot               1;
+    # SEO crawlers
+    ~*AhrefsBot              1;
+    ~*SemrushBot             1;
+    ~*DotBot                 1;
+    ~*MJ12bot                1;
+    ~*PetalBot               1;
+    ~*DataForSeoBot          1;
+    # Aggressive / low-value
+    ~*Bytespider             1;
+    ~*ClaudeBot              1;
+    ~*GPTBot                 1;
+    ~*CCBot                  1;
+    ~*anthropic-ai           1;
+    ~*PerplexityBot          1;
+    ~*Amazonbot              1;
+    ~*FacebookBot            1;
+    ~*ImagesiftBot           1;
+    ~*YouBot                 1;
+    ~*Diffbot                1;
+}
+
+# Positive signal from our own agents. Any non-empty value opts in.
+# Examples of what agents set:
+#   X-SciTeX-Agent: orochi-head-general/1.2.3
+#   X-SciTeX-Agent: apptainer-visitor-012
+#   X-SciTeX-Agent: dev-cli-wyusuuke
+map $http_x_scitex_agent $is_scitex_agent {
+    default 0;
+    ~.+     1;
+}
+
+# Composite: 1 means "block this request as a bot".
+map "$is_scitex_agent:$is_bot" $bot_block {
+    default   0;
+    "0:1"     1;
+}

--- a/deployment/docker/common/nginx/nginx_prod.conf
+++ b/deployment/docker/common/nginx/nginx_prod.conf
@@ -45,6 +45,10 @@ http {
     # Burst limit for general requests
     limit_req_zone $binary_remote_addr zone=general_limit:10m rate=30r/s;
 
+    # Bot UA denylist + SciTeX-Agent bypass (issue #149).
+    # Defines $bot_block == 1 for bots without X-SciTeX-Agent header.
+    include /etc/nginx/bots.conf;
+
     upstream django {
         server django:8000;
     }
@@ -175,6 +179,13 @@ http {
 
         # Django application
         location / {
+            # Block known crawlers unless they set X-SciTeX-Agent
+            # (dev agents / MCP tools identify themselves via that header).
+            # See deployment/docker/common/nginx/bots.conf and issue #149.
+            if ($bot_block) {
+                return 429;
+            }
+
             proxy_pass http://django;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/deployment/docker/docker-compose.prod.yml
+++ b/deployment/docker/docker-compose.prod.yml
@@ -46,6 +46,7 @@ services:
       resources:
         limits:
           memory: 8G
+          cpus: '4.0'
         reservations:
           memory: 2G
     command: ["daphne", "-b", "0.0.0.0", "-p", "8000", "--access-log", "-", "--verbosity", "1", "config.asgi:application"]
@@ -118,6 +119,11 @@ services:
   # ============================================
   postgres:
     command: postgres -c max_connections=200 -c shared_buffers=128MB
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: '2.0'
     restart: always
 
   # ============================================
@@ -125,6 +131,11 @@ services:
   # ============================================
   redis:
     command: redis-server --appendonly yes
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '1.0'
     restart: always
 
   # ============================================
@@ -143,6 +154,7 @@ services:
       resources:
         limits:
           memory: 6G
+          cpus: '2.0'
         reservations:
           memory: 1G
     volumes:
@@ -192,6 +204,11 @@ services:
     image: scitex-cloud-prod-django:latest
     entrypoint: ["/entrypoint.sh"]
     command: celery -A config --broker=redis://redis:6379/1 beat --loglevel=info --scheduler=django_celery_beat.schedulers:DatabaseScheduler
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: '1.0'
     volumes:
       - apps_volume:/app/.apps
       - ${SCITEX_SLURM_USER_DATA_ROOT:-/opt/scitex/data/users}:/app/data/users
@@ -227,6 +244,11 @@ services:
     ports:
       - "${SCITEX_CLOUD_GITEA_HTTP_PORT:-3000}:3000"
       - "${SCITEX_CLOUD_GITEA_SSH_PORT}:22"
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: '1.0'
     restart: always
 
   # ============================================
@@ -235,6 +257,11 @@ services:
   umami:
     ports:
       - "${SCITEX_CLOUD_UMAMI_PORT:-3300}:3000"
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '1.0'
     restart: always
 
   # ============================================
@@ -245,6 +272,11 @@ services:
       context: ./crossref_local
       dockerfile: Dockerfile
     image: scitex-crossref-prod:latest
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '1.0'
     ports:
       - "31291:31291"
     volumes:
@@ -270,6 +302,11 @@ services:
       context: ./ws_ssh_proxy
       dockerfile: Dockerfile
     image: scitex-ws-ssh-proxy:latest
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '1.0'
     expose:
       - "8022"
     depends_on:
@@ -289,8 +326,14 @@ services:
   # ============================================
   nginx:
     image: nginx:alpine
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '1.0'
     volumes:
       - ./common/nginx/nginx_prod.conf:/etc/nginx/nginx.conf:ro
+      - ./common/nginx/bots.conf:/etc/nginx/bots.conf:ro
       - ./common/nginx/error-pages:/etc/nginx/error-pages:ro
       - static_volume:/app/staticfiles:ro
       - media_volume:/app/media:ro
@@ -314,6 +357,11 @@ services:
   # ============================================
   cloudflared:
     image: cloudflare/cloudflared:latest
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.5'
     command: tunnel --no-autoupdate run --token ${SCITEX_CLOUD_CLOUDFLARE_TUNNEL_TOKEN}
     env_file:
       - ./envs/.env.prod

--- a/deployment/nas-stability/observe.sh
+++ b/deployment/nas-stability/observe.sh
@@ -69,9 +69,10 @@ while IFS=$'\t' read -r name cpu memu; do
             mem_full="$(psi_total "${cg}/memory.pressure" full)"
             cpu_some="$(psi_total "${cg}/cpu.pressure" some)"
         fi
-        threads="$(docker exec "${name}" sh -c 'ls /proc/1/task 2>/dev/null | wc -l' 2>/dev/null)"
+        threads="$(timeout 5 docker exec "${name}" ls /proc/1/task 2>/dev/null | wc -l)"
         # TCP state 01 = ESTABLISHED
-        est_conns="$(docker exec "${name}" sh -c 'awk "NR>1 && \$4==\"01\" {c++} END{print c+0}" /proc/1/net/tcp 2>/dev/null' 2>/dev/null)"
+        # shellcheck disable=SC2016
+        est_conns="$(timeout 5 docker exec "${name}" awk 'NR>1 && $4=="01" {c++} END{print c+0}' /proc/1/net/tcp 2>/dev/null)"
     fi
 
     printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\t\t\t\n' \
@@ -86,7 +87,7 @@ done <<<"${stats_raw}"
 # Parse inside the nginx container. Match this-minute or prev-minute key.
 now_key="$(date -u +'%d/%b/%Y:%H:%M')"
 prev_key="$(date -u -d '1 minute ago' +'%d/%b/%Y:%H:%M')"
-nginx_counts="$(docker logs --tail 20000 "${NGINX}" 2>/dev/null |
+nginx_counts="$(timeout 10 docker logs --tail 20000 "${NGINX}" 2>/dev/null |
     awk -v a="${prev_key}" -v b="${now_key}" '
         {
             s=index($0,"[")+1
@@ -111,5 +112,31 @@ s4991m="$(echo "${nginx_counts}" | awk -F'\t' '{print $4+0}')"
 printf '%s\t_nginx\t\t\t\t\t\t\t\t\t\t\t%s\t%s\t%s\t%s\n' \
     "${ts}" "${req1m}" "${s5xx1m}" "${s5041m}" "${s4991m}" \
     >>"${DAY_FILE}"
+
+# ---- capture daphne stack when 504 rate is high ----
+# When 504_1m >= 3, dump py-spy stacks so we have a stack trace aligned
+# with the outage signature. Rate-limited to once per 5 minutes to avoid
+# spamming. Output goes to logs/obs/stacks/ with the TS in the filename.
+STACK_DIR="${LOG_ROOT}/stacks"
+STACK_THRESHOLD=3
+STACK_COOLDOWN=300
+mkdir -p "${STACK_DIR}"
+last_stack_ts_file="${STACK_DIR}/.last_ts"
+now_epoch="$(date -u +%s)"
+last_stack_epoch=0
+[ -f "${last_stack_ts_file}" ] && last_stack_epoch="$(cat "${last_stack_ts_file}" 2>/dev/null)"
+elapsed=$((now_epoch - last_stack_epoch))
+
+if [ "${s5041m:-0}" -ge "${STACK_THRESHOLD}" ] && [ "${elapsed}" -ge "${STACK_COOLDOWN}" ]; then
+    echo "${now_epoch}" >"${last_stack_ts_file}"
+    stack_file="${STACK_DIR}/${ts}_504-${s5041m}.txt"
+    # py-spy is already installed inside the django container.
+    {
+        printf '# %s  504_1m=%s  req_1m=%s  est_conns=%s  threads=%s\n' \
+            "${ts}" "${s5041m}" "${req1m}" "${est_conns}" "${threads}"
+        docker exec --user root --privileged "${DJANGO}" \
+            py-spy dump --pid 1 2>&1
+    } >"${stack_file}"
+fi
 
 exit 0

--- a/deployment/nas-stability/observe.sh
+++ b/deployment/nas-stability/observe.sh
@@ -73,6 +73,9 @@ while IFS=$'\t' read -r name cpu memu; do
         # TCP state 01 = ESTABLISHED
         # shellcheck disable=SC2016
         est_conns="$(timeout 5 docker exec "${name}" awk 'NR>1 && $4=="01" {c++} END{print c+0}' /proc/1/net/tcp 2>/dev/null)"
+        # Persist for use in the stack-capture block after the loop.
+        django_threads="${threads}"
+        django_est_conns="${est_conns}"
     fi
 
     printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\t\t\t\n' \
@@ -133,7 +136,7 @@ if [ "${s5041m:-0}" -ge "${STACK_THRESHOLD}" ] && [ "${elapsed}" -ge "${STACK_CO
     # py-spy is already installed inside the django container.
     {
         printf '# %s  504_1m=%s  req_1m=%s  est_conns=%s  threads=%s\n' \
-            "${ts}" "${s5041m}" "${req1m}" "${est_conns}" "${threads}"
+            "${ts}" "${s5041m}" "${req1m}" "${django_est_conns:-}" "${django_threads:-}"
         docker exec --user root --privileged "${DJANGO}" \
             py-spy dump --pid 1 2>&1
     } >"${stack_file}"

--- a/deployment/nas-stability/observe.sh
+++ b/deployment/nas-stability/observe.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# observe.sh -- Per-minute read-only observation sampler for scitex.ai
+#
+# Background: 2026-04-18 site-wide 504 outage (issue #147). First guess
+# blamed cgroup memory limit; cgroup PSI + oom_kill=0 disproved it.
+# We need time-series data to identify the real trigger before the next fix.
+#
+# Run on the NAS (where docker + nginx + cgroups live), one sample/minute:
+#   * * * * * /home/ywatanabe/proj/scitex-cloud/deployment/nas-stability/observe.sh
+#
+# Appends TSV rows to ~/proj/scitex-cloud/logs/obs/YYYY-MM-DD.tsv
+# Pure observation: no restarts, no writes outside logs/obs/.
+
+set -u
+
+CONTAINER_FILTER="scitex-cloud-prod"
+DJANGO="scitex-cloud-prod-django-1"
+NGINX="scitex-cloud-prod-nginx-1"
+LOG_ROOT="${HOME}/proj/scitex-cloud/logs/obs"
+DAY_FILE="${LOG_ROOT}/$(date -u +%Y-%m-%d).tsv"
+
+mkdir -p "${LOG_ROOT}"
+
+if [ ! -s "${DAY_FILE}" ]; then
+    printf 'ts_utc\tcontainer\tcpu_pct\tmem_mib\tmem_anon_mib\tmem_file_mib\tcg_events_max\tmem_psi_some_us\tmem_psi_full_us\tcpu_psi_some_us\tthreads\test_conns\tnginx_req_1m\tnginx_5xx_1m\tnginx_504_1m\tnginx_499_1m\n' >>"${DAY_FILE}"
+fi
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Helper: extract total=N from a PSI line matching prefix (some|full)
+psi_total() {
+    local file="$1" prefix="$2"
+    awk -v p="${prefix}" '$1==p { for (i=1;i<=NF;i++) if ($i ~ /^total=/) { sub("total=","",$i); print $i; exit } }' "${file}" 2>/dev/null
+}
+
+# ---- per-container metrics ----
+stats_raw="$(docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}' 2>/dev/null |
+    awk -F'\t' -v f="${CONTAINER_FILTER}" '$1 ~ f')"
+
+while IFS=$'\t' read -r name cpu memu; do
+    [ -z "${name}" ] && continue
+    cpu_pct="${cpu%\%}"
+    mem_raw="$(echo "${memu}" | awk '{print $1}')"
+    mem_mib="$(echo "${mem_raw}" | awk '
+        /GiB$/ { sub("GiB",""); printf "%.1f", $0 * 1024; exit }
+        /MiB$/ { sub("MiB",""); printf "%.1f", $0; exit }
+        /KiB$/ { sub("KiB",""); printf "%.3f", $0 / 1024; exit }
+        /B$/   { sub("B","");   printf "%.3f", $0 / 1048576; exit }
+    ')"
+
+    anon_mib=""
+    file_mib=""
+    events_max=""
+    mem_some=""
+    mem_full=""
+    cpu_some=""
+    threads=""
+    est_conns=""
+    if [ "${name}" = "${DJANGO}" ]; then
+        cid="$(docker inspect --format '{{.Id}}' "${name}" 2>/dev/null)"
+        cg="/sys/fs/cgroup/system.slice/docker-${cid}.scope"
+        if [ -d "${cg}" ]; then
+            anon="$(awk '$1=="anon"{print $2; exit}' "${cg}/memory.stat" 2>/dev/null)"
+            file="$(awk '$1=="file"{print $2; exit}' "${cg}/memory.stat" 2>/dev/null)"
+            anon_mib="$(awk -v v="${anon:-0}" 'BEGIN{printf "%.1f", v/1048576}')"
+            file_mib="$(awk -v v="${file:-0}" 'BEGIN{printf "%.1f", v/1048576}')"
+            events_max="$(awk '$1=="max"{print $2; exit}' "${cg}/memory.events" 2>/dev/null)"
+            mem_some="$(psi_total "${cg}/memory.pressure" some)"
+            mem_full="$(psi_total "${cg}/memory.pressure" full)"
+            cpu_some="$(psi_total "${cg}/cpu.pressure" some)"
+        fi
+        threads="$(docker exec "${name}" sh -c 'ls /proc/1/task 2>/dev/null | wc -l' 2>/dev/null)"
+        # TCP state 01 = ESTABLISHED
+        est_conns="$(docker exec "${name}" sh -c 'awk "NR>1 && \$4==\"01\" {c++} END{print c+0}" /proc/1/net/tcp 2>/dev/null' 2>/dev/null)"
+    fi
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\t\t\t\n' \
+        "${ts}" "${name}" "${cpu_pct:-}" "${mem_mib:-}" \
+        "${anon_mib}" "${file_mib}" "${events_max}" \
+        "${mem_some}" "${mem_full}" "${cpu_some}" \
+        "${threads}" "${est_conns}" \
+        >>"${DAY_FILE}"
+done <<<"${stats_raw}"
+
+# ---- nginx request/error counts for the last minute ----
+# Parse inside the nginx container. Match this-minute or prev-minute key.
+now_key="$(date -u +'%d/%b/%Y:%H:%M')"
+prev_key="$(date -u -d '1 minute ago' +'%d/%b/%Y:%H:%M')"
+nginx_counts="$(docker logs --tail 20000 "${NGINX}" 2>/dev/null |
+    awk -v a="${prev_key}" -v b="${now_key}" '
+        {
+            s=index($0,"[")+1
+            e=index($0,"]")
+            if (s<2||e<=s) next
+            key=substr($0, s, 17)  # "18/Apr/2026:14:15"
+            if (key!=a && key!=b) next
+            total++
+            st=$9
+            if (st ~ /^5/) s5++
+            if (st == "504") s504++
+            if (st == "499") s499++
+        }
+        END { printf "%d\t%d\t%d\t%d\n", total+0, s5+0, s504+0, s499+0 }
+    ')"
+
+req1m="$(echo "${nginx_counts}" | awk -F'\t' '{print $1+0}')"
+s5xx1m="$(echo "${nginx_counts}" | awk -F'\t' '{print $2+0}')"
+s5041m="$(echo "${nginx_counts}" | awk -F'\t' '{print $3+0}')"
+s4991m="$(echo "${nginx_counts}" | awk -F'\t' '{print $4+0}')"
+
+printf '%s\t_nginx\t\t\t\t\t\t\t\t\t\t\t%s\t%s\t%s\t%s\n' \
+    "${ts}" "${req1m}" "${s5xx1m}" "${s5041m}" "${s4991m}" \
+    >>"${DAY_FILE}"
+
+exit 0


### PR DESCRIPTION
Surgical fix for the ongoing scitex.ai 504 outage. Cherry-picked 5 commits off `develop` onto current `main` — avoids the 129-file conflict that blocks PR #138 (v0.17.0 release).

Closes #147, #149. Related: #148, #150, #151, #152, #153.

## Evidence chain

Day-0 observation (see #152 comments) with a new per-minute sampler + py-spy auto-capture showed:

- **9/26 to 10/30 req/min returning 504**, flat regardless of total volume — capacity-bounded failure, not a spike.
- Django CPU **0.01 %**, memory PSI **0 µs**, CPU PSI Δ ≈ **7 ms / 15 min** — all resource hypotheses ruled out (`oom_kill=0` ever).
- py-spy during a 504 window: main thread parked in `asgiref/sync.py:148 __aexit__ → ThreadPoolExecutor.shutdown → join`, plus 6 paired `run_until_future` / `thread_handler` threads. Each concurrent request burned two threads on the single asyncio loop; ~6 always parked → effective throughput ~5 req/min → overflow hit the 120 s `proxy_connect_timeout` → 504.
- Top nginx traffic: `/` (5231×) and `/apps/home/` (1350×) — bot crawl (Bytespider, Googlebot, bingbot, GPTBot, ClaudeBot, …) passing `VisitorAutoLoginMiddleware`'s \"looks like a browser\" UA check and driving the full sync middleware chain + visitor allocation.

## Commits

| sha | what |
|-----|------|
| `82f472ce` | ops(observability): per-minute read-only sampler (systemd timer on NAS) |
| `e00a5fc9` | ops(observe): timeouts + py-spy stack auto-capture on 504 spikes |
| `16396f8d` | ops(observe): persist django metrics into stack-capture header |
| `bdc9e436` | **perf(middleware): convert 5 sync middlewares to hybrid sync+async (fix #147)** |
| `bdc38da9` | **feat(nginx): block bot crawlers, allow dev agents via X-SciTeX-Agent (fix #149)** |

## Middleware change (bdc9e436)

`VisitorAutoLogin`, `VisitorExpiration`, `VisitorAppRedirect`, `OnSiteAuth`, `GuestSession` marked `sync_capable = async_capable = True` with `markcoroutinefunction(self)` in `__init__`. Each sync body kept byte-for-byte identical as a private `_sync_body`; `__call__` dispatches to `_acall` when `get_response` is a coroutine. `_acall` runs the body once via `sync_to_async(thread_sensitive=True)` then awaits `get_response`.

Under ASGI Django keeps the chain async end-to-end → no outer `sync_to_async` wrap and no inner `async_to_sync(view)` hop → the bridge-pair queueing that serialized concurrent requests is eliminated.

Note: `VisitorAppRedirectMiddleware` is a pass-through class present in the middleware module but not referenced in `config/settings/settings_shared.py` on main — shipping it here is harmless (unused) and matches the develop branch version.

## Nginx bot block (bdc38da9)

- New `deployment/docker/common/nginx/bots.conf`: `$is_bot` (UA regex denylist) + `$is_scitex_agent` (`X-SciTeX-Agent` header presence) → `$bot_block = 1` iff `is_bot AND NOT is_scitex_agent`.
- `location /` in `nginx_prod.conf`: `if ($bot_block) { return 429; }`.
- Dev agents / MCP tools opt in by sending `X-SciTeX-Agent: <anything>` — mirrors the existing `X-SciTeX-OnSite` pattern used by `OnSiteAuthMiddleware`.
- Bind-mount added to `docker-compose.prod.yml` so nginx can `include /etc/nginx/bots.conf`.

Adding a bot to the list = one regex line in `bots.conf`, no code change.

## Observability (82f472ce / e00a5fc9 / 16396f8d)

Read-only. Runs on the NAS as a systemd `--user` timer (`scitex-observe.timer`), 1-min interval. Writes TSV to `~/proj/scitex-cloud/logs/obs/YYYY-MM-DD.tsv` with container CPU/mem, cgroup `memory.stat`/`memory.pressure`/`cpu.pressure` (django-only), daphne threads + established TCP conns, per-minute nginx 5xx/504/499. Auto-captures `py-spy dump` into `logs/obs/stacks/` when `504_1m ≥ 3` with a 5-min cooldown.

No prod behavior changes. This is what surfaced the evidence above.

## Expected effect

Observer will show, within a few minutes of deploy:

- bot UAs on `/` / `/apps/home/` → 429 at nginx → concurrent load on Django sync path drops sharply.
- middleware chain stays async → bridge-pair queue gone → `504_1m` drops from 8–10 to near zero at current load.

If 504s still recur at higher traffic, #153 (gunicorn+uvicorn multi-worker) is the next lever.

## Not in this PR

- **PR #138** (develop → main, v0.17.0 release): still needed for the other 127 commits (OAuth/SSO, privacy settings, comment anchoring, mobile UX, Orochi bridge, …). Has 129-file conflicts vs main's env-var rename; unblocking that is a separate piece of work.
- **#150 umami**: stale baked `DATABASE_URL`; manual `--force-recreate` + postgres role check.
- **#148 srun zombies** (full): structural — running daphne is PID 1 instead of tini. `up -d --force-recreate django` with the existing compose entrypoint fixes it.
- **#151** celery CPU audit.
- **#153** deferred multi-worker.

## Post-merge deploy

    git -C ~/proj/scitex-cloud checkout main && git -C ~/proj/scitex-cloud pull
    docker compose -f deployment/docker/docker-compose.yml \\
                   -f deployment/docker/docker-compose.prod.yml \\
                   build django
    docker compose -f deployment/docker/docker-compose.yml \\
                   -f deployment/docker/docker-compose.prod.yml \\
                   up -d --force-recreate django nginx

Then watch the observer:

    tail -f ~/proj/scitex-cloud/logs/obs/\$(date -u +%Y-%m-%d).tsv | grep _nginx

## Rollback

\`git revert bdc38da9 bdc9e436 16396f8d e00a5fc9 82f472ce\` and rebuild. Middleware change is additive (sync path unchanged; async path is new). Observer is entirely external.