### PR TITLE
fix(gate3): accounts/project test failures (apikey prefix uniqueness, visitor pool table check)

### DIFF
--- a/apps/infra/project_app/services/visitor_pool/pool_manager.py
+++ b/apps/infra/project_app/services/visitor_pool/pool_manager.py
@@ -40,17 +40,18 @@ class PoolAllocator:
 
     @classmethod
     def _check_table_exists(cls) -> bool:
-        """Check if VisitorAllocation table exists."""
-        try:
-            from django.db import connection
+        """Check if VisitorAllocation table exists.
 
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'project_app_visitorallocation'"
-                )
-                return cursor.fetchone()[0] > 0
-        except Exception:
-            return False
+        Uses Django's database-agnostic introspection so the check works
+        across SQLite (test/CI), PostgreSQL, and MySQL alike. The previous
+        implementation queried ``information_schema.tables`` directly, which
+        does not exist on SQLite and silently returned False there, wrongly
+        triggering the DemoProjectPool fallback.
+        """
+        from django.db import connection
+
+        table_name = VisitorAllocation._meta.db_table
+        return table_name in connection.introspection.table_names()
 
     @classmethod
     @transaction.atomic


### PR DESCRIPTION
## Bucket: accounts-project (v0181 green gate)

Root-cause fixes for the two failing test files.

### tests/apps/accounts_app/views/test_api_keys_views.py (6 failures: IntegrityError UNIQUE on profile_app_apikey)
Real model bug. `APIKey.key_prefix` was `max_length=8, unique=True`, but the stored value is `full_key[:8]` = `'scitex_'` (7 chars) + 1 hex char — only 16 distinct values. Creating many keys across tests inevitably collided on the UNIQUE constraint. The display prefix has no reason to be unique (`key_hash`, a 64-char SHA256, already enforces real uniqueness). Fix:
- Widen `key_prefix` to `max_length=14` and drop `unique=True` (`apps/infra/accounts_app/models/api_key.py`).
- Store `full_key[:14]` (e.g. `scitex_a1b2c3d`) — more useful for display too.
- Add migration `0013_alter_apikey_key_prefix.py`.
- Update the single test asserting the slice length (`full_key[:8]` -> `full_key[:14]`).

### tests/apps/project_app/services/visitor_pool/test_visitor_pool.py (5 failures: RuntimeError: Failed to create demo project directory)
Real cross-DB bug. `PoolAllocator._check_table_exists()` queried `information_schema.tables`, which does not exist on SQLite (CI pytest uses `SCITEX_HUB_USE_SQLITE_DEV=1`). The broad `except Exception: return False` silently masked the error and wrongly concluded the VisitorAllocation table was missing, triggering the DemoProjectPool fallback — which then raised `Failed to create demo project directory`. Fix: use Django's database-agnostic `connection.introspection.table_names()` (`apps/infra/project_app/services/visitor_pool/pool_manager.py`). Equivalent table name (`project_app_visitorallocation`), now works on SQLite/Postgres/MySQL. Also removes a silent-fallback anti-pattern.

### Notes
- No mocks added; no assertions weakened.
- Local pytest could not run in the isolated worktree (Django init hangs without the full `.env.dev`); relying on CI.