### PR TITLE
fix(deps): pin scitex>=2.28.13,<2.29 to dodge broken 2.29 exact-pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,13 @@ all = [
     # --- SciTeX umbrella (Django-settings imports `import scitex as stx`
     # for `@stx.session` / `stx.session.INJECTED` / `@stx.module`, so
     # this is a hard runtime requirement, not an optional sibling.) ---
-    "scitex>=2.29",
+    # TEMPORARY upper-bound: scitex 2.29.0 / 2.29.1 ship a broken
+    # exact-pin on `scitex-config==0.3.3` (a version never published to
+    # PyPI), so any install touching scitex>=2.29 hits
+    # `ResolutionImpossible`. Tracking upstream fix in
+    # https://github.com/ywatanabe1989/scitex-python/issues/282 —
+    # relax to `scitex>=2.28.13` once 2.29.2 lands with sane `>=` pins.
+    "scitex>=2.28.13,<2.29",
     "scitex-ui>=0.2.0",
     # --- GUI (dearpygui-based modules) ---
     "dearpygui>=1.11",


### PR DESCRIPTION
## Summary

Temporary workaround for the v0.18.0 release pipeline halt.

\`scitex 2.29.0\` / \`scitex 2.29.1\` ship an exact pin on
\`scitex-config==0.3.3\`, a version that was never published to PyPI
(`0.3.0` → `0.3.1` → `0.3.2` → `0.3.4` exist; `0.3.3` is missing).
Every pip-install graph that pulls \`scitex>=2.29\` hits
\`ResolutionImpossible\` with "no matching distributions available for
your environment: scitex-config".

`scitex 2.28.13` (latest 2.28.x) uses sane \`>=\` pins. Cap at \`<2.29\`
so pip resolves to it.

## Cross-ref

- Upstream issue: ywatanabe1989/scitex-python#282
- Blocked release pipeline: https://github.com/ywatanabe1989/scitex-hub/actions/runs/26331569020
- v0.18.0 rename context: ADR-0001

## Once \`scitex 2.29.2\` lands

The lead is preparing \`scitex 2.29.2\` to restore \`>=\` pins. After that
publishes, relax the cap here back to plain \`scitex>=2.28.13\` (or to
the new \`>=2.29.2\` floor if 2.29.2 brings features we want).

🤖 Generated with [Claude Code](https://claude.com/claude-code)