### PR TITLE
fix(prod): complete bot-block deploy + expose user_type in oauth userinfo

### DIFF
--- a/apps/infra/auth_app/oauth_views.py
+++ b/apps/infra/auth_app/oauth_views.py
@@ -8,6 +8,17 @@ from django.http import JsonResponse
 from oauth2_provider.decorators import protected_resource
 
 
+def _get_user_type(user):
+    """Derive user type from username/email patterns."""
+    if user.username.startswith("visitor-"):
+        return "visitor"
+    if user.email.endswith("@visitor.scitex.local"):
+        return "visitor"
+    if not user.email or user.email.endswith("@readonly.scitex.local"):
+        return "readonly"
+    return "member"
+
+
 @protected_resource(scopes=["profile", "email"])
 def userinfo(request):
     """GET /oauth/userinfo/ — return user profile for OAuth2 token."""
@@ -19,5 +30,6 @@ def userinfo(request):
             "email": user.email,
             "name": user.get_full_name() or user.username,
             "email_verified": True,
+            "user_type": _get_user_type(user),
         }
     )

--- a/deployment/docker/docker_prod/docker-compose.yml
+++ b/deployment/docker/docker_prod/docker-compose.yml
@@ -348,6 +348,7 @@ services:
     image: nginx:alpine
     volumes:
       - ../common/nginx/nginx_prod.conf:/etc/nginx/nginx.conf:ro
+      - ../common/nginx/bots.conf:/etc/nginx/bots.conf:ro
       - ../common/nginx/error-pages:/etc/nginx/error-pages:ro
       - static_volume:/app/staticfiles:ro
       - media_volume:/app/media:ro


### PR DESCRIPTION
Two small prod-readiness fixes landed from nas.

1. **nginx bots.conf mount** — mount `common/nginx/bots.conf` into the prod nginx container so the bot-block feature (`bdc38da9` / #149) actually activates in production. Without this the include directive points at a file that isn't inside the container.

2. **user_type in /oauth/userinfo/** — external apps (orochi et al.) need to know whether an authenticated user is `visitor` / `readonly` / `member` to gate features. Derived from username + email patterns; no DB schema change.