### PR TITLE
fix(writer_app/migrations): repair manuscript field/index ordering (test-DB setup)

### DIFF
--- a/apps/workspace/writer_app/migrations/0007_remove_collaborativeedit_manuscript_and_more.py
+++ b/apps/workspace/writer_app/migrations/0007_remove_collaborativeedit_manuscript_and_more.py
@@ -4,12 +4,37 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("writer_app", "0006_collaborationinvitation"),
     ]
 
     operations = [
+        # Drop indexes / unique_together that reference the fields being removed
+        # BEFORE removing those fields. On SQLite every RemoveField triggers a
+        # full table remake which rebuilds the model's indexes from the current
+        # model state; if a manuscript/session index is still declared at that
+        # point, _model_indexes_sql calls options.get_field('manuscript') on a
+        # field that no longer exists -> KeyError: 'manuscript'.
+        migrations.RemoveIndex(
+            model_name="collaborativeedit",
+            name="writer_app__manuscr_98b4a0_idx",
+        ),
+        migrations.RemoveIndex(
+            model_name="collaborativeedit",
+            name="writer_app__session_5175fe_idx",
+        ),
+        migrations.AlterUniqueTogether(
+            name="collaborationinvitation",
+            unique_together=None,
+        ),
+        migrations.RemoveIndex(
+            model_name="collaborationinvitation",
+            name="writer_app__manuscr_7a7459_idx",
+        ),
+        migrations.RemoveIndex(
+            model_name="collaborationinvitation",
+            name="writer_app__invited_5b1353_idx",
+        ),
         migrations.RemoveField(
             model_name="collaborativeedit",
             name="manuscript",


### PR DESCRIPTION
## Problem

Running the test suite creates the test DB via pytest-django's migrate under SQLite (`SCITEX_HUB_USE_SQLITE_DEV=1`), which failed with ~170 errors, all rooted in:

```
KeyError: 'manuscript'
  ... SQLite _remake_table -> create_model -> _model_indexes_sql
      -> options.get_field('manuscript')
```

This broke test-DB setup for the **entire** suite (all `tests/apps/*`), not just writer_app.

## Root cause

Migration `0007_remove_collaborativeedit_manuscript_and_more` removed `CollaborativeEdit.manuscript`/`session` and deleted `CollaborativeEdit` + `CollaborationInvitation`, but it never first dropped the indexes / unique_together that referenced those fields:

- `CollaborativeEdit` (from 0005) had `Index(fields=['manuscript','section_id','version'])` and `Index(fields=['session','created_at'])`.
- `CollaborationInvitation` (from 0006) had two manuscript-referencing indexes and `unique_together {('manuscript','invited_email'),('manuscript','invited_user')}`.

On SQLite every `RemoveField` triggers a full table remake. The remake rebuilds the model's indexes from the **current** model state via `_model_indexes_sql`, which calls `options.get_field('manuscript')` on a field the same migration is removing -> `KeyError: 'manuscript'`.

## Fix

Drop the manuscript/session-referencing indexes and the `CollaborationInvitation` unique_together **before** the `RemoveField` operations, so the forward migration is internally consistent on SQLite. Minimal, no squash. Final model state is unchanged (both models are deleted in this migration).