### PR TITLE
feat: absorb umbrella cloud helpers + project _mcp + skills (umbrella-thinning Phase A)

### DIFF
--- a/src/scitex_hub/__init__.py
+++ b/src/scitex_hub/__init__.py
@@ -52,6 +52,71 @@ def get_version() -> str:
     return __version__
 
 
+def get_context(page: str = "", **kw) -> dict:
+    """Get web app context: username, page, skills, available actions.
+
+    Convenience wrapper over :class:`CloudClient.get_context`.
+
+    Parameters
+    ----------
+    page : str, optional
+        Page name or URL fragment to query context for. ``""`` means the
+        current page.
+    **kw
+        Forwarded to :class:`CloudClient` (e.g. base URL, auth credentials).
+
+    Returns
+    -------
+    dict
+        Context dict (``username``, ``page``, ``actions``, ...).
+    """
+    return CloudClient(**kw).get_context(page)
+
+
+def eval_js(code: str, timeout: int = 10, **kw) -> dict:
+    """Evaluate JavaScript in the user's connected browser.
+
+    Convenience wrapper over :class:`CloudClient.eval_js`.
+
+    Parameters
+    ----------
+    code : str
+        JavaScript code to evaluate.
+    timeout : int, optional
+        Seconds to wait for the result (default ``10``).
+    **kw
+        Forwarded to :class:`CloudClient`.
+
+    Returns
+    -------
+    dict
+        Result of the JavaScript evaluation.
+    """
+    return CloudClient(**kw).eval_js(code, timeout)
+
+
+def ui_action(steps: list, delay_ms: int = 900, **kw) -> dict:
+    """Drive browser UI: navigate, highlight, click, fill, scroll.
+
+    Convenience wrapper over :class:`CloudClient.ui_action`.
+
+    Parameters
+    ----------
+    steps : list
+        List of action-step dicts; each describes one browser action.
+    delay_ms : int, optional
+        Milliseconds to wait between steps (default ``900``).
+    **kw
+        Forwarded to :class:`CloudClient`.
+
+    Returns
+    -------
+    dict
+        Result summary.
+    """
+    return CloudClient(**kw).ui_action(steps, delay_ms)
+
+
 def health_check(endpoint: str | None = None) -> dict:
     """Check scitex-hub service health.
 
@@ -86,6 +151,9 @@ __all__ = [
     "__version__",
     "get_version",
     "health_check",
+    "get_context",
+    "eval_js",
+    "ui_action",
     "CloudClient",
     "Environment",
     "get_environment",

--- a/src/scitex_hub/_skills/scitex-hub-cloud/01_availability.md
+++ b/src/scitex_hub/_skills/scitex-hub-cloud/01_availability.md
@@ -1,0 +1,64 @@
+---
+description: How stx.cloud handles optional scitex-cloud dependency — AVAILABLE flag, graceful degradation, and installation.
+---
+
+# Cloud Availability and Optional Dependency
+
+`stx.cloud` delegates all implementation to the separate `scitex-cloud` package (Django web application). The hub package (`scitex`) never hard-requires it.
+
+## AVAILABLE Flag
+
+```python
+import scitex as stx
+
+if stx.cloud.AVAILABLE:
+    status = stx.cloud.health_check()
+else:
+    print("scitex-cloud not installed")
+```
+
+`stx.cloud.AVAILABLE` is `True` only when `scitex-cloud` is importable. It is set at module import time and never changes after that.
+
+## Behavior When Not Installed
+
+Every public function raises `ImportError` with an actionable message:
+
+```
+ImportError: scitex-cloud package not installed.
+Install with: pip install scitex-cloud
+Original error: No module named 'scitex_cloud'
+```
+
+No silent failures. No fallback behavior.
+
+## Installation
+
+```bash
+pip install scitex-cloud
+```
+
+## Environment Branding
+
+`stx.cloud.__init__` sets two environment variables before attempting to import `scitex-cloud`. These allow the downstream package to display the correct brand name in logs and UI:
+
+| Variable | Default value |
+|----------|---------------|
+| `SCITEX_CLOUD_BRAND` | `"scitex.cloud"` |
+| `SCITEX_CLOUD_ALIAS` | `"cloud"` |
+
+These are set with `os.environ.setdefault`, so they can be overridden by the caller before importing `scitex`.
+
+## Architecture
+
+```
+scitex (hub)
+  └── stx.cloud  (thin wrapper)
+        └── scitex_cloud  (spoke package, Django app)
+              └── scitex_cloud.api.CloudClient
+```
+
+All logic lives in `scitex_cloud`. The wrapper in `stx.cloud` only:
+1. Sets brand env vars
+2. Imports and re-exports `get_version`, `health_check`
+3. Wraps `CloudClient` methods as module-level functions
+4. Provides stub functions that raise `ImportError` when the package is absent

--- a/src/scitex_hub/_skills/scitex-hub-cloud/02_health-and-version.md
+++ b/src/scitex_hub/_skills/scitex-hub-cloud/02_health-and-version.md
@@ -1,0 +1,66 @@
+---
+description: Check scitex-cloud service health and retrieve version with health_check() and get_version().
+---
+
+# Health Check and Version
+
+## get_version
+
+Returns the version string of the installed `scitex-cloud` package.
+
+```python
+get_version() -> str
+```
+
+**Parameters:** none
+
+**Returns:** version string, e.g. `"0.7.0a0"`
+
+**Source:** Re-exported directly from `scitex_cloud.get_version`.
+
+```python
+import scitex as stx
+
+version = stx.cloud.get_version()
+print(version)  # "0.7.0a0"
+```
+
+---
+
+## health_check
+
+Verifies the cloud service is running and reachable.
+
+```python
+health_check() -> dict
+```
+
+**Parameters:** none
+
+**Returns:** dict with at minimum a `"status"` key.
+
+```python
+import scitex as stx
+
+status = stx.cloud.health_check()
+# {"status": "healthy", ...}
+```
+
+**Source:** Re-exported directly from `scitex_cloud.health_check`.
+
+---
+
+## Pattern: Guard with AVAILABLE
+
+```python
+import scitex as stx
+
+if not stx.cloud.AVAILABLE:
+    raise RuntimeError("scitex-cloud required but not installed")
+
+status = stx.cloud.health_check()
+assert status["status"] == "healthy", f"Cloud unhealthy: {status}"
+
+version = stx.cloud.get_version()
+print(f"Connected to scitex-cloud {version}")
+```

--- a/src/scitex_hub/_skills/scitex-hub-cloud/03_context.md
+++ b/src/scitex_hub/_skills/scitex-hub-cloud/03_context.md
@@ -1,0 +1,49 @@
+---
+description: Retrieve the current web app context (username, page state, available actions) with get_context().
+---
+
+# Web App Context
+
+## get_context
+
+Returns the current state of the user's active web app session: who is logged in, what page is open, what skills and actions are available.
+
+```python
+get_context(page: str = "", **kw) -> dict
+```
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | `str` | `""` | Page name or URL fragment to query context for. Pass `""` for the current page. |
+| `**kw` | any | — | Forwarded to `CloudClient.__init__` (e.g., auth credentials, base URL). |
+
+**Returns:** `dict` — keys include at minimum `"username"`, `"page"`, and `"actions"`. Exact shape is defined by `scitex_cloud`.
+
+**Implementation:** `_Client(**kw).get_context(page)` where `_Client` is `scitex_cloud.api.CloudClient`.
+
+---
+
+## Examples
+
+```python
+import scitex as stx
+
+# Current page context
+ctx = stx.cloud.get_context()
+print(ctx["username"])  # logged-in user
+print(ctx["actions"])   # list of available actions on current page
+
+# Context for a specific page
+ctx = stx.cloud.get_context("dashboard")
+print(ctx["page"])
+```
+
+---
+
+## Notes
+
+- Requires the browser/client to be connected to scitex-cloud.
+- The `**kw` forwarded to `CloudClient` allows passing custom host, port, auth tokens, etc. — see `scitex-cloud` documentation for supported kwargs.
+- Raises `ImportError` if `scitex-cloud` is not installed (see [01_availability.md](01_availability.md)).

--- a/src/scitex_hub/_skills/scitex-hub-cloud/04_browser-control.md
+++ b/src/scitex_hub/_skills/scitex-hub-cloud/04_browser-control.md
@@ -1,0 +1,109 @@
+---
+description: Evaluate JavaScript in the user's browser and drive UI interactions with eval_js() and ui_action().
+---
+
+# Browser Control
+
+## eval_js
+
+Evaluates a JavaScript expression or statement in the user's connected browser and returns the result.
+
+```python
+eval_js(code: str, timeout: int = 10, **kw) -> dict
+```
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `code` | `str` | required | JavaScript code to evaluate in the browser. |
+| `timeout` | `int` | `10` | Seconds to wait for the result before raising. |
+| `**kw` | any | — | Forwarded to `CloudClient.__init__`. |
+
+**Returns:** `dict` — result of the JavaScript evaluation as returned by `scitex_cloud`.
+
+**Implementation:** `_Client(**kw).eval_js(code, timeout)`
+
+### Examples
+
+```python
+import scitex as stx
+
+# Read the page title
+result = stx.cloud.eval_js("document.title")
+
+# Get current URL
+result = stx.cloud.eval_js("window.location.href")
+
+# Read a DOM element's text
+result = stx.cloud.eval_js("document.querySelector('#status').innerText")
+
+# Execute multi-line JS
+result = stx.cloud.eval_js("""
+    const items = document.querySelectorAll('.item');
+    Array.from(items).map(el => el.textContent);
+""")
+
+# With custom timeout
+result = stx.cloud.eval_js("longRunningFunction()", timeout=30)
+```
+
+---
+
+## ui_action
+
+Drives browser UI actions programmatically: navigation, highlight, click, fill, scroll, etc.
+
+```python
+ui_action(steps: list, delay_ms: int = 900, **kw) -> dict
+```
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `steps` | `list` | required | List of action step dicts. Each dict describes one browser action. |
+| `delay_ms` | `int` | `900` | Milliseconds to wait between steps. |
+| `**kw` | any | — | Forwarded to `CloudClient.__init__`. |
+
+**Returns:** `dict` — result summary from `scitex_cloud`.
+
+**Implementation:** `_Client(**kw).ui_action(steps, delay_ms)`
+
+### Step Format
+
+Each step is a dict. The exact keys are defined by `scitex_cloud`. Common action types include `navigate`, `click`, `fill`, `scroll`, and `highlight`.
+
+### Examples
+
+```python
+import scitex as stx
+
+# Single click
+stx.cloud.ui_action([
+    {"action": "click", "selector": "#submit-btn"}
+])
+
+# Multi-step: navigate then fill a form
+stx.cloud.ui_action([
+    {"action": "navigate", "url": "/dashboard"},
+    {"action": "fill", "selector": "#search-input", "value": "my query"},
+    {"action": "click", "selector": "#search-btn"},
+], delay_ms=500)
+
+# With custom delay between steps
+stx.cloud.ui_action(
+    steps=[
+        {"action": "scroll", "selector": "#results", "direction": "down"},
+    ],
+    delay_ms=200,
+)
+```
+
+---
+
+## Notes
+
+- Both functions require an active browser connection managed by `scitex-cloud`.
+- `**kw` passes authentication or connection options to `CloudClient` — see `scitex-cloud` docs for supported kwargs.
+- Raises `ImportError` if `scitex-cloud` is not installed (see [01_availability.md](01_availability.md)).

--- a/src/scitex_hub/_skills/scitex-hub-cloud/05_matplotlib-hook.md
+++ b/src/scitex_hub/_skills/scitex-hub-cloud/05_matplotlib-hook.md
@@ -1,0 +1,98 @@
+---
+description: Automatic matplotlib integration for cloud environments — inline figure display via install_matplotlib_hook() and uninstall_matplotlib_hook().
+---
+
+# Matplotlib Hook
+
+`scitex/cloud/_matplotlib_hook.py` patches matplotlib to display figures inline when running inside a cloud (headless) environment. It is not imported by `cloud/__init__.py` by default; it must be imported or installed explicitly.
+
+## install_matplotlib_hook
+
+Patches `matplotlib.figure.Figure.savefig` and `matplotlib.pyplot.show` to emit inline image markers when in a cloud environment.
+
+```python
+install_matplotlib_hook() -> None
+```
+
+**Parameters:** none
+
+**Behavior:**
+- Idempotent: calling it multiple times has no effect after the first call (guarded by `_hooked` flag).
+- Hooks two entry points:
+  - `Figure.savefig` — after saving, calls `emit_inline_image(fname)` if in cloud environment.
+  - `plt.show` — in cloud environment, saves all open figures to `<project_root>/scitex/temp/<timestamp>/figure_<n>.png` and emits inline image markers. Does NOT call the original `plt.show()` in cloud (headless). In non-cloud environments, delegates to the original `plt.show()`.
+- Safe: if `matplotlib` is not installed, the function silently returns.
+
+```python
+from scitex.cloud._matplotlib_hook import install_matplotlib_hook
+
+install_matplotlib_hook()
+
+import matplotlib.pyplot as plt
+fig, ax = plt.subplots()
+ax.plot([1, 2, 3], [4, 5, 6])
+plt.show()  # Saves to project_root/scitex/temp/<ts>/figure_1.png and emits inline marker
+```
+
+---
+
+## uninstall_matplotlib_hook
+
+Restores the original `Figure.savefig` and `plt.show` functions.
+
+```python
+uninstall_matplotlib_hook() -> None
+```
+
+**Parameters:** none
+
+**Behavior:**
+- Idempotent: no-op if hooks were not installed.
+- Restores both `Figure.savefig` and `plt.show` to their pre-hook originals.
+- Safe: if `matplotlib` is not installed, silently returns.
+
+```python
+from scitex.cloud._matplotlib_hook import uninstall_matplotlib_hook
+
+uninstall_matplotlib_hook()
+# matplotlib now behaves normally
+```
+
+---
+
+## Auto-install Behavior
+
+The module auto-installs hooks at import time if `is_cloud_environment()` returns `True`:
+
+```python
+# Bottom of _matplotlib_hook.py:
+from scitex.cloud import is_cloud_environment
+if is_cloud_environment():
+    install_matplotlib_hook()
+```
+
+This means importing `scitex.cloud._matplotlib_hook` in a cloud session automatically enables inline figure display.
+
+---
+
+## Output Path
+
+When `plt.show()` is called in cloud mode, figures are saved to:
+
+```
+<project_root>/scitex/temp/<YYYYMMDD_HHMMSS>/figure_<fignum>.png
+```
+
+The inline image marker emitted uses the project-relative path:
+
+```
+scitex/temp/20260325_142300/figure_1.png
+```
+
+---
+
+## Notes
+
+- `is_cloud_environment()`, `emit_inline_image()`, and `get_project_root()` are defined in `scitex_cloud` (the spoke package). They are not available when `scitex-cloud` is not installed.
+- The hook is intentionally NOT auto-applied by `stx.cloud.__init__` — the user or the cloud runtime must trigger it explicitly.
+- `__all__` exports only `install_matplotlib_hook` and `uninstall_matplotlib_hook`.

--- a/src/scitex_hub/_skills/scitex-hub-cloud/SKILL.md
+++ b/src/scitex_hub/_skills/scitex-hub-cloud/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: scitex-hub-cloud
+description: SciTeX Hub web service integration — health monitoring, web app context, JavaScript evaluation, and browser UI control. Module-level helpers wrap CloudClient.
+user-invocable: false
+---
+
+# scitex-hub: Cloud Web Service Integration
+
+`scitex_hub` exposes module-level helpers that wrap
+:class:`scitex_hub.CloudClient` for the most common web-app interactions:
+reading context, evaluating JavaScript, and driving the browser UI.
+
+These are re-exported by the umbrella as `stx.cloud.get_context`,
+`stx.cloud.eval_js`, and `stx.cloud.ui_action`.
+
+## Sub-skills
+
+### Setup and Availability
+- [01_availability.md](01_availability.md) — `AVAILABLE` flag, optional dependency pattern, installation
+
+### Core API
+- [02_health-and-version.md](02_health-and-version.md) — `health_check()`, `get_version()`
+- [03_context.md](03_context.md) — `get_context(page, **kw)`: username, page state, available actions
+- [04_browser-control.md](04_browser-control.md) — `eval_js(code, timeout, **kw)`, `ui_action(steps, delay_ms, **kw)`
+
+### Integration
+- [05_matplotlib-hook.md](05_matplotlib-hook.md) — inline figure display in headless cloud sessions
+
+## Public API Summary
+
+```python
+import scitex_hub
+
+scitex_hub.get_version()      # -> str
+scitex_hub.health_check()     # -> dict
+
+scitex_hub.get_context(page="", **kw)            # -> dict
+scitex_hub.eval_js(code, timeout=10, **kw)       # -> dict
+scitex_hub.ui_action(steps, delay_ms=900, **kw)  # -> dict
+```
+
+## Quick Start
+
+```python
+import scitex_hub
+
+# Verify connection
+status = scitex_hub.health_check()
+
+# Get current page context
+ctx = scitex_hub.get_context()
+print(ctx["username"], ctx["actions"])
+
+# Read from the browser
+result = scitex_hub.eval_js("document.title")
+
+# Drive UI
+scitex_hub.ui_action([
+    {"action": "click", "selector": "#submit-btn"},
+])
+```

--- a/src/scitex_hub/_skills/scitex-hub-module/01_module-decorator.md
+++ b/src/scitex_hub/_skills/scitex-hub-module/01_module-decorator.md
@@ -1,0 +1,88 @@
+---
+description: Mark functions as SciTeX workspace modules with the @module decorator and collect structured outputs.
+---
+
+# scitex_hub.module — @module Decorator
+
+`scitex_hub.module` is the canonical home for the workspace-module API. The
+umbrella `scitex.module` (and the legacy `scitex_cloud.module` alias) re-export
+from here.
+
+The `@module` decorator transforms a function into a SciTeX workspace module. The workspace runner discovers decorated functions, injects runtime values, collects outputs, and serializes results.
+
+## @module decorator
+
+```python
+from scitex_hub.module import module, output, html, INJECTED
+
+@module(
+    label="EEG Viewer",        # display name in UI
+    icon="fa-brain",           # FontAwesome icon class
+    category="visualization",  # one of: writing, visualization, data, analysis,
+                               #         reference, utility, other
+    description="Plots EEG signals",
+    version="1.0.0",
+    dependencies=["mne"],
+)
+def eeg_viewer(
+    project=INJECTED,   # injected: Path to project directory
+    plt=INJECTED,       # injected: matplotlib.pyplot (Agg backend)
+    logger=INJECTED,    # injected: logging.Logger
+):
+    """Shows EEG data from the project."""
+    data_path = project / "data/eeg.npy"
+    # ... analysis ...
+    fig, ax = plt.subplots()
+    ax.plot(eeg_data)
+    output(fig, title="EEG Signal")              # register a figure
+    output(summary_df, title="Summary Stats")    # register a DataFrame
+    output(html("<b>Done</b>"), title="Status")  # register HTML
+```
+
+## output and html
+
+Inside a `@module` function, call `output()` to register items for display:
+
+```python
+from scitex_hub.module import output, html
+
+output(fig, title="My Figure")          # matplotlib Figure → base64 PNG
+output(df, title="Results Table")       # DataFrame → HTML table
+output("Analysis complete", title="Log") # str → text
+output({"k": 1}, title="Config")        # dict → JSON
+output(html("<em>note</em>"), title="")  # _SafeHtml → raw HTML
+```
+
+Auto-detected types: `figure`, `table`, `text`, `json`, `html`.
+
+## INJECTED sentinel
+
+Parameters with `default=INJECTED` are filled by the module runner at execution time:
+
+| Parameter name | Value injected |
+|----------------|---------------|
+| `project` | `Path` to the project directory |
+| `plt` | `matplotlib.pyplot` with Agg backend |
+| `logger` | `logging.Logger("scitex_hub.module.user")` |
+
+## ModuleManifest
+
+The manifest is attached to the wrapper as `wrapper._manifest`:
+
+```python
+manifest = eeg_viewer._manifest
+print(manifest.name)        # "eeg_viewer"
+print(manifest.label)       # "EEG Viewer"
+print(manifest.category)    # "visualization"
+manifest.to_dict()          # JSON-serializable dict
+```
+
+## Running a module file
+
+```bash
+python -m scitex_hub.module._runner path/to/module.py \
+    --project-path /path/to/project \
+    --output-dir /tmp/module_out
+```
+
+Writes `result.json` containing `manifest`, `outputs`, `error`.

--- a/src/scitex_hub/_skills/scitex-hub-module/SKILL.md
+++ b/src/scitex_hub/_skills/scitex-hub-module/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: scitex-hub-module
+description: Mark functions as SciTeX workspace modules with the @module decorator and collect structured outputs. Canonical home — the umbrella scitex.module re-exports from here.
+user-invocable: false
+---
+
+# scitex-hub: Workspace Modules
+
+`scitex_hub.module` is the canonical implementation of the SciTeX workspace
+module API: the `@module` decorator, the `output`/`html` helpers, the
+`INJECTED` sentinel, `ModuleManifest`, and the file runner. The umbrella
+`scitex.module` (and the legacy `scitex_cloud.module` alias) re-export from
+here.
+
+## Sub-skills
+
+| File | Description |
+|------|-------------|
+| [01_module-decorator.md](01_module-decorator.md) | @module decorator, output/html helpers, INJECTED sentinel, ModuleManifest, CLI runner |
+
+## Quick Reference
+
+```python
+from scitex_hub.module import module, output, html, INJECTED
+
+@module(label="My Analysis", category="analysis")
+def run(project=INJECTED, plt=INJECTED, logger=INJECTED):
+    fig, ax = plt.subplots()
+    output(fig, title="Result")
+```

--- a/src/scitex_hub/_skills/scitex-hub-project/01_mcp-file-ops.md
+++ b/src/scitex_hub/_skills/scitex-hub-project/01_mcp-file-ops.md
@@ -1,0 +1,143 @@
+---
+description: Secure project file operations (list, read, write, search, exec) exposed as MCP tools with path traversal protection.
+---
+
+# scitex_hub.project — MCP File Operations
+
+`scitex_hub.project._mcp.handlers` provides async handlers that back the MCP tools `project_list_files`, `project_read_file`, `project_write_file`, `project_search_files`, `project_exec_python`, and `project_exec_shell`. The umbrella `scitex.project` re-exports these handlers.
+
+All operations are sandboxed to paths under `ALLOWED_DATA_ROOT` (default `/app/data/users`, overridable via `SCITEX_PROJECT_DATA_ROOT` environment variable).
+
+## Security model
+
+Every handler calls `_resolve_safe(root_path, relative_path)` which:
+1. Verifies `root_path` is under `ALLOWED_DATA_ROOT`
+2. Verifies the resolved target is under `root_path` (no `../` traversal)
+3. Raises `ValueError` on any violation (never silently allows)
+
+## list_files_handler
+
+List files and directories as a tree.
+
+```python
+from scitex_hub.project._mcp.handlers import list_files_handler
+import asyncio
+
+result = asyncio.run(list_files_handler(
+    root_path="/app/data/users/alice/myproject",
+    relative_path=".",
+    max_depth=3,           # 1–6, default 3
+))
+# {
+#   "success": True,
+#   "path": ".",
+#   "tree": [
+#     {"name": "data", "type": "dir", "children": [...]},
+#     {"name": "analysis.py", "type": "file", "size": 1234},
+#   ]
+# }
+```
+
+Skips hidden files, `__pycache__`, `.git`, `node_modules`.
+
+## read_file_handler
+
+Read text file content (UTF-8, with `errors="replace"`).
+
+```python
+result = asyncio.run(read_file_handler(
+    root_path="/app/data/users/alice/myproject",
+    relative_path="results/summary.csv",
+    max_bytes=65536,       # default 64 KiB
+))
+# {
+#   "success": True,
+#   "path": "results/summary.csv",
+#   "content": "...",
+#   "size_bytes": 1200,
+#   "truncated": False,
+# }
+```
+
+## write_file_handler
+
+Write a text file, creating parent directories as needed.
+
+```python
+result = asyncio.run(write_file_handler(
+    root_path="/app/data/users/alice/myproject",
+    relative_path="notes/todo.md",
+    content="# TODO\n- Check results\n",
+))
+# {"success": True, "path": "notes/todo.md", "size_bytes": 22}
+```
+
+## search_files_handler
+
+Search by filename glob and/or content substring.
+
+```python
+result = asyncio.run(search_files_handler(
+    root_path="/app/data/users/alice/myproject",
+    name_pattern="*.py",
+    content_pattern="import scitex",
+    relative_path=".",
+    max_results=50,
+))
+# {
+#   "success": True,
+#   "matches": [
+#     {"path": "analysis.py", "line": 3, "preview": "import scitex as stx"},
+#   ],
+#   "count": 1,
+#   "truncated": False,
+# }
+```
+
+At least one of `name_pattern` or `content_pattern` must be provided.
+
+## exec_python_handler
+
+Execute Python code as a subprocess with `cwd=root_path`. Detects new/deleted/moved files.
+
+```python
+result = asyncio.run(exec_python_handler(
+    root_path="/app/data/users/alice/myproject",
+    code="import scitex as stx; stx.io.save([1,2,3], 'test.npy')",
+    timeout=30,            # 5–60 s, default 30
+))
+# {
+#   "success": True,
+#   "exit_code": 0,
+#   "stdout": "",
+#   "stderr": "",
+#   "new_files": ["test.npy"],
+#   "moved_files": [],
+#   "deleted_files": [],
+# }
+```
+
+## exec_shell_handler
+
+Execute a shell command via `/bin/bash -c` with `cwd=root_path`.
+
+```python
+result = asyncio.run(exec_shell_handler(
+    root_path="/app/data/users/alice/myproject",
+    command="ls -la results/",
+    timeout=30,
+))
+```
+
+Response format is identical to `exec_python_handler`.
+
+## MCP tool names
+
+| Handler | MCP tool |
+|---|---|
+| `list_files_handler` | `project_list_files` |
+| `read_file_handler` | `project_read_file` |
+| `write_file_handler` | `project_write_file` |
+| `search_files_handler` | `project_search_files` |
+| `exec_python_handler` | `project_exec_python` |
+| `exec_shell_handler` | `project_exec_shell` |

--- a/src/scitex_hub/_skills/scitex-hub-project/SKILL.md
+++ b/src/scitex_hub/_skills/scitex-hub-project/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: scitex-hub-project
+description: SciTeX Hub project management — CRUD plus secure MCP handlers for list, read, write, search, and execute within project sandboxes.
+user-invocable: false
+---
+
+# scitex-hub: Project Management
+
+`scitex_hub.project` covers project lifecycle (CRUD) and the sandboxed
+file-operation handlers that back the MCP project tools. All file operations
+are constrained to `ALLOWED_DATA_ROOT` with path-traversal protection. The
+umbrella `scitex.project` re-exports this surface.
+
+## Sub-skills
+
+| File | Description |
+|------|-------------|
+| [01_mcp-file-ops.md](01_mcp-file-ops.md) | list_files, read_file, write_file, search_files, exec_python, exec_shell handlers; security model |
+
+## Project CRUD
+
+```python
+from scitex_hub.project import (
+    project_list, project_create, project_delete, project_rename,
+)
+
+projects = project_list()
+new = project_create("my-project", description="My research")
+```
+
+## File-operation handlers (async)
+
+```python
+from scitex_hub.project._mcp.handlers import (
+    list_files_handler, read_file_handler, write_file_handler,
+    search_files_handler, exec_python_handler, exec_shell_handler,
+)
+import asyncio
+
+result = asyncio.run(list_files_handler("/app/data/users/alice/proj"))
+```

--- a/src/scitex_hub/project/__init__.py
+++ b/src/scitex_hub/project/__init__.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# File: src/scitex_hub/project.py
-"""Project CRUD — Python API for SciTeX Hub project management.
+# File: src/scitex_hub/project/__init__.py
+"""SciTeX Hub project management.
 
-Usage:
+Project CRUD (Python API):
     from scitex_hub.project import project_list, project_create
 
     projects = project_list()
     new = project_create("my-project", description="My research")
+
+Sandboxed file-operation handlers (async, used by MCP tools) live in
+:mod:`scitex_hub.project._mcp.handlers`.
 """
 
 from __future__ import annotations
 
-from ._mcp_tools.api import _make_request
+from .._mcp_tools.api import _make_request
 
 
 def project_list() -> list[dict]:

--- a/src/scitex_hub/project/_mcp/__init__.py
+++ b/src/scitex_hub/project/_mcp/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_hub/project/_mcp/__init__.py
+"""MCP handlers for sandboxed project file operations."""
+
+# EOF

--- a/src/scitex_hub/project/_mcp/handlers.py
+++ b/src/scitex_hub/project/_mcp/handlers.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_hub/project/_mcp/handlers.py
+"""
+Project file operation handlers for MCP tools.
+
+Security: all operations are constrained to paths under ALLOWED_DATA_ROOT.
+Path traversal (../) is blocked at resolution time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fnmatch
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+# Configurable via environment — default matches Docker container layout
+ALLOWED_DATA_ROOT = os.environ.get("SCITEX_PROJECT_DATA_ROOT", "/app/data/users")
+
+
+def _resolve_safe(root_path: str, relative_path: str = "") -> Path:
+    """
+    Resolve a path within root_path, raising ValueError on any violation.
+
+    Checks:
+    1. root_path must be under ALLOWED_DATA_ROOT
+    2. Resolved target must be under root_path (no path traversal)
+    """
+    root = Path(root_path).resolve()
+    allowed = Path(ALLOWED_DATA_ROOT).resolve()
+
+    if not str(root).startswith(str(allowed)):
+        raise ValueError(
+            f"root_path '{root}' is not under allowed data root '{allowed}'. "
+            "Project paths must be within the configured data directory."
+        )
+
+    if relative_path and relative_path not in (".", ""):
+        target = (root / relative_path).resolve()
+    else:
+        target = root
+
+    if not str(target).startswith(str(root)):
+        raise ValueError(
+            f"Path traversal detected: '{relative_path}' escapes project root."
+        )
+
+    return target
+
+
+def _build_tree(path: Path, max_depth: int, current_depth: int = 0) -> list[dict]:
+    """Recursively build a file tree structure."""
+    if current_depth >= max_depth:
+        return []
+
+    entries = []
+    try:
+        items = sorted(path.iterdir(), key=lambda p: (p.is_file(), p.name))
+    except PermissionError:
+        return []
+
+    for item in items:
+        # Skip hidden files/dirs and common noise
+        if item.name.startswith(".") or item.name in (
+            "__pycache__",
+            "node_modules",
+            ".git",
+        ):
+            continue
+        entry: dict[str, Any] = {
+            "name": item.name,
+            "type": "file" if item.is_file() else "dir",
+        }
+        if item.is_dir():
+            entry["children"] = _build_tree(item, max_depth, current_depth + 1)
+        else:
+            entry["size"] = item.stat().st_size
+        entries.append(entry)
+
+    return entries
+
+
+async def list_files_handler(
+    root_path: str,
+    relative_path: str = ".",
+    max_depth: int = 3,
+) -> dict:
+    """List files and directories within the project."""
+    try:
+        target = _resolve_safe(root_path, relative_path)
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+
+    if not target.exists():
+        return {"success": False, "error": f"Path does not exist: {relative_path}"}
+    if not target.is_dir():
+        return {"success": False, "error": f"Not a directory: {relative_path}"}
+
+    tree = _build_tree(target, max_depth=max(1, min(max_depth, 6)))
+    return {
+        "success": True,
+        "path": str(target.relative_to(Path(root_path).resolve())),
+        "tree": tree,
+    }
+
+
+async def read_file_handler(
+    root_path: str,
+    relative_path: str,
+    max_bytes: int = 65536,
+) -> dict:
+    """Read file content from the project."""
+    try:
+        target = _resolve_safe(root_path, relative_path)
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+
+    if not target.exists():
+        return {"success": False, "error": f"File not found: {relative_path}"}
+    if not target.is_file():
+        return {"success": False, "error": f"Not a file: {relative_path}"}
+
+    size = target.stat().st_size
+    truncated = size > max_bytes
+
+    try:
+        with open(target, encoding="utf-8", errors="replace") as f:
+            content = f.read(max_bytes)
+    except Exception as e:
+        return {"success": False, "error": f"Cannot read file: {e}"}
+
+    return {
+        "success": True,
+        "path": relative_path,
+        "content": content,
+        "size_bytes": size,
+        "truncated": truncated,
+        "truncated_at_bytes": max_bytes if truncated else None,
+    }
+
+
+async def write_file_handler(
+    root_path: str,
+    relative_path: str,
+    content: str,
+) -> dict:
+    """Write content to a file in the project (creates parent dirs as needed)."""
+    try:
+        target = _resolve_safe(root_path, relative_path)
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with open(target, "w", encoding="utf-8") as f:
+            f.write(content)
+    except Exception as e:
+        return {"success": False, "error": f"Cannot write file: {e}"}
+
+    return {
+        "success": True,
+        "path": relative_path,
+        "size_bytes": target.stat().st_size,
+    }
+
+
+async def search_files_handler(
+    root_path: str,
+    name_pattern: str = "",
+    content_pattern: str = "",
+    relative_path: str = ".",
+    max_results: int = 50,
+) -> dict:
+    """Search project files by name glob and/or content substring."""
+    try:
+        search_root = _resolve_safe(root_path, relative_path)
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+
+    if not search_root.exists():
+        return {"success": False, "error": f"Directory not found: {relative_path}"}
+
+    if not name_pattern and not content_pattern:
+        return {"success": False, "error": "Provide name_pattern or content_pattern"}
+
+    matches = []
+    root_resolved = Path(root_path).resolve()
+
+    for item in search_root.rglob("*"):
+        if len(matches) >= max_results:
+            break
+        # Skip hidden and noisy items — check relative path only, not absolute prefix
+        rel_parts = item.relative_to(search_root).parts
+        if any(
+            p.startswith(".") or p in ("__pycache__", "node_modules") for p in rel_parts
+        ):
+            continue
+        if not item.is_file():
+            continue
+
+        name_ok = not name_pattern or fnmatch.fnmatch(item.name, name_pattern)
+        if not name_ok:
+            continue
+
+        if content_pattern:
+            try:
+                text = item.read_text(encoding="utf-8", errors="replace")
+                if content_pattern not in text:
+                    continue
+                # Find first matching line for context
+                for lineno, line in enumerate(text.splitlines(), 1):
+                    if content_pattern in line:
+                        match_line = lineno
+                        match_preview = line.strip()[:120]
+                        break
+                else:
+                    match_line, match_preview = 0, ""
+            except Exception:
+                continue
+            matches.append(
+                {
+                    "path": str(item.relative_to(root_resolved)),
+                    "line": match_line,
+                    "preview": match_preview,
+                }
+            )
+        else:
+            matches.append({"path": str(item.relative_to(root_resolved))})
+
+    return {
+        "success": True,
+        "matches": matches,
+        "count": len(matches),
+        "truncated": len(matches) >= max_results,
+    }
+
+
+async def exec_python_handler(
+    root_path: str,
+    code: str,
+    timeout: int = 30,
+) -> dict:
+    """Execute Python code in the project directory.
+
+    Runs the code as a subprocess with cwd=root_path.
+    Captures stdout, stderr, and lists any new files created.
+    """
+    try:
+        root = _resolve_safe(root_path)
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+
+    if not root.exists():
+        return {"success": False, "error": f"Project root not found: {root_path}"}
+
+    timeout = max(5, min(timeout, 60))
+
+    # Snapshot files before execution for detecting new files
+    before = set()
+    for item in root.rglob("*"):
+        if item.is_file():
+            before.add(str(item.relative_to(root)))
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "python3",
+            "-c",
+            code,
+            cwd=str(root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        )
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        return {
+            "success": False,
+            "error": f"Execution timed out after {timeout}s",
+        }
+    except FileNotFoundError:
+        return {"success": False, "error": "python3 not found in container"}
+    except Exception as e:
+        return {"success": False, "error": f"Execution failed: {e}"}
+
+    stdout = stdout_bytes.decode("utf-8", errors="replace")[:8192]
+    stderr = stderr_bytes.decode("utf-8", errors="replace")[:4096]
+
+    # Detect file changes (new, deleted, moved)
+    after = set()
+    for item in root.rglob("*"):
+        if item.is_file():
+            after.add(str(item.relative_to(root)))
+    created = after - before
+    deleted = before - after
+    # Filter out moves: if basename exists in both created and deleted, it's a move
+    deleted_basenames = {Path(p).name for p in deleted}
+    truly_new = sorted(p for p in created if Path(p).name not in deleted_basenames)
+    moved = sorted(p for p in created if Path(p).name in deleted_basenames)
+
+    return {
+        "success": proc.returncode == 0,
+        "exit_code": proc.returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "new_files": truly_new,
+        "moved_files": moved,
+        "deleted_files": sorted(deleted),
+    }
+
+
+async def exec_shell_handler(
+    root_path: str,
+    command: str,
+    timeout: int = 30,
+) -> dict:
+    """Execute a shell command in the project directory.
+
+    Runs the command via /bin/bash with cwd=root_path.
+    Captures stdout, stderr, and lists any new files created.
+    """
+    try:
+        root = _resolve_safe(root_path)
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+
+    if not root.exists():
+        return {"success": False, "error": f"Project root not found: {root_path}"}
+
+    timeout = max(5, min(timeout, 60))
+
+    # Snapshot files before execution for detecting new files
+    before = set()
+    for item in root.rglob("*"):
+        if item.is_file():
+            before.add(str(item.relative_to(root)))
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "/bin/bash",
+            "-c",
+            command,
+            cwd=str(root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        return {
+            "success": False,
+            "error": f"Execution timed out after {timeout}s",
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Execution failed: {e}"}
+
+    stdout = stdout_bytes.decode("utf-8", errors="replace")[:8192]
+    stderr = stderr_bytes.decode("utf-8", errors="replace")[:4096]
+
+    # Detect file changes (new, deleted, moved)
+    after = set()
+    for item in root.rglob("*"):
+        if item.is_file():
+            after.add(str(item.relative_to(root)))
+    created = after - before
+    deleted = before - after
+    # Filter out moves: if basename exists in both created and deleted, it's a move
+    deleted_basenames = {Path(p).name for p in deleted}
+    truly_new = sorted(p for p in created if Path(p).name not in deleted_basenames)
+    moved = sorted(p for p in created if Path(p).name in deleted_basenames)
+
+    return {
+        "success": proc.returncode == 0,
+        "exit_code": proc.returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "new_files": truly_new,
+        "moved_files": moved,
+        "deleted_files": sorted(deleted),
+    }
+
+
+# EOF

--- a/tests/scitex_hub/test_cloud_helpers.py
+++ b/tests/scitex_hub/test_cloud_helpers.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_hub/test_cloud_helpers.py
+
+"""Tests for the module-level cloud helpers on ``scitex_hub``.
+
+These wrap :class:`scitex_hub.CloudClient` and are re-exported by the umbrella
+as ``stx.cloud.get_context``, ``stx.cloud.eval_js``, ``stx.cloud.ui_action``.
+"""
+
+import pytest
+
+import scitex_hub
+
+
+class _FakeClient:
+    """Records the kwargs it was constructed with and the calls it received."""
+
+    last_init_kwargs = None
+    last_call = None
+
+    def __init__(self, **kwargs):
+        type(self).last_init_kwargs = kwargs
+
+    def get_context(self, page):
+        type(self).last_call = ("get_context", page)
+        return {"page": page, "username": "tester"}
+
+    def eval_js(self, code, timeout):
+        type(self).last_call = ("eval_js", code, timeout)
+        return {"code": code, "timeout": timeout}
+
+    def ui_action(self, steps, delay_ms):
+        type(self).last_call = ("ui_action", steps, delay_ms)
+        return {"steps": steps, "delay_ms": delay_ms}
+
+
+@pytest.fixture
+def fake_client():
+    """Swap the real CloudClient for a recording fake; restore on teardown."""
+    original = scitex_hub.CloudClient
+    _FakeClient.last_init_kwargs = None
+    _FakeClient.last_call = None
+    scitex_hub.CloudClient = _FakeClient
+    try:
+        yield _FakeClient
+    finally:
+        scitex_hub.CloudClient = original
+
+
+def test_get_context_is_importable_from_scitex_hub():
+    # Arrange
+    # (no setup — importing the public symbol is the behaviour under test)
+    # Act
+    from scitex_hub import get_context
+
+    # Assert
+    assert callable(get_context)
+
+
+def test_eval_js_is_importable_from_scitex_hub():
+    # Arrange
+    # Act
+    from scitex_hub import eval_js
+
+    # Assert
+    assert callable(eval_js)
+
+
+def test_ui_action_is_importable_from_scitex_hub():
+    # Arrange
+    # Act
+    from scitex_hub import ui_action
+
+    # Assert
+    assert callable(ui_action)
+
+
+def test_get_context_listed_in_dunder_all():
+    # Arrange
+    exported = scitex_hub.__all__
+    # Act
+    present = "get_context" in exported
+    # Assert
+    assert present is True
+
+
+def test_eval_js_listed_in_dunder_all():
+    # Arrange
+    exported = scitex_hub.__all__
+    # Act
+    present = "eval_js" in exported
+    # Assert
+    assert present is True
+
+
+def test_ui_action_listed_in_dunder_all():
+    # Arrange
+    exported = scitex_hub.__all__
+    # Act
+    present = "ui_action" in exported
+    # Assert
+    assert present is True
+
+
+def test_get_context_returns_client_result(fake_client):
+    # Arrange
+    page = "dashboard"
+    # Act
+    result = scitex_hub.get_context(page)
+    # Assert
+    assert result == {"page": "dashboard", "username": "tester"}
+
+
+def test_get_context_forwards_kwargs_to_client(fake_client):
+    # Arrange
+    # Act
+    scitex_hub.get_context("dashboard", base_url="http://x")
+    # Assert
+    assert fake_client.last_init_kwargs == {"base_url": "http://x"}
+
+
+def test_get_context_defaults_to_current_page(fake_client):
+    # Arrange
+    # Act
+    scitex_hub.get_context()
+    # Assert
+    assert fake_client.last_call == ("get_context", "")
+
+
+def test_eval_js_passes_code_and_timeout(fake_client):
+    # Arrange
+    # Act
+    scitex_hub.eval_js("document.title", timeout=30)
+    # Assert
+    assert fake_client.last_call == ("eval_js", "document.title", 30)
+
+
+def test_eval_js_default_timeout_is_ten(fake_client):
+    # Arrange
+    # Act
+    scitex_hub.eval_js("1+1")
+    # Assert
+    assert fake_client.last_call == ("eval_js", "1+1", 10)
+
+
+def test_ui_action_passes_steps_and_delay(fake_client):
+    # Arrange
+    steps = [{"action": "click", "selector": "#go"}]
+    # Act
+    scitex_hub.ui_action(steps, delay_ms=200)
+    # Assert
+    assert fake_client.last_call == ("ui_action", steps, 200)
+
+
+def test_ui_action_default_delay_is_nine_hundred(fake_client):
+    # Arrange
+    # Act
+    scitex_hub.ui_action([])
+    # Assert
+    assert fake_client.last_call == ("ui_action", [], 900)
+
+
+# EOF

--- a/tests/scitex_hub/test_project_package.py
+++ b/tests/scitex_hub/test_project_package.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_hub/test_project_package.py
+
+"""Tests that ``scitex_hub.project`` is a package exposing CRUD plus the
+sandboxed MCP file-operation handlers.
+
+The umbrella ``scitex.project`` (and its ``_mcp.handlers``) re-export from here,
+so these import paths must remain stable.
+"""
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture
+def data_root(tmp_path):
+    """Point the handlers' sandbox root at a tmp dir; restore on teardown."""
+    from scitex_hub.project._mcp import handlers
+
+    original = handlers.ALLOWED_DATA_ROOT
+    handlers.ALLOWED_DATA_ROOT = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        handlers.ALLOWED_DATA_ROOT = original
+
+
+def test_project_crud_importable():
+    # Arrange
+    # Act
+    from scitex_hub.project import (
+        project_create,
+        project_delete,
+        project_list,
+        project_rename,
+    )
+
+    # Assert
+    assert all(
+        callable(fn)
+        for fn in (project_list, project_create, project_delete, project_rename)
+    )
+
+
+def test_mcp_handlers_importable():
+    # Arrange
+    # Act
+    from scitex_hub.project._mcp.handlers import (
+        exec_python_handler,
+        exec_shell_handler,
+        list_files_handler,
+        read_file_handler,
+        search_files_handler,
+        write_file_handler,
+    )
+
+    # Assert
+    assert all(
+        callable(fn)
+        for fn in (
+            list_files_handler,
+            read_file_handler,
+            write_file_handler,
+            search_files_handler,
+            exec_python_handler,
+            exec_shell_handler,
+        )
+    )
+
+
+def test_write_then_read_roundtrip(data_root):
+    # Arrange
+    from scitex_hub.project._mcp import handlers
+
+    project_dir = data_root / "alice" / "proj"
+    project_dir.mkdir(parents=True)
+    # Act
+    write_result = asyncio.run(
+        handlers.write_file_handler(str(project_dir), "notes.txt", "hello")
+    )
+    # Assert
+    assert write_result["success"] is True
+
+
+def test_read_returns_written_content(data_root):
+    # Arrange
+    from scitex_hub.project._mcp import handlers
+
+    project_dir = data_root / "bob" / "proj"
+    project_dir.mkdir(parents=True)
+    asyncio.run(handlers.write_file_handler(str(project_dir), "notes.txt", "hello"))
+    # Act
+    read_result = asyncio.run(handlers.read_file_handler(str(project_dir), "notes.txt"))
+    # Assert
+    assert read_result["content"] == "hello"
+
+
+def test_path_traversal_is_blocked(data_root):
+    # Arrange
+    from scitex_hub.project._mcp import handlers
+
+    project_dir = data_root / "carol" / "proj"
+    project_dir.mkdir(parents=True)
+    # Act
+    result = asyncio.run(
+        handlers.read_file_handler(str(project_dir), "../../../../etc/passwd")
+    )
+    # Assert
+    assert result["success"] is False
+
+
+# EOF


### PR DESCRIPTION
## Umbrella-thinning Phase A

Makes **scitex-hub** the complete owner of the cloud / module / project surfaces that the umbrella (`scitex.cloud`, `scitex.module`, `scitex.project`) currently delegates, so the umbrella can shrink to thin aliases.

### Cloud helpers
Added module-level `get_context`, `eval_js`, `ui_action` to the `scitex_hub` public API (wrapping `CloudClient`), mirroring the umbrella shim exactly. Importable as `from scitex_hub import get_context, eval_js, ui_action`; added to `__all__`.

### Project
Converted `project.py` → a `project/` package:
- `project/__init__.py` keeps the CRUD API (`project_list/create/delete/rename`).
- `project/_mcp/handlers.py` (new) holds the sandboxed file-operation handlers (`list_files_handler`, `read_file_handler`, `write_file_handler`, `search_files_handler`, `exec_python_handler`, `exec_shell_handler`) that the umbrella MCP imports.

New import path for the umbrella MCP to mount: `scitex_hub.project._mcp.handlers`.

### Module
No reconciliation needed. `scitex_hub.module` already exposes the full superset the umbrella callable requires (`module`, `INJECTED`, `ModuleManifest`, `ModuleOutput`, `ModuleOutputCollector`, `output`, `html`, `render_output`, `render_outputs`). The umbrella's 5 module files differed only in docstrings — behaviour is identical.

### Skills
Moved the umbrella's `cloud/_skills`, `module/_skills`, `project/_skills` `.md` files into `scitex_hub/_skills/` under `scitex-hub-cloud/`, `scitex-hub-module/`, `scitex-hub-project/` (numbered leaves + per-dir `SKILL.md`). Passes the ecosystem skill-quality checks.

### Tests
- `tests/scitex_hub/test_cloud_helpers.py` — import + delegation of the cloud helpers.
- `tests/scitex_hub/test_project_package.py` — `_mcp.handlers` import, write/read roundtrip, path-traversal block.

All 18 new tests pass; existing `scitex_hub` package tests (config, scitex_cloud shim) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)