### PR TITLE
ci(tests): use SQLite for pytest jobs (SCITEX_HUB_USE_SQLITE_DEV=1)

### DIFF
--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -67,6 +67,12 @@ jobs:
           # (already set in tests.yml; mirror it here so the release-tag
           # pipeline matches the push/PR matrix).
           SCITEX_HUB_GITEA_SSH_PORT_DEV: "2222"
+          # settings_dev.py L189-194: when SCITEX_HUB_USE_SQLITE_DEV is set,
+          # Django uses a local sqlite file instead of the postgres service
+          # we don't run in this CI job (no `services: postgres:14` block).
+          # Tests that need postgres behaviour will skip/xfail naturally;
+          # the goal of this gate is to confirm the wheel + import chain.
+          SCITEX_HUB_USE_SQLITE_DEV: "1"
         run: |
           if [ -d tests ]; then
             pytest tests/ -x

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -38,6 +38,11 @@ jobs:
           SCITEX_HUB_DJANGO_SECRET_KEY: ci-test-secret-do-not-use-in-prod  # pragma: allowlist secret
           # settings_dev.py L233: require_env("SCITEX_HUB_GITEA_SSH_PORT_DEV")
           SCITEX_HUB_GITEA_SSH_PORT_DEV: "2222"
+          # settings_dev.py L189-194: SCITEX_HUB_USE_SQLITE_DEV switches
+          # Django from postgres to a local sqlite file. No postgres
+          # service runs in this matrix; sqlite keeps the test gate
+          # focused on the wheel + import + unit-level behaviour.
+          SCITEX_HUB_USE_SQLITE_DEV: "1"
         run: |
           pytest tests/ --cov=src/scitex_hub --cov-report=xml --cov-report=term
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Test gate now clears settings load but crashes at first ORM call with `connection to server at localhost, port 5432 failed: Connection refused`. No postgres service in release.yml / pytest-matrix.yml.

settings_dev.py L189-194 already provides the explicit `SCITEX_HUB_USE_SQLITE_DEV=1` switch. Set it so the test gate confirms wheel + import + unit tests, which is its real role.

Postgres integration coverage stays on tests.yml's terminal-tests job (which has its own service setup) and on deployed environments. Standing up a postgres service in the matrix is a follow-up, not a blocker for v0.18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)