### PR TITLE
fix(ci): install [all,dev] not removed [django]/[test]/[docs] extras

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -52,7 +52,7 @@ jobs:
           node-version: '20'
 
       - name: Install Python dependencies
-        run: pip install -e ".[django,dev,test]"
+        run: pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
 
       - name: Install sibling workspace apps (scitex-ui, figrecipe)
         # package.json declares file:../scitex-ui and

--- a/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
+++ b/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install package + docs deps
-        run: pip install -e ".[docs]"
+        run: pip install -e ".[all]" || pip install -e ".[dev]" || pip install -e .
 
       - name: Build Sphinx HTML (warnings fail PRs only)
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install -e ".[django,dev,test]"
+        run: pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
 
       - name: Run terminal tests
         env:


### PR DESCRIPTION
## Problem
The django-standardization (ADR-0002 §5) flattened `[project.optional-dependencies]` into a single `[all]` extra (plus `[dev]`). Three CI workflows still installed the **removed** extras `[django]`, `[test]`, `[docs]`. pip silently drops nonexistent extras and under-installs, so runtime deps now living in `[all]` (e.g. `psutil`, used by `apps/workspace/console_app/services/project_service_manager.py`) were missing.

Result: the **Terminal Broker & Session Tests** job failed at collection with `ModuleNotFoundError: No module named 'psutil'` (exit 2), and the **E2E Mobile** + **docs** jobs were similarly under-installed.

## Fix
- `tests.yml`, `e2e-mobile.yml`: `.[django,dev,test]` → `.[all,dev]`
- `rtd-sphinx-build`: `.[docs]` → `.[all]`
- Mirror the release / pytest-matrix fallback chain (`|| .[dev] || .`) for robustness.

This unblocks the release pipeline (whose own gate already uses `.[all,dev]`).