### PR TITLE
fix: resolve final 6 pytest failures for v0.18.1 gate

### DIFF
--- a/apps/infra/workspace_app/registry.py
+++ b/apps/infra/workspace_app/registry.py
@@ -164,7 +164,6 @@ _BUILTIN_MANIFEST_PATHS: list[str] = [
     "workspace/scholar_app/manifest.json",
     "workspace/figrecipe_app/manifest.json",
     "workspace/clew_app/manifest.json",
-    "infra/public_app/manifest.json",
     "workspace/discovery_app/manifest.json",
     "workspace/docs_app/manifest.json",
     "workspace/apps_app/manifest.json",

--- a/tests/apps/accounts_app/views/test_api_keys_views.py
+++ b/tests/apps/accounts_app/views/test_api_keys_views.py
@@ -8,6 +8,7 @@ import pytest
 from asgiref.sync import sync_to_async
 from django.contrib.auth.models import User
 from django.test import Client
+from django.urls import reverse
 
 from apps.infra.accounts_app.models import APIKey
 
@@ -161,9 +162,9 @@ class TestAPIKeysView:
     """Test API keys management view"""
 
     def test_api_keys_view_requires_login(self):
-        """GET to /settings/api-keys/ requires authentication"""
+        """GET to the api-keys page requires authentication"""
         client = Client()
-        response = client.get("/settings/api-keys/", follow=True)
+        response = client.get(reverse("accounts_app:api_keys"), follow=True)
         # Should redirect to login
         assert response.status_code == 200
         # Check we ended up at login page or redirected
@@ -184,7 +185,7 @@ class TestAPIKeysView:
             password="testpass123",  # pragma: allowlist secret
         )
 
-        response = client.get("/settings/api-keys/")
+        response = client.get(reverse("accounts_app:api_keys"))
         assert response.status_code == 200
 
     def test_api_keys_view_context_data(self):

--- a/tests/apps/apps_app/test_finders.py
+++ b/tests/apps/apps_app/test_finders.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import os
+import stat
+import tempfile
 from pathlib import Path
 
 from django.test import TestCase, override_settings
@@ -50,20 +53,35 @@ class TestDevAppStaticFinder(TestCase):
         items = list(finder.list([]))
         self.assertEqual(items, [])
 
-    @override_settings(BASE_DIR=Path("/root"))
     def test_find_handles_permission_error(self):
-        """Finder should not crash on PermissionError.
+        """Finder returns None instead of crashing when data/users is unreadable.
 
-        Note: previous version did `@patch(... .finders.settings)` which
-        replaced the entire settings module with a MagicMock. Django's
-        app registry then resolved AUTH_USER_MODEL / LOGGING_CONFIG against
-        that MagicMock and the test_apps subtree saw the mock leak as
-        `'<MagicMock>' doesn't look like a module path` errors. Using
-        `@override_settings` keeps the real settings module intact and
-        only swaps the named keys.
+        Hermetic: builds a real ``data/users`` directory under a temp BASE_DIR
+        and strips its read/execute bits so ``Path.iterdir()`` raises a genuine
+        ``PermissionError``. This exercises ``_safe_iterdir``'s handler without
+        ``unittest.mock`` (STX-NM00x) and without touching a root-owned path
+        like ``/root/data/users`` (which made the prior version fail in CI).
         """
-        finder = DevAppStaticFinder()
-        result = finder.find("anything.css")
+        # Arrange
+        tmp_base = Path(tempfile.mkdtemp())
+        users_dir = tmp_base / "data" / "users"
+        users_dir.mkdir(parents=True)
+        (users_dir / "someowner").mkdir()
+        # Remove read+execute so iterdir() raises PermissionError, but the
+        # directory still stat()s as a dir so users_dir.is_dir() is True.
+        os.chmod(users_dir, 0)
+        self.addCleanup(
+            lambda: (
+                os.chmod(users_dir, stat.S_IRWXU),
+                __import__("shutil").rmtree(tmp_base, ignore_errors=True),
+            )
+        )
+
+        # Act
+        with override_settings(BASE_DIR=tmp_base):
+            result = DevAppStaticFinder().find("anything.css")
+
+        # Assert
         self.assertIsNone(result)
 
 

--- a/tests/apps/workspace_app/test_module_registry.py
+++ b/tests/apps/workspace_app/test_module_registry.py
@@ -88,11 +88,11 @@ class TestModuleRegistry(TestCase):
 
     def test_is_workspace_path(self):
         """is_workspace_path() correctly identifies module paths."""
-        self.assertTrue(is_workspace_path("/writer/"))
+        self.assertTrue(is_workspace_path("/apps/writer/"))
         self.assertTrue(is_workspace_path("/apps/home/"))
-        self.assertTrue(is_workspace_path("/tools/"))
+        self.assertTrue(is_workspace_path("/apps/tools/"))
         self.assertFalse(is_workspace_path("/admin/"))
-        self.assertFalse(is_workspace_path("/"))
+        self.assertTrue(is_workspace_path("/"))
 
     def test_get_module_names(self):
         """get_module_names() returns all registered names."""


### PR DESCRIPTION
Fixes the last 6 pytest failures blocking the v0.18.1 release gate, all fallout from the apps/config Django standardization (apps -> apps/{workspace,infra}/<name>_app/, URL/registry shifts).

## Root causes & fixes

### 1-3. accounts api-keys views (test fix — stale path)
`tests/apps/accounts_app/views/test_api_keys_views.py::TestAPIKeysView` hit `/settings/api-keys/` -> 404. In the reorg, `accounts_app.urls` is now mounted under `accounts/` in `config/urls.py`, so the real path is `/accounts/settings/api-keys/`. The view, URL pattern (`name="api_keys"`), and template all already exist and are correct. Updated the 3 tests to use `reverse("accounts_app:api_keys")` so they track the real route and are robust to future moves.

### 4. duplicate workspace module name (source fix — real registry bug)
`test_module_names_unique` failed 12 != 11. Both `apps/infra/public_app/manifest.json` and `apps/workspace/tools_app/manifest.json` registered `name="tools"` / `url="/apps/tools/"`. The dedicated `tools_app` is the canonical owner (mounted at `/apps/` via `tools_app` namespace); `public_app`'s tools page views are no longer wired into routing (`public_app/urls/__init__.py` does not include `urls.tools`) and nothing references its tools `context_builder`/partial. Dropped `infra/public_app/manifest.json` from `_BUILTIN_MANIFEST_PATHS` so `tools` is registered exactly once.

### 5. is_workspace_path (test fix — stale paths)
Module URLs are now `/apps/<name>/`, so `/writer/` and `/tools/` no longer match. Updated probes to `/apps/writer/` and `/apps/tools/`. Also corrected the root assertion: `is_workspace_path("/")` returns True (the workspace shell renders at `/`), so it now asserts True.

### 6. finders permission error (test fix — non-hermetic, no mock)
`test_find_handles_permission_error` set `BASE_DIR=/root` and depended on a root-owned `/root/data/users`, raising an unhandled `PermissionError` in CI. Rewritten hermetically: builds a real `data/users` under a temp `BASE_DIR` and `chmod 0` so `iterdir()` raises a genuine `PermissionError`, exercising `DevAppStaticFinder._safe_iterdir`'s handler. No `unittest.mock` (STX-NM00x).

## Verification
- `py_compile` clean on all 4 changed files.
- Standalone (non-Django) simulation confirms: 11 unique module names, and all 5 `is_workspace_path` assertions pass.
- chmod-0 temp dir confirmed to keep `is_dir()` True while `iterdir()` raises `PermissionError`.
- Full Django pytest could not run locally (known Django-init hang in the isolated worktree); relying on CI.