### PR TITLE
feat(#146): consume scitex_writer._django as thin wrapper (additive)

### DIFF
--- a/.scitex-apps.json
+++ b/.scitex-apps.json
@@ -14,6 +14,13 @@
       "git_url": "https://github.com/ywatanabe1989/figrecipe.git",
       "git_ref": "develop",
       "pip_package": "figrecipe"
+    },
+    {
+      "name": "scitex-writer",
+      "source": "sibling",
+      "git_url": "https://github.com/ywatanabe1989/scitex-writer.git",
+      "git_ref": "develop",
+      "pip_package": "scitex-writer"
     }
   ]
 }

--- a/apps/workspace/writer_app/urls/__init__.py
+++ b/apps/workspace/writer_app/urls/__init__.py
@@ -1,12 +1,14 @@
+import logging
+
 from django.urls import include, path
 
 app_name = "writer_app"
 
+logger = logging.getLogger(__name__)
+
 urlpatterns = [
     # API endpoints (must be first to match /api/* routes)
     path("api/", include("apps.workspace.writer_app.urls.api")),
-    # v2: shared `scitex_writer._django` implementation (gradual cut-over)
-    path("", include("apps.workspace.writer_app.urls.writer_django")),
     # Feature pages
     path("editor/", include("apps.workspace.writer_app.urls.editor")),
     path("compilation/", include("apps.workspace.writer_app.urls.compilation")),
@@ -16,3 +18,17 @@ urlpatterns = [
     # Main index (must be last as catch-all)
     path("", include("apps.workspace.writer_app.urls.index")),
 ]
+
+# v2: shared `scitex_writer._django` implementation (gradual cut-over).
+# Optional: skipped if scitex-writer is not installed in this environment.
+try:
+    from scitex_writer._django import views as _writer_django_views  # noqa: F401
+
+    urlpatterns.insert(
+        1,
+        path("", include("apps.workspace.writer_app.urls.writer_django")),
+    )
+except ImportError as _exc:
+    logger.info(
+        "[writer_app] scitex-writer not installed, skipping v2 routes: %s", _exc
+    )

--- a/apps/workspace/writer_app/urls/__init__.py
+++ b/apps/workspace/writer_app/urls/__init__.py
@@ -1,10 +1,12 @@
-from django.urls import path, include
+from django.urls import include, path
 
 app_name = "writer_app"
 
 urlpatterns = [
     # API endpoints (must be first to match /api/* routes)
     path("api/", include("apps.workspace.writer_app.urls.api")),
+    # v2: shared `scitex_writer._django` implementation (gradual cut-over)
+    path("", include("apps.workspace.writer_app.urls.writer_django")),
     # Feature pages
     path("editor/", include("apps.workspace.writer_app.urls.editor")),
     path("compilation/", include("apps.workspace.writer_app.urls.compilation")),

--- a/apps/workspace/writer_app/urls/writer_django.py
+++ b/apps/workspace/writer_app/urls/writer_django.py
@@ -1,0 +1,84 @@
+"""Thin wrapper that consumes `scitex_writer._django` as the canonical writer.
+
+Mirrors the `figrecipe_app/urls/figrecipe.py` pattern:
+- `editor_page` and `api_dispatch` come from the writer package
+- a small wrapper injects `working_dir` from the authenticated user's
+  current project
+
+This is the entry point for scitex-cloud#146 — the gradual cut-over from
+the legacy in-repo writer UI to the shared `_django` implementation.
+
+Lives alongside (not replacing) the old `writer_app/urls/editor.py` so the
+switch can be flipped per-environment without destabilising production.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
+from django.urls import path
+from scitex_writer._django.views import api_dispatch as _raw_api_dispatch
+from scitex_writer._django.views import editor_page as _raw_editor_page
+from scitex_writer._django.views import viewer_page as _raw_viewer_page
+
+logger = logging.getLogger(__name__)
+
+
+def _inject_project_context(request) -> None:
+    """Ensure request.GET carries working_dir from the user's current project."""
+    if not request.user.is_authenticated:
+        return
+    if request.GET.get("working_dir"):
+        return
+    try:
+        from apps.infra.project_app.services.project_utils import (
+            get_current_project,
+        )
+    except Exception:
+        return
+
+    project = get_current_project(request, user=request.user)
+    if not project:
+        return
+
+    try:
+        working_dir = str(project.get_local_path())
+    except Exception as exc:
+        logger.warning("[writer.v2] project.get_local_path() failed: %s", exc)
+        return
+
+    mutable = request.GET.copy()
+    mutable["working_dir"] = working_dir
+    request.GET = mutable
+
+
+@login_required
+def editor_page(request):
+    _inject_project_context(request)
+    return _raw_editor_page(request)
+
+
+@login_required
+def viewer_page(request):
+    _inject_project_context(request)
+    return _raw_viewer_page(request)
+
+
+@login_required
+def api_dispatch(request, endpoint):
+    _inject_project_context(request)
+    if not request.GET.get("working_dir"):
+        return JsonResponse(
+            {"error": "No working_dir resolved for the current user"},
+            status=400,
+        )
+    return _raw_api_dispatch(request, endpoint)
+
+
+urlpatterns = [
+    path("editor-v2/", editor_page, name="writer_v2_editor"),
+    path("viewer-v2/", viewer_page, name="writer_v2_viewer"),
+    path("v2/<path:endpoint>", api_dispatch, name="writer_v2_api"),
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 dependencies = [
     "click>=8.0",
     "scitex-app>=0.1.0",
+    "scitex-writer>=2.14.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Non-destructive consumer side of ywatanabe1989/scitex-writer#82 (PR1–PR6). Adds a path for scitex-cloud to start using the shared \`scitex_writer._django\` implementation without touching the existing legacy \`writer_app\` routes. Closes most of #146.

## New

- \`writer_app/urls/writer_django.py\` — thin wrapper mirroring \`figrecipe_app/urls/figrecipe.py\`:
  - \`@login_required\` views that inject \`working_dir\` from \`get_current_project(request, user=…)\`
  - Delegates to \`scitex_writer._django.views.{editor_page, viewer_page, api_dispatch}\`

## Routes added (under \`/apps/writer/\`)

| Path                      | Purpose                                    |
|---------------------------|--------------------------------------------|
| \`editor-v2/\`              | Canonical editor (Monaco + sections + PDF) |
| \`viewer-v2/\`              | Live-paper viewer (unblocks #133)          |
| \`v2/<path:endpoint>\`      | API dispatcher                              |

Legacy \`/editor/\`, \`/compilation/\`, \`/arxiv/\`, \`/version-control/\`, \`/collaboration/\` untouched.

## Deps

\`scitex-writer>=2.14.0\` added to \`pyproject.toml\` dependencies.

## Upstream

Depends on PR1–PR6 in scitex-writer:
- [#84 PR1](https://github.com/ywatanabe1989/scitex-writer/pull/84) foundation
- [#85 PR2](https://github.com/ywatanabe1989/scitex-writer/pull/85) scitex-ui shell
- [#86 PR3](https://github.com/ywatanabe1989/scitex-writer/pull/86) Monaco + sections
- [#87 PR4](https://github.com/ywatanabe1989/scitex-writer/pull/87) PDF + compile
- [#88 PR5](https://github.com/ywatanabe1989/scitex-writer/pull/88) Cite/Fig/Table icon bar
- [#89 PR6](https://github.com/ywatanabe1989/scitex-writer/pull/89) Viewer + claims + DAG

## Next step after merge

Flipping the default \`/editor/\` route to use the v2 wrapper is a follow-up commit once the v2 UX is reviewed visually. After that, legacy \`writer_app/{static,templates,views/editor}\` can be retired.

## Test plan

- [ ] CI green
- [ ] Reviewer: hit /apps/writer/editor-v2/ after login, verify Monaco + sections render
- [ ] Reviewer: hit /apps/writer/viewer-v2/, verify claims+PDF+DAG
- [ ] /apps/writer/v2/api/project-info returns JSON with project_dir set to current project

🤖 Generated with [Claude Code](https://claude.com/claude-code)