### PR TITLE
test(conftest): close headless e2e-guard gap for out-of-tree browser tests (stacks #184)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,9 +236,40 @@ def cleanup_test_users():
 # ``tests/e2e/`` and anything marked ``@pytest.mark.e2e``.
 
 
+# Playwright fixtures that imply a real browser must be launched. Any test
+# requesting one of these would call ``BrowserType.launch`` at run time, which
+# crashes in the headless release gate where no browser executable is provided.
+# pytest-playwright provides ``page``/``browser``/``context``/``browser_context``
+# etc.; ``live_server`` (pytest-django) spins up a live HTTP server that these
+# browser tests target. Detecting the fixture names lets us catch browser tests
+# that live OUTSIDE ``tests/e2e/`` (e.g. ``tests/ui/...``) without having to mark
+# every file by hand.
+_BROWSER_FIXTURES = frozenset(
+    {
+        "page",
+        "browser",
+        "context",
+        "browser_context",
+        "browser_context_args",
+        "browser_type",
+        "browser_name",
+        "new_context",
+        "new_page",
+        "live_server",
+    }
+)
+
+
 def pytest_collection_modifyitems(config, items):
     """Skip E2E/browser tests in the headless gate; run them when the
-    "E2E Mobile Tests" workflow passes ``--browser`` explicitly."""
+    "E2E Mobile Tests" workflow passes ``--browser`` explicitly.
+
+    A test is treated as a browser test (and skipped in the headless gate) when
+    it lives under ``tests/e2e/``, is marked ``@pytest.mark.e2e``, OR requests a
+    Playwright/live-server fixture (``page``, ``browser``, ``live_server``, …).
+    The fixture check is what keeps a plain ``pytest tests/`` from launching a
+    browser for the browser-driven tests under ``tests/ui/``.
+    """
     browser_requested = False
     try:
         browser_requested = bool(config.getoption("--browser"))
@@ -255,5 +286,8 @@ def pytest_collection_modifyitems(config, items):
     e2e_dir = os.sep + "e2e" + os.sep
     for item in items:
         path = str(getattr(item, "fspath", ""))
-        if "e2e" in item.keywords or e2e_dir in path:
+        uses_browser_fixture = bool(
+            _BROWSER_FIXTURES.intersection(getattr(item, "fixturenames", ()))
+        )
+        if "e2e" in item.keywords or e2e_dir in path or uses_browser_fixture:
             item.add_marker(skip_e2e)


### PR DESCRIPTION
## Summary

Fixes the headless **e2e-guard gap** (Bug A) that blocked a plain `pytest tests/` release-gate run. **Stacks on top of #184** (branched from `fix/headless-pytest-addopts-v2`), so it contains #184's `tests/conftest.py` guard and extends it. Merge #184 first, or merge this and close #184 as superseded. PR-only; do **not** auto-merge.

## Bug A — incomplete e2e guard (FIXED)

#184 added a `pytest_collection_modifyitems` guard that skips `tests/e2e/` + `@pytest.mark.e2e` unless `--browser` is passed. But browser-launching tests **outside** `tests/e2e/` — all of `tests/ui/...` (`panel_resizer/test_drag_resize.py`, `test_persistence.py`, `test_toggle.py`, `test_workspace_files_tree.py`, plus `tests/ui/auth/`, `tests/ui/project/`, `tests/ui/scholar/`) — were still collected and crashed with `BrowserType.launch: Executable doesn't exist`.

**Fix:** extend the existing guard to also detect the pytest-playwright / pytest-django browser fixtures via `item.fixturenames` (`page`, `browser`, `context`, `browser_context`, `browser_type`, `browser_name`, `new_context`, `new_page`, `live_server`). Any item requesting one is treated like e2e (skipped unless `--browser`). Extending the single guard was preferred over marking dozens of files. The `E2E Mobile Tests` workflow passes `--browser` explicitly, so the guard returns early there and the tests stay enabled.

### Verification (project venv, headless, `-o addopts=""`)
- `pytest tests/ui` (no `--browser`): **100 skipped, 0 `BrowserType.launch` errors**; every skip fires the guard reason "E2E/browser test skipped in headless gate".
- `pytest tests/ui --browser chromium --collect-only`: **100 tests collected** (enabled, not skipped) — confirms `--browser` still drives them.

## Bug B — auth URL regression (NOT REPRODUCIBLE on this branch)

The task asked to fix `tests/integration/test_urls_smoke.py` (NoReverseMatch for `signin`/`signup`/`reset`/`signup_v2`) and `tests/integration/test_signin_smoke.py` (HTTP 500). **Neither file exists** on `fix/headless-pytest-addopts-v2` or on `develop` — `tests/integration/` contains only `__init__.py` and `test_cross_package_imports.py`. The strings `test_urls_smoke`, `test_signin_smoke`, and `signup_v2` have **zero matches** anywhere in the tree, and there is no `apps/authentication/` package (auth lives in `apps/infra/auth_app/`, namespace `auth_app`, mounted at `/auth/` in `config/urls.py`).

The auth routes are healthy on this branch: `auth_app:signin/signup/login/logout/forgot_password/reset_password` all reverse correctly (e.g. `auth_app:signin -> /auth/signin/`). There is no `reset` or `signup_v2` url name.

**Conclusion:** there is no auth-URL regression to fix here. The Bug B description appears to target a different / stale branch state. I did **not** invent the missing tests or rename real url names. Please point me at the exact branch/commit that exhibits the NoReverseMatch / HTTP 500, or confirm whether those smoke tests should be authored — I'll handle Bug B properly in a follow-up.

## Out of scope (left alone, as instructed)
- `STATICFILES_STORAGE_ALIAS` / Django dep-compat cluster (the project venv has **Django 6.0.5**, the source of that held cluster — flagged for awareness, not touched).
- No merge / tag / release / version bump.
