### PR TITLE
fix(pytest): headless release gate — remove browser flags from global addopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,16 +208,16 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 DJANGO_SETTINGS_MODULE = "config.settings.settings_dev"
 norecursedirs = ["data", "docs", "scripts", "static", "deployment", "node_modules", ".git", "__pycache__", "*.egg-info", ".dev"]
+# Global addopts intentionally exclude browser/E2E flags
+# (--browser/--headed/--slowmo/--video/--screenshot). Those launch a
+# headed Playwright browser and break the headless release gate
+# (`pytest tests/ -x`). E2E tests are marked `@pytest.mark.e2e` and the
+# browser flags are passed explicitly by the "E2E Mobile Tests" workflow.
 addopts = [
     "--verbose",
     "--strict-markers",
     "--tb=short",
     "--capture=no",
-    "--browser=chromium",
-    "--headed",
-    "--slowmo=50",
-    "--video=retain-on-failure",
-    "--screenshot=only-on-failure",
 ]
 markers = [
     "e2e: End-to-end tests using browser automation",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,3 +214,46 @@ def cleanup_test_users():
             print(f"\n[Cleanup] Deleted {deleted_count} test user(s)")
     except Exception as e:
         print(f"\n[Cleanup] Skipped (DB not accessible): {e}")
+
+
+# =============================================================================
+# Headless release-gate guard
+# =============================================================================
+#
+# The global ``addopts`` in pyproject.toml no longer carry the Playwright
+# browser flags (``--browser``/``--headed``/``--slowmo``/``--video``/
+# ``--screenshot``). That keeps the release gate (``pytest tests/ -x``, run by
+# the pytest-matrix workflow in headless CI) from trying to launch a *headed*
+# browser. But pytest-playwright still launches a (headless) browser whenever
+# an E2E test that uses the ``page``/``browser`` fixtures is collected, so a
+# plain ``pytest tests/`` would still open a browser at run time.
+#
+# The "E2E Mobile Tests" workflow (e2e-mobile.yml) drives the browser tests
+# explicitly: it clears addopts with ``-o "addopts="`` and passes ``--browser``
+# (plus ``--headed=false --screenshot --video``) on the command line. We detect
+# that by checking whether ``--browser`` was supplied; when it was, the E2E
+# tests run untouched. Otherwise (the headless gate) we skip everything under
+# ``tests/e2e/`` and anything marked ``@pytest.mark.e2e``.
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip E2E/browser tests in the headless gate; run them when the
+    "E2E Mobile Tests" workflow passes ``--browser`` explicitly."""
+    browser_requested = False
+    try:
+        browser_requested = bool(config.getoption("--browser"))
+    except (ValueError, KeyError):
+        # pytest-playwright not installed → no --browser option → headless gate.
+        browser_requested = False
+    if browser_requested:
+        return
+
+    skip_e2e = pytest.mark.skip(
+        reason="E2E/browser test skipped in headless gate "
+        "(run via the 'E2E Mobile Tests' workflow with --browser)"
+    )
+    e2e_dir = os.sep + "e2e" + os.sep
+    for item in items:
+        path = str(getattr(item, "fspath", ""))
+        if "e2e" in item.keywords or e2e_dir in path:
+            item.add_marker(skip_e2e)


### PR DESCRIPTION
## Problem
The global `[tool.pytest.ini_options] addopts` carried `--browser=chromium --headed --slowmo=50 --video=retain-on-failure --screenshot=only-on-failure`. The release gate (`pytest tests/ -x`, run by the **pytest-matrix** workflow with `SCITEX_HUB_USE_SQLITE_DEV=1` and no `-o addopts=` override) inherited these and tried to launch a **headed** Playwright browser in headless CI, breaking the gate. (scitex-dev's DJ-503 audit rule flags exactly this.)

## Fix
- Remove the 5 browser/E2E flags from global `addopts`; keep `--verbose --strict-markers --tb=short --capture=no` (matches peer convention: scitex-io `-v --tb=short`, scitex-dev none).
- Add `pytest_collection_modifyitems` in `tests/conftest.py` that **skips** e2e-marked / `tests/e2e/` tests **unless `--browser` is passed** on the CLI — so a plain `pytest tests/` never opens a browser, even headless.

## E2E still runs
The "E2E Mobile Tests" workflow (`e2e-mobile.yml`) already clears addopts via `-o 'addopts='` and passes `--browser` + `--headed=false --screenshot --video` explicitly against `tests/e2e/playwright/*.py`. Because it passes `--browser`, the new conftest guard leaves those tests enabled. No workflow change was required.

## Verification
Locally, removing the flags + the guard means `pytest tests/` no longer launches a browser during collection/run. Remaining collection errors in the local sandbox are pre-existing **environment** issues (`scitex.session.INJECTED` requires `scitex-session`; not all deps installed locally) — NOT browser or addopts issues. CI installs `.[all,dev]`, where those imports resolve; CI on this PR is the authoritative re-check.