### PR TITLE
fix(deps): declare umbrella 'scitex' as django-extra runtime dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,13 @@ django = [
     "weasyprint>=60.0",
     "pydantic<2.12",
     "scitex-ui>=0.2.0",
+    # The umbrella `scitex` package is imported at Django-settings load
+    # time (`config/routing.py` and `config/settings/settings_*.py` do
+    # `import scitex as stx`), so it's a hard runtime requirement for
+    # the Django stack — not just a sibling dev tool. Without this,
+    # `pytest tests/` halts in pytest-django with
+    # `ImportError: No module named 'scitex'` before any test runs.
+    "scitex>=2.29",
 ]
 gui = [
     "dearpygui>=1.11",


### PR DESCRIPTION
## Summary

Pre-existing CI break: pytest-matrix has been red on develop since May 19
because the Django settings (`config/routing.py`, `config/settings/settings_*.py`)
import the umbrella `scitex` package, but it was never declared as a
dependency. pytest-django loads project settings before collecting
tests, so the missing import halts every CI run with
\`ImportError: No module named 'scitex'\`.

This adds \`scitex>=2.29\` to the \`[django]\` extra (and therefore
\`[all]\`), which is what CI installs (\`pip install -e .[all,dev]\`).

## Why this blocks v0.18.0

The release pipeline (\`.github/workflows/pypi-publish-and-github-release-on-tag.yml\`)
gates publish on the test job. Without this fix, the v0.18.0 tag push
would halt at the test step, no PyPI publish, no GitHub release. Same
gate would have blocked v0.17.6 too, but that tag was pushed before
the import was added.

## Test plan

- [ ] CI \`tests\` workflow now green (pytest-django can load settings)
- [ ] \`pip install -e .[all,dev]\` resolves scitex from PyPI
- [ ] After this lands, \`git tag v0.18.0 && git push origin v0.18.0\`
  triggers the full release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)