### PR TITLE
fix(tests): resolve umbrella-absorb (#181) Phase A fallout

### DIFF
--- a/config/settings/settings_shared.py
+++ b/config/settings/settings_shared.py
@@ -231,7 +231,11 @@ REDIS_URL = os.getenv("SCITEX_HUB_REDIS_URL", "redis://127.0.0.1:6379/1")
 try:
     import redis as _redis
 
-    _r = _redis.from_url(REDIS_URL)
+    # Short, explicit timeouts so an unreachable / unanswered Redis fails
+    # fast and we fall back to local cache, instead of blocking settings
+    # import (and therefore django.setup()) on a hanging TCP connect — e.g.
+    # under WSL2 where a closed port may hang rather than refuse.
+    _r = _redis.from_url(REDIS_URL, socket_connect_timeout=0.5, socket_timeout=0.5)
     _r.ping()
     CACHES = {
         "default": {
@@ -261,7 +265,9 @@ try:
     import redis as _redis2
 
     _redis_url2 = os.getenv("SCITEX_HUB_REDIS_URL", "redis://127.0.0.1:6379/2")
-    _redis2.from_url(_redis_url2).ping()
+    # Same fast-fail timeouts as the cache probe above — never block
+    # settings import on an unreachable Redis.
+    _redis2.from_url(_redis_url2, socket_connect_timeout=0.5, socket_timeout=0.5).ping()
     CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels_redis.core.RedisChannelLayer",

--- a/templates/global_base_partials/global_body_scripts.html
+++ b/templates/global_base_partials/global_body_scripts.html
@@ -78,7 +78,5 @@
 {% vite_script 'shared/components/nav-prefetch' %}
 <!-- Mobile Notice Banner Dismiss -->
 {% vite_script 'shared/utils/mobile-notice' %}
-<!-- Mobile Gestures (swipe right from edge → open sidebar, left → close) -->
-{% vite_script 'scitex_ui/shell/sidebar-drawer-gesture' %}
 <!-- Dev App Install/Uninstall (Hub Explore + Apps browse) -->
 {% vite_script 'apps_app/dev-install' %}

--- a/tests/apps/public_app/test_api_docs_config.py
+++ b/tests/apps/public_app/test_api_docs_config.py
@@ -35,9 +35,9 @@ class TestAPIDocSections:
     def test_section_order_matches_sections(self):
         """All sections in order list must exist in sections dict."""
         for key in API_DOC_SECTION_ORDER:
-            assert (
-                key in API_DOC_SECTIONS
-            ), f"Section {key} in order but not in sections"
+            assert key in API_DOC_SECTIONS, (
+                f"Section {key} in order but not in sections"
+            )
 
     def test_all_sections_in_order(self):
         """All sections must be in the order list."""
@@ -95,16 +95,22 @@ def client():
     return Client()
 
 
+@pytest.mark.django_db
 class TestAPIDocURLs:
-    """Test API documentation URL generation."""
+    """Test API documentation URL generation.
+
+    These hit the API-docs views through the Django test client; rendering
+    runs the ``project_context`` context processor, which queries the
+    ``User`` table, so DB access (``django_db``) is required.
+    """
 
     def test_section_urls_are_valid(self, client):
         """Each section URL should return 200."""
         for key in API_DOC_SECTION_ORDER:
             response = client.get(f"/docs/web-api/{key}/")
-            assert (
-                response.status_code == 200
-            ), f"Section {key} returned {response.status_code}"
+            assert response.status_code == 200, (
+                f"Section {key} returned {response.status_code}"
+            )
 
     def test_main_api_docs_url(self, client):
         """Main API docs URL should return 200."""
@@ -189,9 +195,9 @@ class TestCampaignTokens:
         assert result["hashtag"] == "alpha"
         assert result["legacy_format"] is True
         # No silent fallback: a DeprecationWarning must be emitted.
-        assert any(
-            issubclass(w.category, DeprecationWarning) for w in caught
-        ), "legacy prefix should emit DeprecationWarning"
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught), (
+            "legacy prefix should emit DeprecationWarning"
+        )
 
     def test_is_valid_campaign_token_accepts_legacy_alias(self):
         """is_valid_campaign_token should accept the legacy alias too."""

--- a/tests/apps/public_app/views/test_pages.py
+++ b/tests/apps/public_app/views/test_pages.py
@@ -45,7 +45,7 @@ class TestVideoCatalogStructure:
             "pages_data",
             os.path.join(
                 os.path.dirname(__file__),
-                "../../../../apps/public_app/views/pages_data.py",
+                "../../../../apps/infra/public_app/views/pages_data.py",
             ),
         )
         # We need to mock the pages_shortcuts import
@@ -61,7 +61,7 @@ class TestVideoCatalogStructure:
         # Now manually parse the file to extract OG_BASE_URL
         pages_data_path = os.path.join(
             os.path.dirname(__file__),
-            "../../../../apps/public_app/views/pages_data.py",
+            "../../../../apps/infra/public_app/views/pages_data.py",
         )
         pages_data_path = os.path.abspath(pages_data_path)
 
@@ -75,9 +75,9 @@ class TestVideoCatalogStructure:
         assert match, "OG_BASE_URL not found in pages_data.py"
         og_base_url = match.group(1)
 
-        assert og_base_url.startswith(
-            "https://"
-        ), f"OG_BASE_URL should be HTTPS: {og_base_url}"
+        assert og_base_url.startswith("https://"), (
+            f"OG_BASE_URL should be HTTPS: {og_base_url}"
+        )
         assert "scitex.ai" in og_base_url
 
     def test_video_catalog_structure(self):
@@ -87,7 +87,7 @@ class TestVideoCatalogStructure:
         # Parse the file to extract VIDEO_CATALOG structure
         pages_data_path = os.path.join(
             os.path.dirname(__file__),
-            "../../../../apps/public_app/views/pages_data.py",
+            "../../../../apps/infra/public_app/views/pages_data.py",
         )
         pages_data_path = os.path.abspath(pages_data_path)
 
@@ -118,7 +118,7 @@ class TestVideoCatalogStructure:
         """Thumbnails should be PNG files."""
         pages_data_path = os.path.join(
             os.path.dirname(__file__),
-            "../../../../apps/public_app/views/pages_data.py",
+            "../../../../apps/infra/public_app/views/pages_data.py",
         )
         pages_data_path = os.path.abspath(pages_data_path)
 
@@ -135,8 +135,15 @@ class TestVideoCatalogStructure:
 
 
 @pytest.mark.skipif(not DJANGO_AVAILABLE, reason="Django not available")
+@pytest.mark.django_db
 class TestVideoPlayerView:
-    """Test video_player view function (requires Django)."""
+    """Test video_player view function (requires Django).
+
+    Rendering the video-player template runs the ``project_context``
+    context processor, which performs a ``User.objects.get(...)`` query.
+    Even though the view itself is called directly via RequestFactory,
+    that DB access requires the ``django_db`` mark.
+    """
 
     @pytest.fixture
     def rf(self):
@@ -250,9 +257,9 @@ class TestVideoPlayerIntegration:
         assert match, "og:image meta tag not found"
 
         og_image_url = match.group(1)
-        assert og_image_url.startswith(
-            "https://"
-        ), f"OG image should be HTTPS: {og_image_url}"
+        assert og_image_url.startswith("https://"), (
+            f"OG image should be HTTPS: {og_image_url}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/scitex_hub/test_appmaker_api.py
+++ b/tests/scitex_hub/test_appmaker_api.py
@@ -17,16 +17,17 @@ class TestRegistryManifestLoading:
         from apps.infra.workspace_app.registry import get_all_modules
 
         modules = get_all_modules()
-        assert len(modules) == 10
+        assert len(modules) == 12
 
     def test_module_names(self):
         from apps.infra.workspace_app.registry import get_module_names
 
         names = get_module_names()
+        # Unique module names. There are 12 registered modules but two share
+        # the "tools" name (apps_app + tools_app), so the unique-name set has 11.
         expected = {
             "writer",
             "scholar",
-            "vis",
             "clew",
             "home",
             "tools",
@@ -34,6 +35,8 @@ class TestRegistryManifestLoading:
             "docs",
             "figrecipe",
             "discovery",
+            "comms",
+            "console",
         }
         assert names == expected
 
@@ -64,12 +67,12 @@ class TestRegistryManifestLoading:
         for rel_path in _BUILTIN_MANIFEST_PATHS:
             path = _APPS_ROOT / rel_path
             data = json.loads(path.read_text())
-            assert (
-                data.get("$schema") == "scitex-app-manifest"
-            ), f"{rel_path} missing $schema"
-            assert (
-                data.get("$schema_version") == "1.0.0"
-            ), f"{rel_path} missing $schema_version"
+            assert data.get("$schema") == "scitex-app-manifest", (
+                f"{rel_path} missing $schema"
+            )
+            assert data.get("$schema_version") == "2.0.0", (
+                f"{rel_path} missing $schema_version"
+            )
 
 
 class TestInitAppRename:
@@ -116,7 +119,7 @@ class TestAppManagementAPI:
         from scitex_hub.appmaker import list_all
 
         apps = list_all()
-        assert len(apps) == 10
+        assert len(apps) == 12
         names = {a["name"] for a in apps}
         assert "writer" in names
         assert "scholar" in names

--- a/tests/scitex_hub/test_cli.py
+++ b/tests/scitex_hub/test_cli.py
@@ -38,11 +38,16 @@ class TestMainCLI:
 
 
 class TestSetupCommand:
-    """Tests for setup command."""
+    """Tests for setup-environment command.
+
+    Per noun-verb CLI convention (§5), the bare ``setup`` leaf was renamed
+    to ``setup-environment``; bare ``setup`` is now a hidden deprecation
+    redirect. The real options live under the canonical name.
+    """
 
     def test_setup_help(self, runner):
-        """Test setup --help."""
-        result = runner.invoke(main, ["setup", "--help"])
+        """Test setup-environment --help."""
+        result = runner.invoke(main, ["setup-environment", "--help"])
         assert result.exit_code == 0
         assert "--env" in result.output
         assert "dev" in result.output
@@ -50,11 +55,11 @@ class TestSetupCommand:
 
 
 class TestDeployCommand:
-    """Tests for deploy command."""
+    """Tests for deploy-project command (renamed from bare ``deploy``)."""
 
     def test_deploy_help(self, runner):
-        """Test deploy --help."""
-        result = runner.invoke(main, ["deploy", "--help"])
+        """Test deploy-project --help."""
+        result = runner.invoke(main, ["deploy-project", "--help"])
         assert result.exit_code == 0
         assert "--env" in result.output
         assert "--build" in result.output
@@ -80,21 +85,21 @@ class TestDockerCommand:
 
 
 class TestStatusCommand:
-    """Tests for status command."""
+    """Tests for show-status command (renamed from bare ``status``)."""
 
     def test_status_help(self, runner):
-        """Test status --help."""
-        result = runner.invoke(main, ["status", "--help"])
+        """Test show-status --help."""
+        result = runner.invoke(main, ["show-status", "--help"])
         assert result.exit_code == 0
         assert "--env" in result.output
 
 
 class TestLogsCommand:
-    """Tests for logs command."""
+    """Tests for show-logs command (renamed from bare ``logs``)."""
 
     def test_logs_help(self, runner):
-        """Test logs --help."""
-        result = runner.invoke(main, ["logs", "--help"])
+        """Test show-logs --help."""
+        result = runner.invoke(main, ["show-logs", "--help"])
         assert result.exit_code == 0
         assert "--follow" in result.output
         assert "--tail" in result.output
@@ -112,11 +117,24 @@ class TestGiteaCommand:
         assert "list" in result.output
 
     def test_gitea_subcommands_help(self, runner):
-        """Test gitea subcommands have help."""
-        subcommands = ["clone", "create", "list", "search", "push", "pull", "status"]
+        """Test gitea subcommands have help.
+
+        The bare ``status`` leaf was renamed to ``show-status`` under the
+        noun-verb CLI convention; the remaining repository/sync leaves are
+        unchanged and still live directly under ``gitea``.
+        """
+        subcommands = [
+            "clone",
+            "create",
+            "list",
+            "search",
+            "push",
+            "pull",
+            "show-status",
+        ]
         for cmd in subcommands:
             result = runner.invoke(main, ["gitea", cmd, "--help"])
-            assert result.exit_code == 0
+            assert result.exit_code == 0, f"gitea {cmd} failed"
 
 
 class TestMcpCommand:

--- a/tests/unit/services/test_health_checks.py
+++ b/tests/unit/services/test_health_checks.py
@@ -9,7 +9,6 @@ NAS bind mount permission issues.
 
 import os
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -31,22 +30,12 @@ class TestUserDataPermissions:
         proj_dir.mkdir()
 
         status_data = {}
-        with patch(
-            "apps.infra.public_app.views.status.health_checks.Path"
-        ) as mock_path:
-            mock_path.return_value = users_dir
-            # Actually use the real path for iteration
-            with patch.object(
-                Path,
-                "__new__",
-                lambda cls, *args: (
-                    users_dir
-                    if args and args[0] == "/app/data/users"
-                    else Path.__new__(cls)
-                ),
-            ):
-                # Direct test with tmp_path
-                check_user_data_permissions_with_path(status_data, users_dir)
+        # Call the path-injectable helper directly with the tmp_path tree —
+        # the same pattern the sibling tests use. (The previous version patched
+        # ``Path.__new__`` with a lambda whose fallback called ``Path.__new__``
+        # again — now the patched object — recursing infinitely as ``iterdir()``
+        # built child paths.)
+        check_user_data_permissions_with_path(status_data, users_dir)
 
         assert status_data["user_data_permissions"]["is_healthy"] is True
         assert status_data["user_data_permissions"]["health_class"] == "healthy"


### PR DESCRIPTION
## Summary

Fixes the pre-existing test failures that surfaced after the umbrella-absorb (#181, Phase A). All are unrelated to the manuscript/migration bug (handled by a separate PR). Real fixes only — no mocks, skips, or xfail.

## Root causes & fixes

### Settings hang (was blocking ALL `tests/apps/*` collection)
`config/settings/settings_shared.py` ran a Redis `.ping()` at settings-import time with **no socket timeout**. On a host where the Redis port is unreachable-but-not-refused (e.g. WSL2), the ping blocks forever, hanging `django.setup()` and therefore collection of every app test. Added `socket_connect_timeout=0.5` / `socket_timeout=0.5` to both `.ping()` probes so they fail fast and fall back to local cache as the surrounding `try/except` already intends.

### Cluster: `test_appmaker_api.py` — stale assertions (behaviour intentionally changed in #181)
- registry `get_all_modules()` / `list_all()`: **10 → 12** (`apps_app`→`comms`, `console_app`→`console` were added).
- `get_module_names()`: removed non-existent `vis`; the unique-name set is **11** (`tools` is shared by `apps_app` + `tools_app`, so 12 modules → 11 unique names), added `comms`/`console`.
- manifest `$schema_version`: **1.0.0 → 2.0.0** (uniform across all 12 manifests).
- Verified against the live registry before editing.

### Cluster: `test_cli.py` — stale assertions (noun-verb CLI rename in #181)
- `setup`/`deploy`/`status`/`logs` are now **hidden deprecation-redirect stubs**; the real options moved to `setup-environment` / `deploy-project` / `show-status` / `show-logs`. Tests invoke the canonical names.
- `gitea`: bare `status` leaf renamed to `show-status`; subcommand list updated to the real flat command set.

### Cluster: `public_app` tests
- `test_pages.py`: fixed **wrong relative path** — `pages_data.py` lives at `apps/infra/public_app/views/`, not `apps/public_app/views/` (apps were reorganised under `apps/infra/`). 3 `FileNotFoundError`s → green.
- `test_pages.py` `TestVideoPlayerView` + `test_api_docs_config.py` `TestAPIDocURLs`: added `@pytest.mark.django_db`. Rendering these views runs the `project_context` processor (`User.objects.get`), which needs DB access even when the view is called via `RequestFactory`.

### Cluster: isolated
- `templates/.../global_body_scripts.html`: removed a **dead `vite_script` reference** to `scitex_ui/shell/sidebar-drawer-gesture` — the TS asset exists nowhere in the repo (there is no `scitex_ui/` dir), so it would 404 at runtime and broke the vite entry-resolution test.
- `test_health_checks.py::test_healthy_permissions`: fixed a **RecursionError in the test itself** — it patched `Path.__new__` with a lambda whose fallback called `Path.__new__` (now the patched object), recursing infinitely as `iterdir()` built child paths. The patch was unnecessary; the helper is path-injectable, so it's now called directly like its sibling tests. Dropped the now-unused `unittest.mock` import (also satisfies the no-mock rule).

## Verification
With the hub venv (Django 6.0.5) and SQLite CI env, the fixed non-DB tests are green:

```
213 passed, 2 warnings
```
(cloud_helpers, project_package, appmaker_api, cli, video-catalog-structure, vite, health_checks)

## Out of scope (NOT fixed here)
- **`@pytest.mark.django_db`-marked tests** (`TestVideoPlayerView`, `TestAPIDocURLs`, `TestVideoPlayerIntegration`): now correctly marked, but **blocked-on-migration** — test-DB setup hangs on the separate manuscript/migration bug. They'll pass once that lands.
- **`tests/develop/test_audit.py::test_audit_all_clean`**: red due to a **large pre-existing repo-wide backlog unrelated to #181** — 2,647 `PA-307 §3 test-quality` + 74 `PA-306 §3 no-mocks` + a few §5/§6 MCP-surface violations (2,723 total). This is the existing test-quality / mock debt and the MCP tool-parity gap, not absorb fallout; deliberately **not** masked by adding rules to the audit skip-list (that would hide real debt).
