### PR TITLE
test: add django_db markers to DB-touching tests

### DIFF
--- a/tests/apps/public_app/test_api_docs_config.py
+++ b/tests/apps/public_app/test_api_docs_config.py
@@ -35,9 +35,9 @@ class TestAPIDocSections:
     def test_section_order_matches_sections(self):
         """All sections in order list must exist in sections dict."""
         for key in API_DOC_SECTION_ORDER:
-            assert (
-                key in API_DOC_SECTIONS
-            ), f"Section {key} in order but not in sections"
+            assert key in API_DOC_SECTIONS, (
+                f"Section {key} in order but not in sections"
+            )
 
     def test_all_sections_in_order(self):
         """All sections must be in the order list."""
@@ -95,6 +95,7 @@ def client():
     return Client()
 
 
+@pytest.mark.django_db
 class TestAPIDocURLs:
     """Test API documentation URL generation."""
 
@@ -102,9 +103,9 @@ class TestAPIDocURLs:
         """Each section URL should return 200."""
         for key in API_DOC_SECTION_ORDER:
             response = client.get(f"/docs/web-api/{key}/")
-            assert (
-                response.status_code == 200
-            ), f"Section {key} returned {response.status_code}"
+            assert response.status_code == 200, (
+                f"Section {key} returned {response.status_code}"
+            )
 
     def test_main_api_docs_url(self, client):
         """Main API docs URL should return 200."""
@@ -189,9 +190,9 @@ class TestCampaignTokens:
         assert result["hashtag"] == "alpha"
         assert result["legacy_format"] is True
         # No silent fallback: a DeprecationWarning must be emitted.
-        assert any(
-            issubclass(w.category, DeprecationWarning) for w in caught
-        ), "legacy prefix should emit DeprecationWarning"
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught), (
+            "legacy prefix should emit DeprecationWarning"
+        )
 
     def test_is_valid_campaign_token_accepts_legacy_alias(self):
         """is_valid_campaign_token should accept the legacy alias too."""

--- a/tests/apps/public_app/views/test_pages.py
+++ b/tests/apps/public_app/views/test_pages.py
@@ -75,9 +75,9 @@ class TestVideoCatalogStructure:
         assert match, "OG_BASE_URL not found in pages_data.py"
         og_base_url = match.group(1)
 
-        assert og_base_url.startswith(
-            "https://"
-        ), f"OG_BASE_URL should be HTTPS: {og_base_url}"
+        assert og_base_url.startswith("https://"), (
+            f"OG_BASE_URL should be HTTPS: {og_base_url}"
+        )
         assert "scitex.ai" in og_base_url
 
     def test_video_catalog_structure(self):
@@ -135,6 +135,7 @@ class TestVideoCatalogStructure:
 
 
 @pytest.mark.skipif(not DJANGO_AVAILABLE, reason="Django not available")
+@pytest.mark.django_db
 class TestVideoPlayerView:
     """Test video_player view function (requires Django)."""
 
@@ -250,9 +251,9 @@ class TestVideoPlayerIntegration:
         assert match, "og:image meta tag not found"
 
         og_image_url = match.group(1)
-        assert og_image_url.startswith(
-            "https://"
-        ), f"OG image should be HTTPS: {og_image_url}"
+        assert og_image_url.startswith("https://"), (
+            f"OG image should be HTTPS: {og_image_url}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The pytest-matrix CI job fails with ~18 occurrences of:

```
RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
```

These come from tests that exercise Django views (rendering templates that query the DB) but lack the `django_db` marker.

## Identification

Extracted the authoritative pytest short-summary lines from the latest failing develop run (`gh run view 26712729565 --log-failed`), filtering FAILED lines whose error is exactly the "Database access not allowed" RuntimeError. That yielded 6 unique tests across 2 modules / 2 classes:

- `tests/apps/public_app/test_api_docs_config.py::TestAPIDocURLs` (3 tests) — uses the Django `client` fixture to GET `/docs/web-api/...`.
- `tests/apps/public_app/views/test_pages.py::TestVideoPlayerView` (3 tests) — calls `video_player(request, ...)` which `render()`s a template touching the DB.

Other failures in the same run (FileNotFoundError for `pages_data.py`, vite entry/AttributeError) are unrelated and handled elsewhere.

## Fix

Added a per-class `@pytest.mark.django_db` marker to **only** the two classes that actually access the DB. Config/parsing-only classes (`TestAPIDocSections`, `TestCampaignTokens`, `TestVideoCatalogStructure`) are intentionally left unmarked. `TestVideoPlayerIntegration` already had the marker.

No mocks introduced (STX-NM00x compliant).

## Note

The test DB currently fails to build due to a separate manuscript-migration bug fixed in a sibling PR, so local runs may still error on DB setup. CI will verify once both PRs merge.