### PR TITLE
fix: complete api-keys test path migration (3rd occurrence)

### DIFF
--- a/tests/apps/accounts_app/views/test_api_keys_views.py
+++ b/tests/apps/accounts_app/views/test_api_keys_views.py
@@ -204,7 +204,7 @@ class TestAPIKeysView:
         APIKey.create_key(user=user, name="key1", scopes=["*"])
         APIKey.create_key(user=user, name="key2", scopes=["mcp"])
 
-        response = client.get("/settings/api-keys/")
+        response = client.get(reverse("accounts_app:api_keys"))
         assert response.status_code == 200
         # Check context has api_keys
         assert "api_keys" in response.context


### PR DESCRIPTION
Follow-up to #204. The gate fix migrated two of the three TestAPIKeysView GETs to reverse(accounts_app:api_keys), but test_api_keys_view_context_data still hit the stale top-level /settings/api-keys/ (now mounted under /accounts/), so it would still 404. This points the third call at the real URL via reverse() like the other two.

Verified: py_compile clean; all three client.get calls in the class now use reverse(accounts_app:api_keys).