### PR TITLE
fix(cli): port no-interactive-prompts fix into develop (#159)

### DIFF
--- a/src/scitex_cloud/_cli/_gitea_auth.py
+++ b/src/scitex_cloud/_cli/_gitea_auth.py
@@ -8,6 +8,7 @@ import sys
 import click
 import requests
 
+from .._config import get_config_value
 from ._gitea_utils import get_tea_config, run_tea
 
 # ---------------------------------------------------------------------------
@@ -85,20 +86,43 @@ def _create_or_get_gitea_token(url, user, password):
 
 @click.command()
 @click.option(
-    "--url", default=None, help="Gitea instance URL (auto-detected from .env)"
+    "--url",
+    default=None,
+    envvar="SCITEX_CLOUD_GITEA_URL",
+    help="Gitea instance URL (auto-detected from .env; env: SCITEX_CLOUD_GITEA_URL)",
 )
-@click.option("--token", default=None, help="API token (skip username/password flow)")
-@click.option("--user", "-u", default=None, help="Gitea username")
-@click.option("--password", "-p", default=None, help="Gitea password")
+@click.option(
+    "--token",
+    default=None,
+    envvar="SCITEX_CLOUD_GITEA_TOKEN",
+    help="API token, skip username/password flow (env: SCITEX_CLOUD_GITEA_TOKEN)",
+)
+@click.option(
+    "--user",
+    "-u",
+    default=None,
+    envvar="SCITEX_CLOUD_GITEA_USER",
+    help="Gitea username (env: SCITEX_CLOUD_GITEA_USER)",
+)
+@click.option(
+    "--password",
+    "-p",
+    default=None,
+    envvar="SCITEX_CLOUD_GITEA_PASSWORD",
+    help="Gitea password (env: SCITEX_CLOUD_GITEA_PASSWORD)",
+)
 @click.option(
     "--name", default="scitex-dev", help="Tea login name (default: scitex-dev)"
 )
 def login(url, token, user, password, name):
     """Login to SciTeX Cloud (Gitea).
 
-    When --token is not given, prompts for username/password and
-    automatically creates an API token via the Gitea API (like gh auth login).
-    Running this command a second time re-uses an existing token if found.
+    Non-interactive. Credentials resolve in precedence order (spec §6b):
+    CLI flag → SCITEX_CLOUD_GITEA_{TOKEN,USER,PASSWORD} env var →
+    config file. Missing credentials fail fast with exit code 2.
+
+    Prefer --token (or SCITEX_CLOUD_GITEA_TOKEN) for unattended runs.
+    Username+password still works when token unavailable.
 
     The Gitea URL is auto-detected from SCITEX_CLOUD_GITEA_URL_DEV env var
     or SECRET/.env.dev file. Override with --url.
@@ -107,13 +131,21 @@ def login(url, token, user, password, name):
 
     if url is None:
         url = get_gitea_url()
-        click.echo(f"Auto-detected Gitea URL: {url}")
+        click.echo(f"Auto-detected Gitea URL: {url}", err=True)
 
     if not token:
-        if not user:
-            user = click.prompt("Username")
-        if not password:
-            password = click.prompt("Password", hide_input=True)
+        user = user or get_config_value("gitea", "user")
+        password = password or get_config_value("gitea", "password")
+
+        if not user or not password:
+            click.echo(
+                "error: gitea credentials missing. Set "
+                "SCITEX_CLOUD_GITEA_TOKEN (preferred) or "
+                "SCITEX_CLOUD_GITEA_USER/SCITEX_CLOUD_GITEA_PASSWORD, "
+                "or pass --token / --user and --password",
+                err=True,
+            )
+            sys.exit(2)
 
         token = _create_or_get_gitea_token(url, user, password)
         if not token:
@@ -133,19 +165,24 @@ def login(url, token, user, password, name):
     help="Tea login name to remove (default: scitex-dev)",
 )
 @click.option(
-    "--url", default=None, help="Gitea URL (needed when --delete-token is set)"
+    "--url",
+    default=None,
+    envvar="SCITEX_CLOUD_GITEA_URL",
+    help="Gitea URL (env: SCITEX_CLOUD_GITEA_URL; needed when --delete-token is set)",
 )
 @click.option(
     "--user",
     "-u",
     default=None,
-    help="Gitea username (needed when --delete-token is set)",
+    envvar="SCITEX_CLOUD_GITEA_USER",
+    help="Gitea username (env: SCITEX_CLOUD_GITEA_USER; needed when --delete-token is set)",
 )
 @click.option(
     "--password",
     "-p",
     default=None,
-    help="Gitea password (needed when --delete-token is set)",
+    envvar="SCITEX_CLOUD_GITEA_PASSWORD",
+    help="Gitea password (env: SCITEX_CLOUD_GITEA_PASSWORD; needed when --delete-token is set)",
 )
 @click.option(
     "--delete-token",
@@ -156,7 +193,9 @@ def logout(name, url, user, password, delete_token):
     """Logout from SciTeX Cloud (Gitea).
 
     Removes the local tea login entry.  Use --delete-token to also revoke
-    the API token on the Gitea server.
+    the API token on the Gitea server. In that mode, password is required
+    non-interactively via --password or SCITEX_CLOUD_GITEA_PASSWORD
+    (fail-fast with exit code 2 if missing — no prompt, spec §2).
     """
     if delete_token:
         # Try to pull connection details from tea config if not given
@@ -172,10 +211,17 @@ def logout(name, url, user, password, delete_token):
             click.echo(
                 "Error: --url and --user are required with --delete-token", err=True
             )
-            sys.exit(1)
+            sys.exit(2)
 
         if not password:
-            password = click.prompt("Password to revoke remote token", hide_input=True)
+            password = get_config_value("gitea", "password")
+        if not password:
+            click.echo(
+                "error: --delete-token requires a password. Set "
+                "SCITEX_CLOUD_GITEA_PASSWORD or pass --password",
+                err=True,
+            )
+            sys.exit(2)
 
         token_name = "scitex-cloud-cli"
         api_url = f"{url.rstrip('/')}/api/v1/users/{user}/tokens"

--- a/src/scitex_cloud/_cli/_gitea_repo.py
+++ b/src/scitex_cloud/_cli/_gitea_repo.py
@@ -148,9 +148,21 @@ def search(query, login, limit):
 @click.command()
 @click.argument("repository")
 @click.option("--login", "-l", default="scitex-dev", help="Tea login to use")
-@click.confirmation_option(prompt="Are you sure you want to delete this repository?")
-def delete(repository, login):
-    """Delete a repository (DANGEROUS!)"""
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Confirm destructive action (required for non-interactive use)",
+)
+def delete(repository, login, yes):
+    """Delete a repository (DANGEROUS!). Requires --yes/-y (no prompt)."""
+    if not yes:
+        click.echo(
+            f"error: pass --yes/-y to confirm destructive action: "
+            f"delete repository '{repository}'",
+            err=True,
+        )
+        sys.exit(2)
     import requests
     import yaml
 

--- a/src/scitex_cloud/_cli/_workspace_auth.py
+++ b/src/scitex_cloud/_cli/_workspace_auth.py
@@ -4,11 +4,14 @@
 """Workspace CLI - JWT authentication helpers."""
 
 import json
+import os
 import sys
 from pathlib import Path
 
 import click
 import requests
+
+from .._config import get_config_value
 
 # Cached token location
 TOKEN_CACHE_PATH = Path.home() / ".config" / "scitex" / "token.json"
@@ -17,6 +20,22 @@ TOKEN_CACHE_PATH = Path.home() / ".config" / "scitex" / "token.json"
 def get_server_url(server):
     """Normalise server URL — strip trailing slash."""
     return server.rstrip("/")
+
+
+def _resolve_workspace_credentials():
+    """Resolve (username, password) from env → config, per spec §6b.
+
+    No interactive prompting: missing values are reported by the caller
+    with exit code 2. CLI flag values (when the caller has them) take
+    precedence over what this helper returns.
+    """
+    username = os.environ.get("SCITEX_CLOUD_WORKSPACE_USER") or get_config_value(
+        "workspace", "user"
+    )
+    password = os.environ.get("SCITEX_CLOUD_WORKSPACE_PASSWORD") or get_config_value(
+        "workspace", "password"
+    )
+    return username, password
 
 
 def load_cached_token(server_url):
@@ -38,19 +57,35 @@ def save_token(server_url, tokens):
     TOKEN_CACHE_PATH.write_text(json.dumps({**tokens, "server": server_url}))
 
 
-def get_jwt_token(server_url):
+def get_jwt_token(server_url, username=None, password=None):
     """Return a valid JWT access token.
 
-    Uses cached token when available; otherwise prompts for credentials
-    and calls /api/token/ to obtain a fresh pair.
+    Uses cached token when available; otherwise requires credentials
+    from (in precedence order): function arguments (CLI flags) →
+    ``SCITEX_CLOUD_WORKSPACE_USER`` / ``SCITEX_CLOUD_WORKSPACE_PASSWORD``
+    env vars → config file (spec §6b). Missing credentials cause a
+    fail-fast exit with code 2 — no interactive prompt, so this is
+    safe to run under CI/agent/cron.
     """
     cached = load_cached_token(server_url)
     if cached:
         return cached
 
-    click.echo(f"Authenticating with {server_url}")
-    username = click.prompt("Username")
-    password = click.prompt("Password", hide_input=True)
+    env_user, env_password = _resolve_workspace_credentials()
+    username = username or env_user
+    password = password or env_password
+
+    if not username or not password:
+        click.echo(
+            "error: workspace credentials missing. Set "
+            "SCITEX_CLOUD_WORKSPACE_USER/SCITEX_CLOUD_WORKSPACE_PASSWORD, "
+            "pass --user/--password, or configure "
+            "~/.scitex/scitex-cloud/config.yaml",
+            err=True,
+        )
+        sys.exit(2)
+
+    click.echo(f"Authenticating with {server_url}", err=True)
 
     try:
         resp = requests.post(

--- a/src/scitex_cloud/_cli/project.py
+++ b/src/scitex_cloud/_cli/project.py
@@ -3,11 +3,23 @@
 # File: src/scitex_cloud/_cli/project.py
 """Project CRUD CLI commands."""
 
+import sys
+
 import click
 from rich.console import Console
 from rich.table import Table
 
 console = Console()
+
+
+def _require_yes(yes, action):
+    """Fail fast with exit 2 if destructive action lacks --yes (spec §2)."""
+    if not yes:
+        click.echo(
+            f"error: pass --yes/-y to confirm destructive action: {action}",
+            err=True,
+        )
+        sys.exit(2)
 
 
 @click.group()
@@ -76,13 +88,15 @@ def project_create(name, description, template):
 
 @project.command("delete")
 @click.argument("slug")
-@click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Confirm destructive action (required for non-interactive use)",
+)
 def project_delete(slug, yes):
-    """Delete a project by slug."""
-    if not yes:
-        if not click.confirm(f"Delete project '{slug}'?"):
-            console.print("[yellow]Cancelled.[/yellow]")
-            return
+    """Delete a project by slug. Requires --yes/-y (no interactive prompt)."""
+    _require_yes(yes, f"delete project '{slug}'")
 
     from scitex_cloud.project import project_delete as _delete
 

--- a/src/scitex_cloud/_cli/setup.py
+++ b/src/scitex_cloud/_cli/setup.py
@@ -5,10 +5,12 @@
 """Setup commands for scitex-cloud CLI."""
 
 import shutil
+import sys
 from pathlib import Path
 
 import click
 
+from .._config import load_config
 from .._config._environments import ENVIRONMENTS, get_environment
 
 
@@ -17,33 +19,46 @@ from .._config._environments import ENVIRONMENTS, get_environment
     "--env",
     type=click.Choice(list(ENVIRONMENTS.keys())),
     default=None,
-    help="Target environment (dev, prod)",
+    envvar="SCITEX_CLOUD_ENV",
+    help="Target environment — dev, prod (env: SCITEX_CLOUD_ENV)",
 )
 @click.option("--force", is_flag=True, help="Overwrite existing configuration")
-@click.pass_context
-def setup(ctx, env, force):
+def setup(env, force):
     """Setup SciTeX Cloud environment.
 
     \b
-    Interactive setup wizard for configuring SciTeX Cloud deployment.
-    Creates necessary configuration files and validates prerequisites.
+    Non-interactive setup wizard. Environment resolution (spec §6b):
+    --env flag > SCITEX_CLOUD_ENV env var > config file `env` key.
+    Missing value fails fast with exit code 2 — no prompt.
 
     \b
     Examples:
-        scitex-cloud setup              # Interactive setup
         scitex-cloud setup --env dev    # Setup development environment
         scitex-cloud setup --env prod   # Setup production environment
+        SCITEX_CLOUD_ENV=dev scitex-cloud setup
     """
     click.echo(click.style("SciTeX Cloud Setup", fg="cyan", bold=True))
     click.echo()
 
-    # Select environment
     if env is None:
-        env = click.prompt(
-            "Select environment",
-            type=click.Choice(list(ENVIRONMENTS.keys())),
-            default="dev",
+        cfg = load_config()
+        raw = cfg.get("env")
+        if isinstance(raw, str):
+            env = raw
+
+    if env is None:
+        click.echo(
+            "error: set SCITEX_CLOUD_ENV or pass --env (choices: "
+            f"{', '.join(ENVIRONMENTS.keys())})",
+            err=True,
         )
+        sys.exit(2)
+    if env not in ENVIRONMENTS:
+        click.echo(
+            f"error: invalid --env '{env}' (choices: {', '.join(ENVIRONMENTS.keys())})",
+            err=True,
+        )
+        sys.exit(2)
 
     environment = get_environment(env)
     click.echo(f"Setting up: {click.style(environment.description, fg='green')}")

--- a/src/scitex_cloud/_config/__init__.py
+++ b/src/scitex_cloud/_config/__init__.py
@@ -1,3 +1,7 @@
 """Configuration for scitex-cloud (internal)."""
 
+from ._loader import get_config_value, load_config
+
+__all__ = ["get_config_value", "load_config"]
+
 # EOF

--- a/src/scitex_cloud/_config/_loader.py
+++ b/src/scitex_cloud/_config/_loader.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_cloud/_config/_loader.py
+"""YAML config loader for scitex-cloud CLI (spec §6b).
+
+Provides a minimal, non-failing loader used as a last-resort fallback
+for CLI values. Resolution precedence (highest first) per the SciTeX
+CLI convention:
+
+    1. CLI flag (e.g. ``--user``)
+    2. Env var (``SCITEX_CLOUD_*``)
+    3. Config file (this module)
+
+Config file search order (first existing wins):
+
+    1. explicit ``path`` argument to :func:`load_config`
+    2. ``$SCITEX_CLOUD_CONFIG``
+    3. ``./.scitex/scitex-cloud.yaml`` (project-local override)
+    4. ``~/.scitex/scitex-cloud/config.yaml`` (user default)
+
+If none of those resolve to a readable YAML file, an empty dict is
+returned — missing config is not an error.
+
+Schema (all keys optional)::
+
+    workspace:
+      url: https://scitex-cloud.com
+      user: <username>
+    gitea:
+      url: https://gitea.scitex-cloud.com
+      user: <username>
+      token: <api-token>
+    env: dev | prod | staging
+
+Note: passwords are technically allowed under ``workspace`` / ``gitea``
+for unattended use, but env vars are strongly preferred. This docstring
+deliberately does not prominently document the password key.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def _candidate_paths(explicit: Optional[str]) -> list[Path]:
+    """Return config file candidates in precedence order."""
+    paths: list[Path] = []
+    if explicit:
+        paths.append(Path(explicit).expanduser())
+    env_path = os.environ.get("SCITEX_CLOUD_CONFIG")
+    if env_path:
+        paths.append(Path(env_path).expanduser())
+    paths.append(Path.cwd() / ".scitex" / "scitex-cloud.yaml")
+    paths.append(Path.home() / ".scitex" / "scitex-cloud" / "config.yaml")
+    return paths
+
+
+def load_config(path: Optional[str] = None) -> Dict[str, Any]:
+    """Load YAML config, returning ``{}`` if nothing is found/readable.
+
+    Never raises on IO or parse errors — CLI commands should degrade
+    gracefully to env vars / flags. Bad YAML just looks like "no
+    config".
+
+    Parameters
+    ----------
+    path : str, optional
+        Explicit config path. Takes precedence over env/default paths.
+
+    Returns
+    -------
+    dict
+        Parsed YAML mapping, or ``{}`` if no config resolvable.
+    """
+    try:
+        import yaml  # noqa: WPS433 (local import — optional dep)
+    except ImportError:
+        return {}
+
+    for candidate in _candidate_paths(path):
+        if not candidate.is_file():
+            continue
+        try:
+            with candidate.open("r", encoding="utf-8") as fh:
+                data = yaml.safe_load(fh) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+        if isinstance(data, dict):
+            return data
+        # Non-mapping top-level (list, scalar) is not a valid config.
+        return {}
+    return {}
+
+
+def get_config_value(
+    section: str,
+    key: str,
+    *,
+    path: Optional[str] = None,
+    default: Any = None,
+) -> Any:
+    """Fetch ``config[section][key]`` with graceful fallbacks."""
+    cfg = load_config(path)
+    section_data = cfg.get(section)
+    if isinstance(section_data, dict):
+        return section_data.get(key, default)
+    return default
+
+
+# EOF

--- a/tests/scitex_cloud/test_no_interactive_prompts.py
+++ b/tests/scitex_cloud/test_no_interactive_prompts.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_cloud/test_no_interactive_prompts.py
+
+"""CLI spec §2 compliance — no interactive prompts.
+
+Every refactored command must:
+- succeed (or fail for another reason) when value comes from flag / env;
+- exit with code 2 and a stderr guidance message when the value is
+  missing everywhere, instead of blocking on stdin.
+
+These tests invoke CLI commands under ``CliRunner`` with
+``input=""`` so that any residual ``click.prompt`` / ``click.confirm``
+would block and surface as a test failure.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_cloud._cli._gitea_auth import login as gitea_login
+from scitex_cloud._cli._gitea_auth import logout as gitea_logout
+from scitex_cloud._cli._gitea_repo import delete as repo_delete
+from scitex_cloud._cli.project import project_delete
+from scitex_cloud._cli.setup import setup as setup_cmd
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_env(monkeypatch, tmp_path):
+    """Strip SCITEX_CLOUD_* env and point HOME to a clean tmp dir.
+
+    Prevents the developer's real config file from affecting tests.
+    """
+    for name in [
+        "SCITEX_CLOUD_WORKSPACE_USER",
+        "SCITEX_CLOUD_WORKSPACE_PASSWORD",
+        "SCITEX_CLOUD_WORKSPACE_URL",
+        "SCITEX_CLOUD_GITEA_USER",
+        "SCITEX_CLOUD_GITEA_PASSWORD",
+        "SCITEX_CLOUD_GITEA_TOKEN",
+        "SCITEX_CLOUD_GITEA_URL",
+        "SCITEX_CLOUD_ENV",
+        "SCITEX_CLOUD_CONFIG",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestSetupNoPrompt:
+    def test_missing_env_fails_fast(self, runner, isolated_env):
+        result = runner.invoke(setup_cmd, [], input="")
+        assert result.exit_code == 2, result.output
+        assert "SCITEX_CLOUD_ENV" in result.output
+
+    def test_env_from_envvar(self, runner, isolated_env, monkeypatch):
+        monkeypatch.setenv("SCITEX_CLOUD_ENV", "nonexistent-env")
+        result = runner.invoke(setup_cmd, [], input="")
+        # Either invalid-choice exit 2 or ENVIRONMENTS-specific path;
+        # the key property is: no prompt, no hang.
+        assert result.exit_code in (1, 2), result.output
+        assert "Username" not in result.output
+        assert "Password" not in result.output
+
+
+class TestGiteaLoginNoPrompt:
+    def test_missing_all_credentials_fails_fast(self, runner, isolated_env):
+        with patch(
+            "scitex_cloud._cli._gitea_utils.get_gitea_url", return_value="https://x"
+        ):
+            result = runner.invoke(gitea_login, [], input="")
+        assert result.exit_code == 2, result.output
+        assert "gitea credentials missing" in result.output.lower()
+
+    def test_token_from_envvar_skips_username_flow(
+        self, runner, isolated_env, monkeypatch
+    ):
+        monkeypatch.setenv("SCITEX_CLOUD_GITEA_TOKEN", "envtoken")
+        with (
+            patch(
+                "scitex_cloud._cli._gitea_utils.get_gitea_url", return_value="https://x"
+            ),
+            patch("scitex_cloud._cli._gitea_auth.run_tea") as run_tea,
+        ):
+            result = runner.invoke(gitea_login, [], input="")
+        assert result.exit_code == 0, result.output
+        run_tea.assert_called_once()
+        args = run_tea.call_args.args
+        assert "--token" in args
+        assert "envtoken" in args
+
+
+class TestGiteaLogoutNoPrompt:
+    def test_delete_token_without_password_fails_fast(
+        self, runner, isolated_env, monkeypatch
+    ):
+        monkeypatch.setenv("SCITEX_CLOUD_GITEA_URL", "https://x")
+        monkeypatch.setenv("SCITEX_CLOUD_GITEA_USER", "u")
+        result = runner.invoke(
+            gitea_logout,
+            ["--delete-token", "--url", "https://x", "--user", "u"],
+            input="",
+        )
+        assert result.exit_code == 2, result.output
+        assert "password" in result.output.lower()
+
+
+class TestProjectDeleteNoPrompt:
+    def test_delete_without_yes_fails_fast(self, runner, isolated_env):
+        result = runner.invoke(project_delete, ["my-project"], input="")
+        assert result.exit_code == 2, result.output
+        assert "--yes" in result.output
+
+    def test_delete_with_yes_calls_backend(self, runner, isolated_env, monkeypatch):
+        with patch("scitex_cloud.project.project_delete") as backend:
+            result = runner.invoke(project_delete, ["my-project", "--yes"], input="")
+        assert result.exit_code == 0, result.output
+        backend.assert_called_once_with("my-project")
+
+
+class TestRepoDeleteNoPrompt:
+    def test_delete_without_yes_fails_fast(self, runner, isolated_env):
+        result = runner.invoke(repo_delete, ["owner/repo"], input="")
+        assert result.exit_code == 2, result.output
+        assert "--yes" in result.output
+
+
+# EOF


### PR DESCRIPTION
Cherry-pick of `14464a7d fix(cli): remove interactive prompts per spec §2 + §6` from the post-release branch so `develop` carries the CLI fix ahead of the next minor release.

Skipped the `chore(version): bump to 0.17.0-alpha.post1` commit — develop has its own versioning in pyproject.toml.

- Tests included: `tests/scitex_cloud/test_no_interactive_prompts.py`
- New module: `src/scitex_cloud/_config/_loader.py`