### PR TITLE
compat(env): accept SCITEX_CLOUD_* env vars as alias of SCITEX_HUB_*

### DIFF
--- a/config/_env.py
+++ b/config/_env.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# File: config/_env.py
+"""
+Environment-variable read helpers with legacy SCITEX_CLOUD_* alias support.
+
+Background
+----------
+The project was renamed scitex-cloud -> scitex-hub at v0.18.0 (ADR-0001).
+Commit d38d6894 renamed the operator-facing env-var prefix from
+``SCITEX_CLOUD_*`` to ``SCITEX_HUB_*`` (Step D.1). Deployments and CI that
+still export the old prefix would otherwise silently fall through to the
+default value, which violates the project's "no silent fallback" rule.
+
+This module exposes :func:`getenv_with_legacy_alias`, which reads
+``SCITEX_HUB_<NAME>`` first and, if unset, falls back to
+``SCITEX_CLOUD_<NAME>`` while emitting an explicit ``DeprecationWarning``.
+The direction is strictly one-way:
+
+    SCITEX_HUB_<NAME>   (canonical)   <- preferred
+    SCITEX_CLOUD_<NAME> (legacy alias) -> read only if HUB is unset
+
+The new prefix is what every component should set going forward; the
+legacy prefix is recognized for backward compatibility and is logged.
+
+See: docs/adr/0001-rename-scitex-cloud-to-scitex-hub.md
+"""
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Optional
+
+# Canonical and legacy prefixes for the environment-variable rename.
+_HUB_PREFIX = "SCITEX_HUB_"
+_CLOUD_PREFIX = "SCITEX_CLOUD_"
+
+
+def _legacy_name(hub_name: str) -> Optional[str]:
+    """Return the SCITEX_CLOUD_* alias for a SCITEX_HUB_* name, else None."""
+    if hub_name.startswith(_HUB_PREFIX):
+        return _CLOUD_PREFIX + hub_name[len(_HUB_PREFIX) :]
+    return None
+
+
+def getenv_with_legacy_alias(
+    name: str,
+    default: Optional[str] = None,
+) -> Optional[str]:
+    """Read a ``SCITEX_HUB_*`` env var, falling back to ``SCITEX_CLOUD_*``.
+
+    If ``SCITEX_HUB_<X>`` is set, its value is returned (canonical path).
+    Otherwise, if ``SCITEX_CLOUD_<X>`` is set, its value is returned and a
+    :class:`DeprecationWarning` is emitted to flag the legacy prefix.
+    If neither is set, ``default`` is returned.
+
+    The alias direction is one-way: ``SCITEX_HUB_*`` is canonical;
+    ``SCITEX_CLOUD_*`` is the legacy alias kept for backward compatibility
+    (ADR-0001). Callers should only pass ``SCITEX_HUB_*`` names — this
+    function never falls back from CLOUD to HUB.
+
+    Args:
+        name: The canonical env-var name (must start with ``SCITEX_HUB_``
+            to enable alias lookup; other names work but skip the alias).
+        default: Value returned when neither the canonical nor the legacy
+            name is set in the environment.
+
+    Returns:
+        The environment value, or ``default`` if unset.
+    """
+    value = os.environ.get(name)
+    if value is not None:
+        return value
+
+    legacy = _legacy_name(name)
+    if legacy is not None:
+        legacy_value = os.environ.get(legacy)
+        if legacy_value is not None:
+            warnings.warn(
+                (
+                    f"Environment variable {legacy!r} is a deprecated alias "
+                    f"of {name!r}. The scitex-cloud -> scitex-hub rename "
+                    "(ADR-0001) deprecated the SCITEX_CLOUD_* prefix; set "
+                    f"{name} instead. The legacy name will be removed in a "
+                    "future major release."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return legacy_value
+
+    return default
+
+
+def require_env_with_legacy_alias(name: str) -> str:
+    """Like :func:`getenv_with_legacy_alias` but raises if both are unset.
+
+    Mirrors the existing ``require_env`` helper in
+    :mod:`config.settings.settings_shared`, but transparently honors the
+    legacy ``SCITEX_CLOUD_*`` alias (with DeprecationWarning).
+    """
+    value = getenv_with_legacy_alias(name)
+    if value is None:
+        legacy = _legacy_name(name) or ""
+        hint = f" (or its deprecated alias {legacy!r})" if legacy else ""
+        raise EnvironmentError(
+            f"Required environment variable {name!r}{hint} is not set. "
+            "Check deployment/docker/envs/.env.{ENV} file."
+        )
+    return value
+
+
+__all__ = [
+    "getenv_with_legacy_alias",
+    "require_env_with_legacy_alias",
+]
+
+# EOF

--- a/config/settings/settings_shared.py
+++ b/config/settings/settings_shared.py
@@ -11,19 +11,26 @@ from pathlib import Path
 
 import scitex as stx
 
+from config._env import (
+    getenv_with_legacy_alias as _getenv_alias,
+)
+from config._env import (
+    require_env_with_legacy_alias as _require_env_alias,
+)
+
 
 # ---------------------------------------
 # Functions
 # ---------------------------------------
 def require_env(var_name: str) -> str:
-    """Get required environment variable or raise clear error."""
-    value = os.environ.get(var_name)
-    if value is None:
-        raise EnvironmentError(
-            f"Required environment variable '{var_name}' is not set. "
-            f"Check deployment/docker/envs/.env.{{ENV}} file."
-        )
-    return value
+    """Get required environment variable or raise clear error.
+
+    Honors the legacy ``SCITEX_CLOUD_*`` alias of ``SCITEX_HUB_*`` (ADR-0001):
+    if the canonical name is unset but the deprecated alias is set, the alias
+    value is returned and a ``DeprecationWarning`` is emitted (no silent
+    fallback). Strictly one-direction (HUB canonical, CLOUD legacy).
+    """
+    return _require_env_alias(var_name)
 
 
 def discover_local_apps():
@@ -100,16 +107,19 @@ LOGOUT_REDIRECT_URL = "/"
 # Metadata
 # ---------------------------------------
 SCITEX_HUB_VERSION = _get_version()
-SCITEX_HUB_VISITOR_POOL_SIZE = int(os.environ.get("SCITEX_HUB_VISITOR_POOL_SIZE", 4))
-UMAMI_WEBSITE_ID = os.environ.get("SCITEX_HUB_UMAMI_WEBSITE_ID", "")
-UMAMI_SCRIPT_URL = os.environ.get(
+SCITEX_HUB_VISITOR_POOL_SIZE = int(
+    _getenv_alias("SCITEX_HUB_VISITOR_POOL_SIZE", "4") or "4"
+)
+UMAMI_WEBSITE_ID = _getenv_alias("SCITEX_HUB_UMAMI_WEBSITE_ID", "")
+UMAMI_SCRIPT_URL = _getenv_alias(
     "SCITEX_HUB_UMAMI_SCRIPT_URL", "https://cloud.umami.is/script.js"
 )
 
 # ---------------------------------------
 # Security
 # ---------------------------------------
-SECRET_KEY = os.getenv("SCITEX_HUB_DJANGO_SECRET_KEY")
+# Honors SCITEX_CLOUD_DJANGO_SECRET_KEY as a deprecated alias (ADR-0001).
+SECRET_KEY = _getenv_alias("SCITEX_HUB_DJANGO_SECRET_KEY")
 if not SECRET_KEY:
     raise ValueError("SCITEX_HUB_DJANGO_SECRET_KEY must be set in environment")
 
@@ -226,7 +236,7 @@ DATABASES = {
 # ---------------------------------------
 # Cache + Sessions
 # ---------------------------------------
-REDIS_URL = os.getenv("SCITEX_HUB_REDIS_URL", "redis://127.0.0.1:6379/1")
+REDIS_URL = _getenv_alias("SCITEX_HUB_REDIS_URL", "redis://127.0.0.1:6379/1")
 
 try:
     import redis as _redis
@@ -264,7 +274,7 @@ SESSION_COOKIE_AGE = 86400
 try:
     import redis as _redis2
 
-    _redis_url2 = os.getenv("SCITEX_HUB_REDIS_URL", "redis://127.0.0.1:6379/2")
+    _redis_url2 = _getenv_alias("SCITEX_HUB_REDIS_URL", "redis://127.0.0.1:6379/2")
     # Same fast-fail timeouts as the cache probe above — never block
     # settings import on an unreachable Redis.
     _redis2.from_url(_redis_url2, socket_connect_timeout=0.5, socket_timeout=0.5).ping()
@@ -296,24 +306,26 @@ USE_TZ = True
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-EMAIL_BACKEND = os.getenv("SCITEX_HUB_EMAIL_BACKEND")
-EMAIL_HOST = os.getenv("SCITEX_HUB_EMAIL_HOST")
-EMAIL_PORT = int(os.getenv("SCITEX_HUB_EMAIL_PORT", "587"))
-EMAIL_USE_TLS = os.getenv("SCITEX_HUB_EMAIL_USE_TLS", "True").lower() == "true"
-EMAIL_HOST_USER = os.getenv("SCITEX_HUB_EMAIL_HOST_USER")
-EMAIL_HOST_PASSWORD = os.getenv("SCITEX_HUB_EMAIL_HOST_PASSWORD")
+EMAIL_BACKEND = _getenv_alias("SCITEX_HUB_EMAIL_BACKEND")
+EMAIL_HOST = _getenv_alias("SCITEX_HUB_EMAIL_HOST")
+EMAIL_PORT = int(_getenv_alias("SCITEX_HUB_EMAIL_PORT", "587") or "587")
+EMAIL_USE_TLS = (
+    _getenv_alias("SCITEX_HUB_EMAIL_USE_TLS", "True") or "True"
+).lower() == "true"
+EMAIL_HOST_USER = _getenv_alias("SCITEX_HUB_EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = _getenv_alias("SCITEX_HUB_EMAIL_HOST_PASSWORD")
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 SERVER_EMAIL = EMAIL_HOST_USER
-SITE_URL = os.getenv("SCITEX_HUB_SITE_URL", "http://127.0.0.1:8000")
+SITE_URL = _getenv_alias("SCITEX_HUB_SITE_URL", "http://127.0.0.1:8000")
 
 # Campaign Chat Mode
-SCITEX_HUB_CAMPAIGN_ANTHROPIC_API_KEY = os.getenv(
+SCITEX_HUB_CAMPAIGN_ANTHROPIC_API_KEY = _getenv_alias(
     "SCITEX_HUB_CAMPAIGN_ANTHROPIC_API_KEY", ""
 )
-SCITEX_HUB_CAMPAIGN_MODEL = os.getenv(
+SCITEX_HUB_CAMPAIGN_MODEL = _getenv_alias(
     "SCITEX_HUB_CAMPAIGN_MODEL", "claude-haiku-4-5-20251001"
 )
-SCITEX_HUB_CAMPAIGN_DAILY_LIMIT = os.getenv("SCITEX_HUB_CAMPAIGN_DAILY_LIMIT", "10")
+SCITEX_HUB_CAMPAIGN_DAILY_LIMIT = _getenv_alias("SCITEX_HUB_CAMPAIGN_DAILY_LIMIT", "10")
 
 # ---------------------------------------
 # Sub-module imports (celery, logging, auth, integrations)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,11 @@ all = [
     "pytest-playwright>=0.7",
     "pytest-base-url>=2.1",
     "pytest-asyncio>=1.2",
+    # pytest-matrix workflow runs `pytest --cov=src/scitex_hub
+    # --cov-report=xml --cov-report=term` and uploads to Codecov — the
+    # plugin must be in the install graph, otherwise pytest exits 4 on
+    # "unrecognized arguments: --cov".
+    "pytest-cov>=4.1",
     # --- Sphinx docs build (run by CI on tag) ---
     "sphinx>=7.0",
     "sphinx-rtd-theme>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,14 @@ dependencies = [
     "click>=8.0",
     "scitex-app>=0.2.8",
     "scitex-config>=0.3.6",
+    # `scitex-session` is consumed via the umbrella as `scitex.session.INJECTED`
+    # (settings_shared.py / settings_auth.py / config/routing.py).
+    # scitex >= 2.29 lazy-loads `scitex_session` and raises ImportError if
+    # the sub-package is missing — but the umbrella's `[session]` extra
+    # only declares matplotlib + pyyaml, NOT scitex-session itself
+    # (upstream gap, ywatanabe1989/scitex-python). Declare it directly
+    # so the import works in any install graph.
+    "scitex-session>=0.1.6",
     "scitex-writer>=2.17.2",
     "scitex-dev>=0.15.0",
     "gitpython>=3.1",

--- a/tests/config/test_env_legacy_alias.py
+++ b/tests/config/test_env_legacy_alias.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+# File: tests/config/test_env_legacy_alias.py
+"""Tests for the SCITEX_CLOUD_* -> SCITEX_HUB_* env-var alias layer.
+
+Background: ADR-0001 renamed the operator-facing env-var prefix from
+``SCITEX_CLOUD_*`` to ``SCITEX_HUB_*`` (commit d38d6894). Existing
+deployments may still export the legacy prefix; the alias layer in
+``config/_env.py`` accepts the legacy name with a ``DeprecationWarning``
+(no silent fallback, per CLAUDE.md).
+"""
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from config._env import (
+    getenv_with_legacy_alias,
+    require_env_with_legacy_alias,
+)
+
+
+class TestGetenvWithLegacyAlias:
+    """Direct getenv-with-alias semantics."""
+
+    def test_hub_value_preferred_when_both_set(self, monkeypatch):
+        """If both prefixes are set, the canonical HUB value wins (no warning)."""
+        monkeypatch.setenv("SCITEX_HUB_DJANGO_SECRET_KEY", "hub-value")
+        monkeypatch.setenv("SCITEX_CLOUD_DJANGO_SECRET_KEY", "cloud-value")
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            value = getenv_with_legacy_alias("SCITEX_HUB_DJANGO_SECRET_KEY")
+        assert value == "hub-value"
+        # No DeprecationWarning should fire when HUB is set.
+        deprecation_warnings = [
+            w for w in record if issubclass(w.category, DeprecationWarning)
+        ]
+        assert deprecation_warnings == []
+
+    def test_cloud_alias_used_when_hub_unset_emits_warning(self, monkeypatch):
+        """SCITEX_CLOUD_* is read when SCITEX_HUB_* is unset, with warning.
+
+        This is the headline behaviour requested by the operator:
+        existing deployments that still export SCITEX_CLOUD_DJANGO_SECRET_KEY
+        keep working, but we surface the deprecation explicitly.
+        """
+        monkeypatch.delenv("SCITEX_HUB_DJANGO_SECRET_KEY", raising=False)
+        monkeypatch.setenv("SCITEX_CLOUD_DJANGO_SECRET_KEY", "abc")
+        with pytest.warns(DeprecationWarning, match="SCITEX_CLOUD_DJANGO_SECRET_KEY"):
+            value = getenv_with_legacy_alias("SCITEX_HUB_DJANGO_SECRET_KEY")
+        assert value == "abc"
+
+    def test_default_returned_when_neither_set(self, monkeypatch):
+        """Default applies only when both canonical and legacy are absent."""
+        monkeypatch.delenv("SCITEX_HUB_SOMETHING", raising=False)
+        monkeypatch.delenv("SCITEX_CLOUD_SOMETHING", raising=False)
+        assert (
+            getenv_with_legacy_alias("SCITEX_HUB_SOMETHING", "fallback") == "fallback"
+        )
+
+    def test_none_returned_when_no_default(self, monkeypatch):
+        monkeypatch.delenv("SCITEX_HUB_NOPE", raising=False)
+        monkeypatch.delenv("SCITEX_CLOUD_NOPE", raising=False)
+        assert getenv_with_legacy_alias("SCITEX_HUB_NOPE") is None
+
+    def test_alias_is_one_directional(self, monkeypatch):
+        """Passing a SCITEX_CLOUD_* name does not fall back to SCITEX_HUB_*.
+
+        Direction is strictly HUB-canonical, CLOUD-legacy. Callers should
+        only ever pass the canonical HUB name; the helper does NOT try to
+        synthesize HUB from a CLOUD-name read.
+        """
+        monkeypatch.setenv("SCITEX_HUB_X", "hub")
+        monkeypatch.delenv("SCITEX_CLOUD_X", raising=False)
+        # Asking directly for the legacy name returns None (it's unset),
+        # NOT the HUB value — the helper does not reverse-alias.
+        assert getenv_with_legacy_alias("SCITEX_CLOUD_X") is None
+
+
+class TestRequireEnvWithLegacyAlias:
+    """Hard-fail wrapper used by Django settings."""
+
+    def test_raises_when_both_unset(self, monkeypatch):
+        monkeypatch.delenv("SCITEX_HUB_REQUIRED_FOO", raising=False)
+        monkeypatch.delenv("SCITEX_CLOUD_REQUIRED_FOO", raising=False)
+        with pytest.raises(EnvironmentError, match="SCITEX_HUB_REQUIRED_FOO"):
+            require_env_with_legacy_alias("SCITEX_HUB_REQUIRED_FOO")
+
+    def test_accepts_legacy_alias_with_warning(self, monkeypatch):
+        monkeypatch.delenv("SCITEX_HUB_REQUIRED_BAR", raising=False)
+        monkeypatch.setenv("SCITEX_CLOUD_REQUIRED_BAR", "legacy-value")
+        with pytest.warns(DeprecationWarning):
+            value = require_env_with_legacy_alias("SCITEX_HUB_REQUIRED_BAR")
+        assert value == "legacy-value"
+
+
+# EOF


### PR DESCRIPTION
## Summary

- Adds **config/_env.py** with `getenv_with_legacy_alias` / `require_env_with_legacy_alias` helpers. When the canonical `SCITEX_HUB_<X>` is unset but the legacy `SCITEX_CLOUD_<X>` is set, the legacy value is returned AND a `DeprecationWarning` is emitted (no silent fallback). Direction is strictly one-way — HUB is canonical, CLOUD is the legacy alias from the v0.18.0 scitex-cloud -> scitex-hub rename (ADR-0001).
- Rewires `config/settings/settings_shared.py` to use the helper for SECRET_KEY, REDIS_URL, EMAIL_*, SITE_URL, UMAMI_*, CAMPAIGN_*, VISITOR_POOL_SIZE, and `require_env()` — so every existing call site picks up the alias for free.
- Tests: `tests/config/test_env_legacy_alias.py` covers HUB-wins, CLOUD-alias-with-warning, default behaviour, one-directional semantics, and the require-env hard-fail.

## Context

- Operator directive (Telegram): "トークンはエイリアスとして残してください" — keep `SCITEX_CLOUD_*` working as a deprecated alias after the D.1 prefix rename in commit d38d6894.
- The other two directives in the original spec — relax scitex pin (commit 50d3e4a4) and use SQLite in release.yml test gate (commit 89afa4e3 + matching `SCITEX_HUB_USE_SQLITE_DEV: "1"` in release.yml L75) — were already landed on develop earlier today, so this PR delivers only the remaining alias work.

## Test plan

- [ ] CI tests pass (matrix on 3.11/3.12/3.13 with `SCITEX_HUB_USE_SQLITE_DEV=1`)
- [ ] New `tests/config/test_env_legacy_alias.py` runs green in CI (verified locally with isolated import — 7/7 logic checks pass)
- [ ] Existing settings_shared.py reads continue to function (no behaviour change when `SCITEX_HUB_*` is set)