### PR TITLE
test(deps): add pytest-cov to [dev] (fixes Codecov matrix --cov error)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ dev = [
     "black>=23.0",
     "ruff>=0.1.0",
     "pytest>=7.0",
+    "pytest-cov>=4.0",
     "figrecipe>=0.13.0",
     "joblib",
     "flask",


### PR DESCRIPTION
The pytest-matrix workflow runs `pytest tests/ --cov=src/scitex_hub ...` and installs `.[all,dev]`, but `pytest-cov` was not declared in any extra → `unrecognized arguments: --cov` (exit 4). Add `pytest-cov>=4.0` to `[dev]` next to pytest, matching scitex-dev/scitex-io. No addopts change (the --cov flag is on the workflow command line, not addopts). Codecov job only; release gate unaffected.