### PR TITLE
chore(version): bump to 0.17.0-alpha.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scitex-cloud"
-version = "0.17.0-alpha"
+version = "0.17.0-alpha.post1"
 description = "SciTeX Cloud - Deployment and management CLI for SciTeX"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

Post-release version bump for #159 — CLI interactive-prompt removal (spec §2 + §6 compliance).

No API changes beyond what already merged in #159. The `.post1` segment reflects that this is a packaging-only bump on top of the `0.17.0-alpha` release.

## Release trigger

Publish to PyPI triggers on `release:published` (`.github/workflows/publish-pypi.yml`). After this PR merges, a GitHub release `v0.17.0-alpha.post1` will be created pointing at main, which fires the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)