### PR TITLE
fix(tests): consolidate v0.18.1 release-gate fixes (supersedes #187-#195)

### DIFF
--- a/apps/infra/llm_app/views/chat.py
+++ b/apps/infra/llm_app/views/chat.py
@@ -1,5 +1,6 @@
 import json
 
+from channels.layers import get_channel_layer
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.http import HttpResponse, JsonResponse
@@ -114,8 +115,6 @@ def api_tts_relay(request):
     browser can call ``/llm/api/tts/`` and play audio through speakers.
     """
     import logging
-
-    from channels.layers import get_channel_layer
 
     logger = logging.getLogger(__name__)
 

--- a/apps/infra/project_app/services/demo_project_pool.py
+++ b/apps/infra/project_app/services/demo_project_pool.py
@@ -18,8 +18,10 @@ import logging
 import secrets
 from datetime import timedelta
 from typing import Optional, Tuple
-from django.utils import timezone
+
 from django.contrib.auth.models import User
+from django.utils import timezone
+
 from apps.infra.project_app.models import Project
 
 logger = logging.getLogger(__name__)
@@ -150,7 +152,7 @@ class VisitorPool:
         )
 
         manager = get_project_filesystem_manager(demo_user)
-        success, project_path = manager.create_empty_project_directory(project)
+        success, project_path = manager.create_project_directory(project)
 
         if not success:
             logger.error(

--- a/apps/workspace/apps_app/migrations/0009_alter_modulesubmission_status_appsmodule_and_more.py
+++ b/apps/workspace/apps_app/migrations/0009_alter_modulesubmission_status_appsmodule_and_more.py
@@ -1,6 +1,6 @@
 """Rename MarketplaceModule to AppsModule (state only) and widen submission status field.
 
-The actual DB table is marketplace_app_marketplacemodule (pinned in 0006).
+The actual DB table is apps_app_marketplacemodule (pinned in 0006).
 We only need to update Django's internal state so the model name matches the code.
 """
 
@@ -8,14 +8,13 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("apps_app", "0008_rename_marketplace_to_apps_module_name"),
     ]
 
     operations = [
         # 1. Rename MarketplaceModule -> AppsModule in Django state only
-        #    (the actual DB table stays marketplace_app_marketplacemodule)
+        #    (the actual DB table stays apps_app_marketplacemodule)
         migrations.SeparateDatabaseAndState(
             state_operations=[
                 migrations.RenameModel(

--- a/apps/workspace/apps_app/models.py
+++ b/apps/workspace/apps_app/models.py
@@ -118,7 +118,7 @@ class AppsModule(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
-        db_table = "marketplace_app_marketplacemodule"
+        db_table = "apps_app_marketplacemodule"
         ordering = ["-star_count", "-install_count"]
         verbose_name = "App"
 
@@ -168,7 +168,7 @@ class ModuleVersion(models.Model):
     released_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
-        db_table = "marketplace_app_moduleversion"
+        db_table = "apps_app_moduleversion"
         unique_together = ("module", "version")
         ordering = ["-released_at"]
         verbose_name = "App Version"
@@ -192,7 +192,7 @@ class ModuleInstallation(models.Model):
     config = models.JSONField(default=dict, blank=True)
 
     class Meta:
-        db_table = "marketplace_app_moduleinstallation"
+        db_table = "apps_app_moduleinstallation"
         unique_together = ("user", "module")
         ordering = ["tab_order"]
         verbose_name = "App Installation"
@@ -214,7 +214,7 @@ class ModuleStar(models.Model):
     starred_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
-        db_table = "marketplace_app_modulestar"
+        db_table = "apps_app_modulestar"
         unique_together = ("user", "module")
         ordering = ["-starred_at"]
 
@@ -255,7 +255,7 @@ class ModuleSubmission(models.Model):
     reviewed_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
-        db_table = "marketplace_app_modulesubmission"
+        db_table = "apps_app_modulesubmission"
         ordering = ["-submitted_at"]
         verbose_name = "App Submission"
 
@@ -282,7 +282,7 @@ class ModuleReview(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
-        db_table = "marketplace_app_modulereview"
+        db_table = "apps_app_modulereview"
         unique_together = ("user", "module")
         ordering = ["-created_at"]
         verbose_name = "App Review"

--- a/apps/workspace/console_app/views/terminal/config.py
+++ b/apps/workspace/console_app/views/terminal/config.py
@@ -9,6 +9,14 @@ from pathlib import Path
 from django.conf import settings
 
 # =============================================================================
+# Terminal MOTD (Message of the Day)
+# =============================================================================
+# Defined first so that a partial module (re)load — e.g. if a later
+# environment-dependent assignment raises — never leaves this name undefined.
+SHOW_MOTD = os.environ.get("SCITEX_HUB_SHOW_MOTD", "true").lower() != "false"
+
+
+# =============================================================================
 # Container Configuration
 # =============================================================================
 
@@ -123,12 +131,6 @@ def parse_time_limit_seconds(time_str: str) -> int:
 
 
 SLURM_TIME_LIMIT_SECONDS = parse_time_limit_seconds(SLURM_TIME_LIMIT)
-
-
-# =============================================================================
-# Terminal MOTD (Message of the Day)
-# =============================================================================
-SHOW_MOTD = os.environ.get("SCITEX_HUB_SHOW_MOTD", "true").lower() != "false"
 
 
 # EOF

--- a/apps/workspace/writer_app/migrations/0007_remove_collaborativeedit_manuscript_and_more.py
+++ b/apps/workspace/writer_app/migrations/0007_remove_collaborativeedit_manuscript_and_more.py
@@ -4,12 +4,37 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("writer_app", "0006_collaborationinvitation"),
     ]
 
     operations = [
+        # Drop indexes / unique_together that reference the fields being removed
+        # BEFORE removing those fields. On SQLite every RemoveField triggers a
+        # full table remake which rebuilds the model's indexes from the current
+        # model state; if a manuscript/session index is still declared at that
+        # point, _model_indexes_sql calls options.get_field('manuscript') on a
+        # field that no longer exists -> KeyError: 'manuscript'.
+        migrations.RemoveIndex(
+            model_name="collaborativeedit",
+            name="writer_app__manuscr_98b4a0_idx",
+        ),
+        migrations.RemoveIndex(
+            model_name="collaborativeedit",
+            name="writer_app__session_5175fe_idx",
+        ),
+        migrations.AlterUniqueTogether(
+            name="collaborationinvitation",
+            unique_together=None,
+        ),
+        migrations.RemoveIndex(
+            model_name="collaborationinvitation",
+            name="writer_app__manuscr_7a7459_idx",
+        ),
+        migrations.RemoveIndex(
+            model_name="collaborationinvitation",
+            name="writer_app__invited_5b1353_idx",
+        ),
         migrations.RemoveField(
             model_name="collaborativeedit",
             name="manuscript",

--- a/config/settings/settings_shared.py
+++ b/config/settings/settings_shared.py
@@ -231,7 +231,11 @@ REDIS_URL = os.getenv("SCITEX_HUB_REDIS_URL", "redis://127.0.0.1:6379/1")
 try:
     import redis as _redis
 
-    _r = _redis.from_url(REDIS_URL)
+    # Short, explicit timeouts so an unreachable / unanswered Redis fails
+    # fast and we fall back to local cache, instead of blocking settings
+    # import (and therefore django.setup()) on a hanging TCP connect — e.g.
+    # under WSL2 where a closed port may hang rather than refuse.
+    _r = _redis.from_url(REDIS_URL, socket_connect_timeout=0.5, socket_timeout=0.5)
     _r.ping()
     CACHES = {
         "default": {
@@ -261,7 +265,9 @@ try:
     import redis as _redis2
 
     _redis_url2 = os.getenv("SCITEX_HUB_REDIS_URL", "redis://127.0.0.1:6379/2")
-    _redis2.from_url(_redis_url2).ping()
+    # Same fast-fail timeouts as the cache probe above — never block
+    # settings import on an unreachable Redis.
+    _redis2.from_url(_redis_url2, socket_connect_timeout=0.5, socket_timeout=0.5).ping()
     CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels_redis.core.RedisChannelLayer",

--- a/templates/global_base_partials/global_body_scripts.html
+++ b/templates/global_base_partials/global_body_scripts.html
@@ -78,7 +78,5 @@
 {% vite_script 'shared/components/nav-prefetch' %}
 <!-- Mobile Notice Banner Dismiss -->
 {% vite_script 'shared/utils/mobile-notice' %}
-<!-- Mobile Gestures (swipe right from edge → open sidebar, left → close) -->
-{% vite_script 'scitex_ui/shell/sidebar-drawer-gesture' %}
 <!-- Dev App Install/Uninstall (Hub Explore + Apps browse) -->
 {% vite_script 'apps_app/dev-install' %}

--- a/tests/apps/llm_app/views/test_chat_tts_relay.py
+++ b/tests/apps/llm_app/views/test_chat_tts_relay.py
@@ -5,40 +5,81 @@
 The relay endpoint accepts POST {"text": "..."} from authenticated users,
 pushes a tts_speak message to the user's speech_<username> channel group,
 and returns {"success": True, "relayed_to": "speech_<username>"}.
+
+These tests run against a real in-memory channel layer (no mocks): the view
+calls ``get_channel_layer()`` which, under ``override_settings`` below,
+returns ``channels.layers.InMemoryChannelLayer``. The delivered message is
+read back from the group to assert on real behaviour.
 """
 
+import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.urls import reverse
 
 _TEST_PW = "Testpass123!"  # pragma: allowlist secret
-_RELAY_URL = "/llm/api/tts/relay/"
+# llm_app is mounted at /apps/llm/ in config/urls.py (post app-reorg);
+# resolve by name so the test does not hard-code the mount prefix.
+_RELAY_URL = reverse("llm_app:api_tts_relay")
+
+_IN_MEMORY_LAYER = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+
+def _post_json(client, body):
+    """POST a JSON body string to the relay endpoint."""
+    return client.post(_RELAY_URL, data=body, content_type="application/json")
+
+
+def _receive_group_message(group_name):
+    """Subscribe a temporary channel to the group and return one message.
+
+    Returns the delivered dict, or None if nothing was delivered within the
+    timeout. Uses the real default channel layer (InMemoryChannelLayer under
+    the override_settings applied to the test classes).
+    """
+    layer = get_channel_layer()
+
+    async def _pull():
+        channel = await layer.new_channel()
+        await layer.group_add(group_name, channel)
+        try:
+            return await asyncio.wait_for(layer.receive(channel), timeout=1.0)
+        except asyncio.TimeoutError:
+            return None
+
+    return async_to_sync(_pull)()
 
 
 class TestTtsRelayAuthentication(TestCase):
     """api_tts_relay requires a logged-in user."""
 
-    def test_relay_requires_authentication(self):
+    def test_relay_unauthenticated_request_is_rejected(self):
         """Unauthenticated request must be redirected or rejected."""
-        response = self.client.post(
-            _RELAY_URL,
-            data=json.dumps({"text": "hello"}),
-            content_type="application/json",
-        )
+        # Arrange
+        body = json.dumps({"text": "hello"})
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
         # login_required redirects to the login page (302) or returns 401/403
-        self.assertIn(response.status_code, (302, 401, 403))
+        assert response.status_code in (302, 401, 403)
 
-    def test_relay_requires_post(self):
+    def test_relay_get_method_returns_405(self):
         """GET request to the relay endpoint must return 405 Method Not Allowed."""
+        # Arrange
         User.objects.create_user("tts_relay_get_user", password=_TEST_PW)
         self.client.login(username="tts_relay_get_user", password=_TEST_PW)
+        # Act
         response = self.client.get(_RELAY_URL)
-        self.assertEqual(response.status_code, 405)
+        # Assert
+        assert response.status_code == 405
 
 
+@override_settings(CHANNEL_LAYERS=_IN_MEMORY_LAYER)
 class TestTtsRelayInputValidation(TestCase):
     """api_tts_relay validates the request body before sending to channel layer."""
 
@@ -46,113 +87,111 @@ class TestTtsRelayInputValidation(TestCase):
         self.user = User.objects.create_user("tts_relay_val_user", password=_TEST_PW)
         self.client.login(username="tts_relay_val_user", password=_TEST_PW)
 
-    def test_relay_requires_text_field(self):
+    def test_relay_empty_text_returns_400(self):
         """POST with empty text must return 400."""
-        response = self.client.post(
-            _RELAY_URL,
-            data=json.dumps({"text": ""}),
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, 400)
-        body = json.loads(response.content)
-        self.assertIn("error", body)
+        # Arrange
+        body = json.dumps({"text": ""})
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert response.status_code == 400
 
-    def test_relay_requires_text_field_missing(self):
+    def test_relay_empty_text_response_has_error_field(self):
+        """The 400 response for empty text must carry an error field."""
+        # Arrange
+        body = json.dumps({"text": ""})
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert "error" in json.loads(response.content)
+
+    def test_relay_missing_text_field_returns_400(self):
         """POST without any text key must return 400."""
-        response = self.client.post(
-            _RELAY_URL,
-            data=json.dumps({}),
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, 400)
-        body = json.loads(response.content)
-        self.assertIn("error", body)
+        # Arrange
+        body = json.dumps({})
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert response.status_code == 400
+
+    def test_relay_missing_text_field_response_has_error_field(self):
+        """The 400 response for a missing text key must carry an error field."""
+        # Arrange
+        body = json.dumps({})
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert "error" in json.loads(response.content)
 
     def test_relay_whitespace_only_text_returns_400(self):
         """POST with whitespace-only text (strips to empty) must return 400."""
-        response = self.client.post(
-            _RELAY_URL,
-            data=json.dumps({"text": "   "}),
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, 400)
+        # Arrange
+        body = json.dumps({"text": "   "})
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert response.status_code == 400
 
     def test_relay_invalid_json_returns_400(self):
         """Malformed JSON body must return 400."""
-        response = self.client.post(
-            _RELAY_URL,
-            data="not-valid-json",
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, 400)
-        body = json.loads(response.content)
-        self.assertIn("error", body)
+        # Arrange
+        body = "not-valid-json"
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert response.status_code == 400
+
+    def test_relay_invalid_json_response_has_error_field(self):
+        """The 400 response for malformed JSON must carry an error field."""
+        # Arrange
+        body = "not-valid-json"
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert "error" in json.loads(response.content)
 
 
+@override_settings(CHANNEL_LAYERS=_IN_MEMORY_LAYER)
 class TestTtsRelayChannelSend(TestCase):
     """api_tts_relay pushes the correct message to the channel layer."""
 
     def setUp(self):
         self.user = User.objects.create_user("tts_relay_chan_user", password=_TEST_PW)
         self.client.login(username="tts_relay_chan_user", password=_TEST_PW)
+        self.group_name = f"speech_{self.user.username}"
 
-    def _post_text(self, text):
-        return self.client.post(
-            _RELAY_URL,
-            data=json.dumps({"text": text}),
-            content_type="application/json",
-        )
+    def test_relay_delivers_message_to_user_speech_group(self):
+        """A subscriber on speech_<username> must receive the relayed message."""
+        # Arrange
+        group_name = self.group_name
+        # Act
+        _post_json(self.client, json.dumps({"text": "hello from container"}))
+        message = _receive_group_message(group_name)
+        # Assert
+        assert message is not None
 
-    def test_relay_sends_to_correct_channel_group(self):
-        """group_send must be called with group_name = speech_<username>."""
-        mock_layer = MagicMock()
-        # group_send is called inside a new event loop via run_until_complete,
-        # so it must be an awaitable.
-        mock_layer.group_send = AsyncMock(return_value=None)
+    def test_relay_message_has_tts_speak_type(self):
+        """The message delivered to the group must have type tts_speak."""
+        # Arrange
+        group_name = self.group_name
+        # Act
+        _post_json(self.client, json.dumps({"text": "speak this"}))
+        message = _receive_group_message(group_name)
+        # Assert
+        assert message["type"] == "tts_speak"
 
-        with patch(
-            "apps.infra.llm_app.views.chat.get_channel_layer", return_value=mock_layer
-        ):
-            response = self._post_text("hello from container")
-
-        self.assertEqual(response.status_code, 200)
-        mock_layer.group_send.assert_called_once()
-        call_args = mock_layer.group_send.call_args
-        group_name = call_args[0][0]
-        self.assertEqual(group_name, f"speech_{self.user.username}")
-
-    def test_relay_sends_correct_message_type(self):
-        """The message dict passed to group_send must have type tts_speak."""
-        mock_layer = MagicMock()
-        mock_layer.group_send = AsyncMock(return_value=None)
-
-        with patch(
-            "apps.infra.llm_app.views.chat.get_channel_layer", return_value=mock_layer
-        ):
-            response = self._post_text("speak this")
-
-        self.assertEqual(response.status_code, 200)
-        call_args = mock_layer.group_send.call_args
-        message = call_args[0][1]
-        self.assertEqual(message["type"], "tts_speak")
-
-    def test_relay_sends_correct_text_in_message(self):
-        """The message dict must carry the exact text from the request body."""
+    def test_relay_message_carries_exact_text(self):
+        """The delivered message must carry the exact text from the request body."""
+        # Arrange
         expected_text = "precise text payload"
-        mock_layer = MagicMock()
-        mock_layer.group_send = AsyncMock(return_value=None)
-
-        with patch(
-            "apps.infra.llm_app.views.chat.get_channel_layer", return_value=mock_layer
-        ):
-            response = self._post_text(expected_text)
-
-        self.assertEqual(response.status_code, 200)
-        call_args = mock_layer.group_send.call_args
-        message = call_args[0][1]
-        self.assertEqual(message["text"], expected_text)
+        # Act
+        _post_json(self.client, json.dumps({"text": expected_text}))
+        message = _receive_group_message(self.group_name)
+        # Assert
+        assert message["text"] == expected_text
 
 
+@override_settings(CHANNEL_LAYERS=_IN_MEMORY_LAYER)
 class TestTtsRelaySuccessResponse(TestCase):
     """api_tts_relay returns the correct JSON on success."""
 
@@ -160,65 +199,44 @@ class TestTtsRelaySuccessResponse(TestCase):
         self.user = User.objects.create_user("tts_relay_resp_user", password=_TEST_PW)
         self.client.login(username="tts_relay_resp_user", password=_TEST_PW)
 
-    def test_relay_returns_success_true(self):
+    def test_relay_response_status_is_200(self):
+        """A valid relay request must return HTTP 200."""
+        # Arrange
+        body = json.dumps({"text": "test status"})
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert response.status_code == 200
+
+    def test_relay_response_reports_success_true(self):
         """Successful relay must include success: True in the response."""
-        mock_layer = MagicMock()
-        mock_layer.group_send = AsyncMock(return_value=None)
+        # Arrange
+        body = json.dumps({"text": "test success flag"})
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert json.loads(response.content)["success"] is True
 
-        with patch(
-            "apps.infra.llm_app.views.chat.get_channel_layer", return_value=mock_layer
-        ):
-            response = self.client.post(
-                _RELAY_URL,
-                data=json.dumps({"text": "test success flag"}),
-                content_type="application/json",
-            )
-
-        self.assertEqual(response.status_code, 200)
-        body = json.loads(response.content)
-        self.assertTrue(body["success"])
-
-    def test_relay_returns_relayed_to_group_name(self):
+    def test_relay_response_reports_relayed_to_group_name(self):
         """Response must include relayed_to with the correct group name."""
-        mock_layer = MagicMock()
-        mock_layer.group_send = AsyncMock(return_value=None)
+        # Arrange
+        body = json.dumps({"text": "test group name"})
+        # Act
+        response = _post_json(self.client, body)
+        # Assert
+        assert json.loads(response.content)["relayed_to"] == (
+            f"speech_{self.user.username}"
+        )
 
-        with patch(
-            "apps.infra.llm_app.views.chat.get_channel_layer", return_value=mock_layer
-        ):
-            response = self.client.post(
-                _RELAY_URL,
-                data=json.dumps({"text": "test group name"}),
-                content_type="application/json",
-            )
-
-        self.assertEqual(response.status_code, 200)
-        body = json.loads(response.content)
-        expected_group = f"speech_{self.user.username}"
-        self.assertEqual(body["relayed_to"], expected_group)
-
-    def test_relay_text_is_truncated_at_4096_chars(self):
-        """Text longer than 4096 chars must be accepted without error (truncated silently)."""
-        long_text = "a" * 5000
-        mock_layer = MagicMock()
-        mock_layer.group_send = AsyncMock(return_value=None)
-
-        with patch(
-            "apps.infra.llm_app.views.chat.get_channel_layer", return_value=mock_layer
-        ):
-            response = self.client.post(
-                _RELAY_URL,
-                data=json.dumps({"text": long_text}),
-                content_type="application/json",
-            )
-
-        self.assertEqual(response.status_code, 200)
-        body = json.loads(response.content)
-        self.assertTrue(body["success"])
-        # Verify the actual sent text is capped at 4096
-        call_args = mock_layer.group_send.call_args
-        sent_text = call_args[0][1]["text"]
-        self.assertLessEqual(len(sent_text), 4096)
+    def test_relay_long_text_is_truncated_to_4096_chars(self):
+        """Text longer than 4096 chars must be truncated to 4096 on the wire."""
+        # Arrange
+        group_name = f"speech_{self.user.username}"
+        # Act
+        _post_json(self.client, json.dumps({"text": "a" * 5000}))
+        message = _receive_group_message(group_name)
+        # Assert
+        assert len(message["text"]) <= 4096
 
 
 if __name__ == "__main__":

--- a/tests/apps/project_app/services/test_demo_project_pool.py
+++ b/tests/apps/project_app/services/test_demo_project_pool.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
 #         )
 #
 #         manager = get_project_filesystem_manager(demo_user)
-#         success, project_path = manager.create_empty_project_directory(project)
+#         success, project_path = manager.create_project_directory(project)
 #
 #         if not success:
 #             logger.error(

--- a/tests/apps/public_app/test_api_docs_config.py
+++ b/tests/apps/public_app/test_api_docs_config.py
@@ -35,9 +35,9 @@ class TestAPIDocSections:
     def test_section_order_matches_sections(self):
         """All sections in order list must exist in sections dict."""
         for key in API_DOC_SECTION_ORDER:
-            assert (
-                key in API_DOC_SECTIONS
-            ), f"Section {key} in order but not in sections"
+            assert key in API_DOC_SECTIONS, (
+                f"Section {key} in order but not in sections"
+            )
 
     def test_all_sections_in_order(self):
         """All sections must be in the order list."""
@@ -95,16 +95,22 @@ def client():
     return Client()
 
 
+@pytest.mark.django_db
 class TestAPIDocURLs:
-    """Test API documentation URL generation."""
+    """Test API documentation URL generation.
+
+    These hit the API-docs views through the Django test client; rendering
+    runs the ``project_context`` context processor, which queries the
+    ``User`` table, so DB access (``django_db``) is required.
+    """
 
     def test_section_urls_are_valid(self, client):
         """Each section URL should return 200."""
         for key in API_DOC_SECTION_ORDER:
             response = client.get(f"/docs/web-api/{key}/")
-            assert (
-                response.status_code == 200
-            ), f"Section {key} returned {response.status_code}"
+            assert response.status_code == 200, (
+                f"Section {key} returned {response.status_code}"
+            )
 
     def test_main_api_docs_url(self, client):
         """Main API docs URL should return 200."""
@@ -189,9 +195,9 @@ class TestCampaignTokens:
         assert result["hashtag"] == "alpha"
         assert result["legacy_format"] is True
         # No silent fallback: a DeprecationWarning must be emitted.
-        assert any(
-            issubclass(w.category, DeprecationWarning) for w in caught
-        ), "legacy prefix should emit DeprecationWarning"
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught), (
+            "legacy prefix should emit DeprecationWarning"
+        )
 
     def test_is_valid_campaign_token_accepts_legacy_alias(self):
         """is_valid_campaign_token should accept the legacy alias too."""

--- a/tests/apps/public_app/views/test_pages.py
+++ b/tests/apps/public_app/views/test_pages.py
@@ -45,7 +45,7 @@ class TestVideoCatalogStructure:
             "pages_data",
             os.path.join(
                 os.path.dirname(__file__),
-                "../../../../apps/public_app/views/pages_data.py",
+                "../../../../apps/infra/public_app/views/pages_data.py",
             ),
         )
         # We need to mock the pages_shortcuts import
@@ -61,7 +61,7 @@ class TestVideoCatalogStructure:
         # Now manually parse the file to extract OG_BASE_URL
         pages_data_path = os.path.join(
             os.path.dirname(__file__),
-            "../../../../apps/public_app/views/pages_data.py",
+            "../../../../apps/infra/public_app/views/pages_data.py",
         )
         pages_data_path = os.path.abspath(pages_data_path)
 
@@ -75,9 +75,9 @@ class TestVideoCatalogStructure:
         assert match, "OG_BASE_URL not found in pages_data.py"
         og_base_url = match.group(1)
 
-        assert og_base_url.startswith(
-            "https://"
-        ), f"OG_BASE_URL should be HTTPS: {og_base_url}"
+        assert og_base_url.startswith("https://"), (
+            f"OG_BASE_URL should be HTTPS: {og_base_url}"
+        )
         assert "scitex.ai" in og_base_url
 
     def test_video_catalog_structure(self):
@@ -87,7 +87,7 @@ class TestVideoCatalogStructure:
         # Parse the file to extract VIDEO_CATALOG structure
         pages_data_path = os.path.join(
             os.path.dirname(__file__),
-            "../../../../apps/public_app/views/pages_data.py",
+            "../../../../apps/infra/public_app/views/pages_data.py",
         )
         pages_data_path = os.path.abspath(pages_data_path)
 
@@ -118,7 +118,7 @@ class TestVideoCatalogStructure:
         """Thumbnails should be PNG files."""
         pages_data_path = os.path.join(
             os.path.dirname(__file__),
-            "../../../../apps/public_app/views/pages_data.py",
+            "../../../../apps/infra/public_app/views/pages_data.py",
         )
         pages_data_path = os.path.abspath(pages_data_path)
 
@@ -135,8 +135,15 @@ class TestVideoCatalogStructure:
 
 
 @pytest.mark.skipif(not DJANGO_AVAILABLE, reason="Django not available")
+@pytest.mark.django_db
 class TestVideoPlayerView:
-    """Test video_player view function (requires Django)."""
+    """Test video_player view function (requires Django).
+
+    Rendering the video-player template runs the ``project_context``
+    context processor, which performs a ``User.objects.get(...)`` query.
+    Even though the view itself is called directly via RequestFactory,
+    that DB access requires the ``django_db`` mark.
+    """
 
     @pytest.fixture
     def rf(self):
@@ -250,9 +257,9 @@ class TestVideoPlayerIntegration:
         assert match, "og:image meta tag not found"
 
         og_image_url = match.group(1)
-        assert og_image_url.startswith(
-            "https://"
-        ), f"OG image should be HTTPS: {og_image_url}"
+        assert og_image_url.startswith("https://"), (
+            f"OG image should be HTTPS: {og_image_url}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/scitex_hub/test_appmaker_api.py
+++ b/tests/scitex_hub/test_appmaker_api.py
@@ -17,16 +17,17 @@ class TestRegistryManifestLoading:
         from apps.infra.workspace_app.registry import get_all_modules
 
         modules = get_all_modules()
-        assert len(modules) == 10
+        assert len(modules) == 12
 
     def test_module_names(self):
         from apps.infra.workspace_app.registry import get_module_names
 
         names = get_module_names()
+        # Unique module names. There are 12 registered modules but two share
+        # the "tools" name (apps_app + tools_app), so the unique-name set has 11.
         expected = {
             "writer",
             "scholar",
-            "vis",
             "clew",
             "home",
             "tools",
@@ -34,6 +35,8 @@ class TestRegistryManifestLoading:
             "docs",
             "figrecipe",
             "discovery",
+            "comms",
+            "console",
         }
         assert names == expected
 
@@ -64,12 +67,12 @@ class TestRegistryManifestLoading:
         for rel_path in _BUILTIN_MANIFEST_PATHS:
             path = _APPS_ROOT / rel_path
             data = json.loads(path.read_text())
-            assert (
-                data.get("$schema") == "scitex-app-manifest"
-            ), f"{rel_path} missing $schema"
-            assert (
-                data.get("$schema_version") == "1.0.0"
-            ), f"{rel_path} missing $schema_version"
+            assert data.get("$schema") == "scitex-app-manifest", (
+                f"{rel_path} missing $schema"
+            )
+            assert data.get("$schema_version") == "2.0.0", (
+                f"{rel_path} missing $schema_version"
+            )
 
 
 class TestInitAppRename:
@@ -116,7 +119,7 @@ class TestAppManagementAPI:
         from scitex_hub.appmaker import list_all
 
         apps = list_all()
-        assert len(apps) == 10
+        assert len(apps) == 12
         names = {a["name"] for a in apps}
         assert "writer" in names
         assert "scholar" in names

--- a/tests/scitex_hub/test_cli.py
+++ b/tests/scitex_hub/test_cli.py
@@ -38,11 +38,16 @@ class TestMainCLI:
 
 
 class TestSetupCommand:
-    """Tests for setup command."""
+    """Tests for setup-environment command.
+
+    Per noun-verb CLI convention (§5), the bare ``setup`` leaf was renamed
+    to ``setup-environment``; bare ``setup`` is now a hidden deprecation
+    redirect. The real options live under the canonical name.
+    """
 
     def test_setup_help(self, runner):
-        """Test setup --help."""
-        result = runner.invoke(main, ["setup", "--help"])
+        """Test setup-environment --help."""
+        result = runner.invoke(main, ["setup-environment", "--help"])
         assert result.exit_code == 0
         assert "--env" in result.output
         assert "dev" in result.output
@@ -50,11 +55,11 @@ class TestSetupCommand:
 
 
 class TestDeployCommand:
-    """Tests for deploy command."""
+    """Tests for deploy-project command (renamed from bare ``deploy``)."""
 
     def test_deploy_help(self, runner):
-        """Test deploy --help."""
-        result = runner.invoke(main, ["deploy", "--help"])
+        """Test deploy-project --help."""
+        result = runner.invoke(main, ["deploy-project", "--help"])
         assert result.exit_code == 0
         assert "--env" in result.output
         assert "--build" in result.output
@@ -80,21 +85,21 @@ class TestDockerCommand:
 
 
 class TestStatusCommand:
-    """Tests for status command."""
+    """Tests for show-status command (renamed from bare ``status``)."""
 
     def test_status_help(self, runner):
-        """Test status --help."""
-        result = runner.invoke(main, ["status", "--help"])
+        """Test show-status --help."""
+        result = runner.invoke(main, ["show-status", "--help"])
         assert result.exit_code == 0
         assert "--env" in result.output
 
 
 class TestLogsCommand:
-    """Tests for logs command."""
+    """Tests for show-logs command (renamed from bare ``logs``)."""
 
     def test_logs_help(self, runner):
-        """Test logs --help."""
-        result = runner.invoke(main, ["logs", "--help"])
+        """Test show-logs --help."""
+        result = runner.invoke(main, ["show-logs", "--help"])
         assert result.exit_code == 0
         assert "--follow" in result.output
         assert "--tail" in result.output
@@ -112,11 +117,24 @@ class TestGiteaCommand:
         assert "list" in result.output
 
     def test_gitea_subcommands_help(self, runner):
-        """Test gitea subcommands have help."""
-        subcommands = ["clone", "create", "list", "search", "push", "pull", "status"]
+        """Test gitea subcommands have help.
+
+        The bare ``status`` leaf was renamed to ``show-status`` under the
+        noun-verb CLI convention; the remaining repository/sync leaves are
+        unchanged and still live directly under ``gitea``.
+        """
+        subcommands = [
+            "clone",
+            "create",
+            "list",
+            "search",
+            "push",
+            "pull",
+            "show-status",
+        ]
         for cmd in subcommands:
             result = runner.invoke(main, ["gitea", cmd, "--help"])
-            assert result.exit_code == 0
+            assert result.exit_code == 0, f"gitea {cmd} failed"
 
 
 class TestMcpCommand:

--- a/tests/scitex_hub/test_project_package.py
+++ b/tests/scitex_hub/test_project_package.py
@@ -14,6 +14,27 @@ import asyncio
 import pytest
 
 
+def _run(coro):
+    """Run a coroutine to completion from a synchronous test.
+
+    ``asyncio.run`` raises ``RuntimeError`` if an event loop is already
+    running in the current thread (which can happen when another test in the
+    same session leaves a loop installed, e.g. Django/channels async tests).
+    To stay independent of session-wide loop state, run the coroutine on a
+    fresh loop in a dedicated worker thread whenever a loop is already
+    running; otherwise use ``asyncio.run`` directly.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
 @pytest.fixture
 def data_root(tmp_path):
     """Point the handlers' sandbox root at a tmp dir; restore on teardown."""
@@ -77,7 +98,7 @@ def test_write_then_read_roundtrip(data_root):
     project_dir = data_root / "alice" / "proj"
     project_dir.mkdir(parents=True)
     # Act
-    write_result = asyncio.run(
+    write_result = _run(
         handlers.write_file_handler(str(project_dir), "notes.txt", "hello")
     )
     # Assert
@@ -90,9 +111,9 @@ def test_read_returns_written_content(data_root):
 
     project_dir = data_root / "bob" / "proj"
     project_dir.mkdir(parents=True)
-    asyncio.run(handlers.write_file_handler(str(project_dir), "notes.txt", "hello"))
+    _run(handlers.write_file_handler(str(project_dir), "notes.txt", "hello"))
     # Act
-    read_result = asyncio.run(handlers.read_file_handler(str(project_dir), "notes.txt"))
+    read_result = _run(handlers.read_file_handler(str(project_dir), "notes.txt"))
     # Assert
     assert read_result["content"] == "hello"
 
@@ -104,7 +125,7 @@ def test_path_traversal_is_blocked(data_root):
     project_dir = data_root / "carol" / "proj"
     project_dir.mkdir(parents=True)
     # Act
-    result = asyncio.run(
+    result = _run(
         handlers.read_file_handler(str(project_dir), "../../../../etc/passwd")
     )
     # Assert

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -24,6 +24,25 @@ pytest.importorskip(
     reason="scitex-hub[django] / [test] not installed — ui/ tests skipped",
 )
 
+
+def pytest_collection_modifyitems(config, items):
+    """Mark the whole ``tests/ui/`` tree as ``e2e``.
+
+    These are browser-driven Playwright tests (they use the ``page: Page``
+    fixture and a real Chromium binary). They cannot run in the headless
+    unit-test release gate (``pytest tests/ -x`` with ``-m "not e2e"`` —
+    see pyproject ``[tool.pytest.ini_options].addopts``); the browser
+    binary isn't installed there, so they error with
+    ``BrowserType.launch: Executable doesn't exist``. The dedicated E2E
+    Mobile workflow installs the browser and opts back in via
+    ``-o "addopts="``. Marking the tree here keeps new ui/ tests gated
+    automatically. Mirrors tests/e2e/conftest.py.
+    """
+    for item in items:
+        if "tests/ui/" in item.nodeid or item.nodeid.startswith("tests/ui/"):
+            item.add_marker(pytest.mark.e2e)
+
+
 from playwright.sync_api import BrowserContext, Page, expect  # noqa: E402
 
 # Project paths

--- a/tests/unit/services/test_health_checks.py
+++ b/tests/unit/services/test_health_checks.py
@@ -9,7 +9,6 @@ NAS bind mount permission issues.
 
 import os
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -31,22 +30,12 @@ class TestUserDataPermissions:
         proj_dir.mkdir()
 
         status_data = {}
-        with patch(
-            "apps.infra.public_app.views.status.health_checks.Path"
-        ) as mock_path:
-            mock_path.return_value = users_dir
-            # Actually use the real path for iteration
-            with patch.object(
-                Path,
-                "__new__",
-                lambda cls, *args: (
-                    users_dir
-                    if args and args[0] == "/app/data/users"
-                    else Path.__new__(cls)
-                ),
-            ):
-                # Direct test with tmp_path
-                check_user_data_permissions_with_path(status_data, users_dir)
+        # Call the path-injectable helper directly with the tmp_path tree —
+        # the same pattern the sibling tests use. (The previous version patched
+        # ``Path.__new__`` with a lambda whose fallback called ``Path.__new__``
+        # again — now the patched object — recursing infinitely as ``iterdir()``
+        # built child paths.)
+        check_user_data_permissions_with_path(status_data, users_dir)
 
         assert status_data["user_data_permissions"]["is_healthy"] is True
         assert status_data["user_data_permissions"]["health_class"] == "healthy"


### PR DESCRIPTION
## Consolidated v0.18.1 release-gate fixes (supersedes #187-#195)

Two prior agents produced eight heavily-overlapping gate PRs (#187-#195); no
single branch was complete and they touched the same files. This branch is the
clean **union** of every genuine fix, with overlaps resolved to exactly one
correct copy per file, off current `develop`.

### What's included (per source PR)
- **#189** writer_app migration `0007`: `RemoveIndex`x4 + `AlterUniqueTogether(None)` **before** the `RemoveField`/`DeleteModel`, fixing `FieldDoesNotExist: NewCollaborativeEdit ... manuscript` at test-DB setup on SQLite (~170 errors). Canonical copy.
- **#187** `tests/ui/conftest.py` marks `tests/ui` as `e2e` so the headless gate skips browser launches (~98 `BrowserType.launch` errors).
- **#188** `@django_db` markers on DB-touching public_app tests (subsumed by #195's superset copy of those two files).
- **#195** `settings_shared` Redis ping **fast-fail timeouts** (critical: its absence hung all collection); public_app path `apps/`→`apps/infra/`; `test_health_checks` recursion; `global_body_scripts` template; scitex_hub `test_appmaker_api`/`test_cli` stale assertions.
- **#191** `test_project_package.py` residual assertion repair (the appmaker/cli portions taken from the more-complete #195).
- **#192** `apps_app` `db_table` alignment + migration `0009` (fixes `OperationalError: no such table marketplace_app_*` surfacing after #189).
- **#193** stale attr/import refs after app reorg: `llm_app/chat`, `project_app` demo pool, `console_app` terminal config + their tests.

### Overlap reconciliation
- migration `0007`, `tests/ui/conftest.py`, the two public_app test files were byte-identical across the PRs that carried them — included exactly once.
- For `test_api_docs_config.py` / `test_pages.py`, #195's copy is a strict superset of #188's, so #195's was taken.
- For scitex_hub `test_appmaker_api`/`test_cli`, #195's (later) version was taken over #191's contradictory one.
- **#194** and **#190** carried no unique content vs the above (all duplicates / an earlier partial integration), so nothing was pulled from them.

### Headless verification
`SCITEX_HUB_USE_SQLITE_DEV=1 ... pytest tests/ -o addopts="" -m "not e2e" -p no:randomly -q` (Django 6.0.5):

**1442 passed, 43 failed, 707 skipped, 100 deselected.**

- 0 `FieldDoesNotExist`, 0 `BrowserType.launch`, 0 "Database access not allowed", 0 marketplace `OperationalError`, 0 collection hangs.
- The 43 failures are **42 pre-existing-on-develop failures** (404 URL-routing / `profile_app_apikey` UNIQUE-collision / demo-dir RuntimeError classes, in files this consolidation does not change behavior of) **plus `tests/develop/test_audit.py::test_audit_all_clean`** (the ~2723 PA-306/307 repo-wide backlog — handled separately via the scitex-dev `deferred` / audit.skip mechanism, same as orochi).

This branch makes all the in-scope gate errors green; the audit/PA backlog and the pre-existing routing failures are out of scope for this consolidation.
