### PR TITLE
test(llm): fix gate3 llm bucket — bash exec tests (mount + no-mock)

### DIFF
--- a/tests/apps/llm_app/views/test_bash.py
+++ b/tests/apps/llm_app/views/test_bash.py
@@ -1,88 +1,123 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for apps/llm_app/views/bash.py
+"""Tests for apps/infra/llm_app/views/bash.py
 
 Security-critical: verify that the bash exec endpoint:
 - Requires authentication
 - Validates CWD stays within user's filesystem jail
-- Invokes setpriv with the correct UID/GID
-- Times out runaway commands
+- Falls back to the jail root when a project slug cannot be resolved
+
+No-mock policy (STX-NM00x): the jail predicates only read ``user.username``,
+so an unsaved real ``User`` instance is a sufficient, honest collaborator.
+The project-lookup fallback is exercised against the real ORM with a slug
+that does not exist, so ``Project.DoesNotExist`` fires for real.
 """
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
+
+# llm_app is mounted at /apps/llm/ in config/urls.py (post app-reorg);
+# resolve by name so the test does not hard-code the mount prefix.
+_BASH_URL = reverse("llm_app:api_bash_exec")
+
+_TEST_PW = "Testpass123!"  # pragma: allowlist secret
+
+
+def _user(username="alice"):
+    """An unsaved real User — enough for username-only jail predicates."""
+    return User(username=username)
 
 
 class TestValidatePathInUserJail(TestCase):
     """validate_path_in_user_jail: core security predicate"""
 
-    def _make_user(self, username="alice"):
-        user = MagicMock(spec=User)
-        user.username = username
-        return user
-
     def test_user_root_is_inside_jail(self):
+        # Arrange
         from apps.infra.project_app.services.filesystem.permissions import (
             get_user_data_root,
             validate_path_in_user_jail,
         )
 
-        user = self._make_user("alice")
+        user = _user("alice")
         jail = get_user_data_root(user)
-        assert validate_path_in_user_jail(user, jail) is True
+        # Act
+        result = validate_path_in_user_jail(user, jail)
+        # Assert
+        assert result is True
 
     def test_subdir_inside_jail(self):
+        # Arrange
         from apps.infra.project_app.services.filesystem.permissions import (
             get_user_data_root,
             validate_path_in_user_jail,
         )
 
-        user = self._make_user("alice")
-        jail = get_user_data_root(user)
-        subpath = jail / "myproject" / "data"
-        assert validate_path_in_user_jail(user, subpath) is True
+        user = _user("alice")
+        subpath = get_user_data_root(user) / "myproject" / "data"
+        # Act
+        result = validate_path_in_user_jail(user, subpath)
+        # Assert
+        assert result is True
 
     def test_other_user_dir_is_outside_jail(self):
+        # Arrange
         from apps.infra.project_app.services.filesystem.permissions import (
             get_user_data_root,
             validate_path_in_user_jail,
         )
 
-        alice = self._make_user("alice")
-        bob = self._make_user("bob")
-        bob_dir = get_user_data_root(bob)
-        # Alice must not pass bob's dir as her CWD
-        assert validate_path_in_user_jail(alice, bob_dir) is False
+        alice = _user("alice")
+        bob_dir = get_user_data_root(_user("bob"))
+        # Act
+        result = validate_path_in_user_jail(alice, bob_dir)
+        # Assert
+        assert result is False
 
     def test_traversal_attack_blocked(self):
         """Path traversal like /app/data/users/alice/../../bob must be blocked."""
+        # Arrange
         from apps.infra.project_app.services.filesystem.permissions import (
             get_user_data_root,
             validate_path_in_user_jail,
         )
 
-        alice = self._make_user("alice")
-        jail = get_user_data_root(alice)
-        traversal = jail / ".." / ".." / "bob"
-        assert validate_path_in_user_jail(alice, traversal) is False
+        alice = _user("alice")
+        traversal = get_user_data_root(alice) / ".." / ".." / "bob"
+        # Act
+        result = validate_path_in_user_jail(alice, traversal)
+        # Assert
+        assert result is False
 
-    def test_absolute_path_outside_data_blocked(self):
-        """Absolute paths like /etc must not pass jail validation."""
+    def test_etc_is_outside_jail(self):
+        """Absolute path /etc must not pass jail validation."""
+        # Arrange
         from apps.infra.project_app.services.filesystem.permissions import (
             validate_path_in_user_jail,
         )
 
-        user = self._make_user("alice")
-        assert validate_path_in_user_jail(user, Path("/etc")) is False
-        assert validate_path_in_user_jail(user, Path("/tmp")) is False
+        user = _user("alice")
+        # Act
+        result = validate_path_in_user_jail(user, Path("/etc"))
+        # Assert
+        assert result is False
 
+    def test_tmp_is_outside_jail(self):
+        """Absolute path /tmp must not pass jail validation."""
+        # Arrange
+        from apps.infra.project_app.services.filesystem.permissions import (
+            validate_path_in_user_jail,
+        )
 
-_TEST_PW = "Testpass123!"  # pragma: allowlist secret
+        user = _user("alice")
+        # Act
+        result = validate_path_in_user_jail(user, Path("/tmp"))
+        # Assert
+        assert result is False
 
 
 class TestBashExecAuthentication(TestCase):
@@ -93,71 +128,83 @@ class TestBashExecAuthentication(TestCase):
         self.client.login(username=username, password=_TEST_PW)
 
     def test_unauthenticated_request_redirects(self):
+        # Arrange
+        body = json.dumps({"command": "ls"})
+        # Act
         response = self.client.post(
-            "/llm/api/bash/",
-            data=json.dumps({"command": "ls"}),
-            content_type="application/json",
+            _BASH_URL, data=body, content_type="application/json"
         )
+        # Assert
         # login_required redirects to login page
         assert response.status_code in (302, 403)
 
     def test_get_method_not_allowed(self):
+        # Arrange
         self._login("bash_test_alice")
-        response = self.client.get("/llm/api/bash/")
+        # Act
+        response = self.client.get(_BASH_URL)
+        # Assert
         assert response.status_code == 405
 
     def test_missing_command_returns_400(self):
+        # Arrange
         self._login("bash_test_alice2")
+        # Act
         response = self.client.post(
-            "/llm/api/bash/",
-            data=json.dumps({}),
-            content_type="application/json",
+            _BASH_URL, data=json.dumps({}), content_type="application/json"
         )
+        # Assert
         assert response.status_code == 400
-        data = json.loads(response.content)
-        assert "command" in data.get("error", "").lower()
+
+    def test_missing_command_error_mentions_command(self):
+        # Arrange
+        self._login("bash_test_alice2b")
+        # Act
+        response = self.client.post(
+            _BASH_URL, data=json.dumps({}), content_type="application/json"
+        )
+        # Assert
+        assert "command" in json.loads(response.content).get("error", "").lower()
 
     def test_invalid_json_returns_400(self):
+        # Arrange
         self._login("bash_test_alice3")
+        # Act
         response = self.client.post(
-            "/llm/api/bash/",
-            data="not-json",
-            content_type="application/json",
+            _BASH_URL, data="not-json", content_type="application/json"
         )
+        # Assert
         assert response.status_code == 400
 
 
 class TestGetProjectCwd(TestCase):
     """_get_project_cwd: always returns a path within the user's jail"""
 
-    def _make_user(self, pk=1, username="alice"):
-        user = MagicMock(spec=User)
-        user.pk = pk
-        user.username = username
-        return user
-
     def test_no_slug_returns_jail_root(self):
+        # Arrange
         from apps.infra.llm_app.views.bash import _get_project_cwd
         from apps.infra.project_app.services.filesystem.permissions import (
             get_user_data_root,
         )
 
-        user = self._make_user()
+        user = User.objects.create_user("cwd_user_noslug", password=_TEST_PW)
+        # Act
         result = _get_project_cwd(user, "")
-        expected = get_user_data_root(user)
-        assert result == expected
+        # Assert
+        assert result == get_user_data_root(user)
 
-    @patch("apps.infra.project_app.models.Project.objects")
-    def test_bad_slug_falls_back_to_jail(self, mock_objects):
+    def test_bad_slug_falls_back_to_jail(self):
         """If project lookup fails, fall back to jail root (never raise)."""
+        # Arrange
         from apps.infra.llm_app.views.bash import _get_project_cwd
         from apps.infra.project_app.services.filesystem.permissions import (
             get_user_data_root,
         )
 
-        mock_objects.get.side_effect = Exception("not found")
-        user = self._make_user()
+        user = User.objects.create_user("cwd_user_badslug", password=_TEST_PW)
+        # Act
         result = _get_project_cwd(user, "nonexistent-slug")
+        # Assert
         assert result == get_user_data_root(user)
 
 


### PR DESCRIPTION
## Gate3 bucket: llm

Fixes the failing tests in the llm bucket after the apps/config Django standardization (apps moved to `apps/infra/llm_app/`).

### tests/apps/llm_app/views/test_bash.py (4 failures)
**Root cause:** `TestBashExecAuthentication` hard-coded the URL `/llm/api/bash/`, but the app is now mounted at `/apps/llm/` (`config/urls.py`: `path("apps/llm/", include(("apps.infra.llm_app.urls", "llm_app")))`). Every request hit a 404 instead of the expected 302/405/400.

**Fix:** resolve the URL by name via `reverse("llm_app:api_bash_exec")` (mount-agnostic), matching the sibling `test_chat_tts_relay.py` pattern.

Also removed the `unittest.mock` usage (STX-NM00x lint gate) in the same file:
- jail predicates only read `user.username` → unsaved real `User` instances are honest collaborators;
- the project-lookup fallback now runs against the real ORM with a nonexistent slug, so `Project.DoesNotExist` fires for real (no `@patch`).
- Added AAA markers and split multi-assert tests (STX-TQ002/TQ007).

### tests/apps/llm_app/views/test_chat_tts_relay.py (4 failures)
Already correct against current source (uses `reverse("llm_app:api_tts_relay")`, real in-memory channel layer, no mocks). Failures resolve once the relay view/URL resolve under the new app path — no source change needed.

### Verification
Full local Django init hangs in the isolated worktree (known limitation), so relying on CI. Verified locally: both test files + both source views compile; all referenced symbols (`api_bash_exec`, `api_tts_relay`, `_get_project_cwd`, jail predicates) exist and are re-exported in `views/__init__.py` and registered in `urls.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)