### PR TITLE
ci(tests): also set SCITEX_HUB_GITEA_SSH_PORT_DEV for pytest jobs

### DIFF
--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -63,6 +63,10 @@ jobs:
         # secret, so we set an obviously-fake one for the test process only.
         env:
           SCITEX_HUB_DJANGO_SECRET_KEY: ci-test-secret-do-not-use-in-prod  # pragma: allowlist secret
+          # settings_dev.py L233: require_env("SCITEX_HUB_GITEA_SSH_PORT_DEV")
+          # (already set in tests.yml; mirror it here so the release-tag
+          # pipeline matches the push/PR matrix).
+          SCITEX_HUB_GITEA_SSH_PORT_DEV: "2222"
         run: |
           if [ -d tests ]; then
             pytest tests/ -x

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -36,6 +36,8 @@ jobs:
         # secret, so we set an obviously-fake one for the test process only.
         env:
           SCITEX_HUB_DJANGO_SECRET_KEY: ci-test-secret-do-not-use-in-prod  # pragma: allowlist secret
+          # settings_dev.py L233: require_env("SCITEX_HUB_GITEA_SSH_PORT_DEV")
+          SCITEX_HUB_GITEA_SSH_PORT_DEV: "2222"
         run: |
           pytest tests/ --cov=src/scitex_hub --cov-report=xml --cov-report=term
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Follow-up to #173. After SECRET_KEY was satisfied, settings_dev.py L233 hit the next `require_env`: `SCITEX_HUB_GITEA_SSH_PORT_DEV`. tests.yml already sets it to '2222' for the terminal-tests job; mirror that in the release pipeline + push/PR matrix.

Pre-existing `require_env` call sites in `config/settings`:
- settings_shared.py:114 — `SCITEX_HUB_DJANGO_SECRET_KEY` (fixed by #173)
- settings_dev.py:233 — `SCITEX_HUB_GITEA_SSH_PORT_DEV` (this PR)
- settings_prod.py:166 — `SCITEX_HUB_GITEA_SSH_PORT` (prod-only, not loaded by tests)

So this should be the last load-time hard-fail in the CI test chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)