### PR TITLE
ci(tests): set SCITEX_HUB_DJANGO_SECRET_KEY for pytest jobs

### DIFF
--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -58,6 +58,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
       - name: Run pytest
+        # Django settings hard-fail (ValueError, per "no silent fallback")
+        # if SCITEX_HUB_DJANGO_SECRET_KEY is unset. CI doesn't need a real
+        # secret, so we set an obviously-fake one for the test process only.
+        env:
+          SCITEX_HUB_DJANGO_SECRET_KEY: ci-test-secret-do-not-use-in-prod  # pragma: allowlist secret
         run: |
           if [ -d tests ]; then
             pytest tests/ -x

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -31,6 +31,11 @@ jobs:
           # plain editable so a packaging hiccup doesn't strand CI.
           pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
       - name: Run tests
+        # Django settings hard-fail (ValueError, per "no silent fallback")
+        # if SCITEX_HUB_DJANGO_SECRET_KEY is unset. CI doesn't need a real
+        # secret, so we set an obviously-fake one for the test process only.
+        env:
+          SCITEX_HUB_DJANGO_SECRET_KEY: ci-test-secret-do-not-use-in-prod  # pragma: allowlist secret
         run: |
           pytest tests/ --cov=src/scitex_hub --cov-report=xml --cov-report=term
       - name: Upload coverage to Codecov


### PR DESCRIPTION
## Summary

After PR #172 unblocked install resolution (scitex 2.29 pin workaround),
the release pipeline's next halt was Django's \`settings_shared.py\`
raising \`ValueError("SCITEX_HUB_DJANGO_SECRET_KEY must be set in
environment")\` — the hard-fail is intentional (CLAUDE.md "no silent
fallback"), CI just needs an obviously-fake key for the test process.

\`tests.yml\` already does this; propagating the same env to the two
remaining pytest invocations:
- \`pypi-publish-and-github-release-on-tag.yml\` (release pipeline test gate)
- \`pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml\` (push/PR matrix)

The literal value \`ci-test-secret-do-not-use-in-prod\` carries its own
warning to anyone tempted to copy-paste it out of a CI log.

## Why this is the last hop for v0.18.0

Release pipeline order: test → build → publish → release → sync-main.
After PR #172, install resolved; this commit makes the pytest invocation
itself runnable. The next pipeline run on tag v0.18.0 (re-tagged after
this lands) should clear the test gate and proceed to PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)