### PR TITLE
fix(tests): stop test_execution.py leaking stub django.conf (unblocks pytest-matrix)

### DIFF
--- a/tests/apps/console_app/views/terminal/test_execution.py
+++ b/tests/apps/console_app/views/terminal/test_execution.py
@@ -124,22 +124,24 @@ def _install_django_stubs_fixture():
 # the fixture we'd already have None on those names. The fixture is what
 # guards against cross-module leakage; this call just satisfies imports.
 #
-# CRITICAL (cross-module leak fix): capture the TRUE original sys.modules
-# entries *before* the import-time stub install, so the real modules are
-# restored once the module-under-test is imported (see restore block after
-# the imports below). Without this, the MagicMock `django.conf` stub leaked
-# into every later test file and broke the lazy `from django.conf import
-# STATICFILES_STORAGE_ALIAS` that Django's `storages_changed` signal runs,
-# producing ~1000 spurious errors across tests/apps/*.
+# CRITICAL (cross-module leak fix): capture the TRUE original `django` /
+# `django.conf` sys.modules entries *before* the import-time stub install,
+# so the real modules are restored once the module-under-test is imported
+# (see restore block after the imports below). Without this, the MagicMock
+# `django.conf` stub leaked into every later test file and broke the lazy
+# `from django.conf import STATICFILES_STORAGE_ALIAS` that Django's
+# `storages_changed` signal runs, producing ~1000 spurious errors across
+# tests/apps/*.
+#
+# NOTE: we deliberately restore ONLY the `django` keys. The local
+# `apps.workspace.console_app.views.terminal.{config,_command_builder}`
+# stubs are intentionally left installed — sibling tests in this directory
+# (e.g. test_config.py) import that stubbed `config` module and rely on it
+# being present in sys.modules. Those app-local stubs don't poison the
+# wider suite the way the MagicMock `django.conf` does.
 _STUB_KEYS = (
     "django",
     "django.conf",
-    "apps",
-    "apps.workspace.console_app",
-    "apps.workspace.console_app.views",
-    "apps.workspace.console_app.views.terminal",
-    "apps.workspace.console_app.views.terminal.config",
-    "apps.workspace.console_app.views.terminal._command_builder",
 )
 _ORIGINAL_MODULES = {k: sys.modules.get(k) for k in _STUB_KEYS}
 _install_django_stubs()

--- a/tests/apps/console_app/views/terminal/test_execution.py
+++ b/tests/apps/console_app/views/terminal/test_execution.py
@@ -123,6 +123,25 @@ def _install_django_stubs_fixture():
 # level (see imports below this comment), so by the time pytest collects
 # the fixture we'd already have None on those names. The fixture is what
 # guards against cross-module leakage; this call just satisfies imports.
+#
+# CRITICAL (cross-module leak fix): capture the TRUE original sys.modules
+# entries *before* the import-time stub install, so the real modules are
+# restored once the module-under-test is imported (see restore block after
+# the imports below). Without this, the MagicMock `django.conf` stub leaked
+# into every later test file and broke the lazy `from django.conf import
+# STATICFILES_STORAGE_ALIAS` that Django's `storages_changed` signal runs,
+# producing ~1000 spurious errors across tests/apps/*.
+_STUB_KEYS = (
+    "django",
+    "django.conf",
+    "apps",
+    "apps.workspace.console_app",
+    "apps.workspace.console_app.views",
+    "apps.workspace.console_app.views.terminal",
+    "apps.workspace.console_app.views.terminal.config",
+    "apps.workspace.console_app.views.terminal._command_builder",
+)
+_ORIGINAL_MODULES = {k: sys.modules.get(k) for k in _STUB_KEYS}
 _install_django_stubs()
 
 # ---------------------------------------------------------------------------
@@ -167,6 +186,20 @@ SlurmUnavailableError = _execution_mod.SlurmUnavailableError
 from apps.workspace.console_app.views.terminal.config import (  # noqa: E402
     parse_time_limit_seconds,
 )
+
+# Restore the real sys.modules entries now that the module-under-test is
+# imported (its references are already captured above). This prevents the
+# import-time stubs — especially the MagicMock `django.conf` — from leaking
+# into every later test module, which would otherwise break Django's lazy
+# `from django.conf import STATICFILES_STORAGE_ALIAS` (via the
+# storages_changed signal) and cascade ~1000 errors across tests/apps/*.
+# The autouse module-scoped fixture re-installs the stubs only for the
+# duration of THIS module's own tests.
+for _k, _v in _ORIGINAL_MODULES.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
 
 # ===========================================================================
 # Tests: check_slurm_status


### PR DESCRIPTION
## The dominant release-gate blocker

`pytest-matrix` (and the release gate) fails with ~1000 errors, almost all:
`ImportError: cannot import name 'STATICFILES_STORAGE_ALIAS' from 'django.conf' (unknown location)`.

**Root cause (full traceback in #183):** `tests/apps/console_app/views/terminal/test_execution.py` installs minimal `sys.modules` stubs — including a `MagicMock` `django.conf` — at **import time** so it can import the module-under-test without a running Django project, but never restored the real modules. From collection onward `sys.modules["django.conf"]` stays the stub for the whole session. Any later test that sets a Django setting via pytest-django fires the `storages_changed` signal, whose lazy `from django.conf import STATICFILES_STORAGE_ALIAS` then fails against the stub → cascade across `tests/apps/*`.

The module's own autouse fixture tried to guard this, but it captured state **after** the import-time stub already overwrote `django.conf`, so it "restored" the stub.

## Fix
Capture the **true** originals *before* the import-time stub install; restore them immediately after the module-under-test is imported. The autouse fixture still re-installs stubs for THIS module's own tests.

One file, +33 lines. Complements #184 (headless/e2e scoping) — both are needed to green the gate; this addresses the `tests/apps/*` cascade, #184 handles the browser/e2e tests.

## Caveat
This file still violates the ecosystem no-mock rule (STX-NM00x) and ideally gets rewritten mock-free as a follow-up; this PR is the minimal leak-stopper to unblock the release. **Not self-merging** — leaving the merge call to @ywatanabe1989 given it's in the standardization test lane.