### PR TITLE
fix(cla): gate issue_comment trigger on URL shape (stop retry storm)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,6 +15,14 @@ permissions:
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
+    # Robust gate: the `github.event.issue.pull_request` field has proven
+    # unreliable on closed-issue comments — the action still fires and errors
+    # with "Could not resolve to a PullRequest". PR URLs always contain
+    # `/pull/`; non-PR issue URLs contain `/issues/`. Use the URL shape
+    # instead. (Ported from scitex-writer ca682ee.)
+    if: |
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' && contains(github.event.issue.html_url, '/pull/'))
     steps:
       - name: CLA Assistant
         uses: contributor-assistant/github-action@v2.6.1


### PR DESCRIPTION
## Summary

CLA Assistant has been failing on every `issue_comment` event since at least 2026-04-18 — 15+ consecutive red runs on `main` (recent burst triggered by mamba-mirror public issue mirroring after PR #154). Error:

```
graphql call to get the committers details failed:
GraphqlError: Could not resolve to a PullRequest with the number of N
```

…where N is the issue number (not a PR number). The action assumes every `issue_comment` event is on a PR; plain-issue comments fail the GraphQL lookup.

## Fix

Port of `scitex-writer` commit `ca682ee` — gate the job on URL shape:
- PR event payloads: `html_url` contains `/pull/`
- Plain issue payloads: `html_url` contains `/issues/`

`github.event.issue.pull_request` was already tried and proven unreliable on closed-issue comments (see scitex-writer#81 history). URL-shape check is the robust fix.

No change to `pull_request_target` behavior — real PR events still run CLA on open / close / synchronize.

## Related

- todo#464 (chronic CLA Assistant failures — now labelled `scitex-cloud`)
- scitex-writer#81 (first diagnosis; same fix)

## Test plan

- [x] Validated YAML syntax (pre-commit check yaml passed)
- [ ] After merge: next `issue_comment` on a plain issue should show `CLAssistant` skipped (not failed)
- [ ] After merge: next PR comment / PR open event still triggers CLA check normally

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>