### PR TITLE
fix(tests): celery eager mode in SQLite test gate

### DIFF
--- a/config/settings/settings_celery.py
+++ b/config/settings/settings_celery.py
@@ -18,6 +18,20 @@ CELERY_TASK_TRACK_STARTED = True
 CELERY_TASK_TIME_LIMIT = 30 * 60  # 30 minutes max per task
 CELERY_RESULT_EXTENDED = True
 
+# Test-mode eager execution
+# ------------------------
+# The SQLite test gate (SCITEX_HUB_USE_SQLITE_DEV=1, used by pytest-matrix
+# in CI) runs without a Redis broker, so .delay() raises
+# kombu.exceptions.OperationalError. Run tasks inline instead of enqueuing.
+# EAGER_PROPAGATES=True surfaces task exceptions to the caller — per
+# project policy, errors must be loud (no silent fallback).
+# In-memory broker keeps Celery's internal probes (canvas, etc.) from
+# doing real network I/O at import time.
+if os.environ.get("SCITEX_HUB_USE_SQLITE_DEV"):
+    CELERY_TASK_ALWAYS_EAGER = True
+    CELERY_TASK_EAGER_PROPAGATES = True
+    CELERY_BROKER_URL = "memory://"
+
 # Task routing to dedicated queues
 CELERY_TASK_ROUTES = {
     "apps.workspace.writer_app.tasks.*": {"queue": "ai_queue"},


### PR DESCRIPTION
Closes the 6 visitor_pool failures left after #206 in the pytest-matrix
release gate on develop.

## Root cause

The pytest-matrix CI jobs set `SCITEX_HUB_USE_SQLITE_DEV=1` to use SQLite
and run without a Redis service container. The default Celery broker URL
is `redis://localhost:6379/1`, so any `.delay()` call raises
`kombu.exceptions.OperationalError: Error 111 connecting to
localhost:6379. Connection refused.` Six tests in
`tests/apps/project_app/services/visitor_pool/test_visitor_pool.py` hit
that path because `VisitorPool.allocate_visitor()` enqueues
`initialize_visitor_workspace` (Phase 2 of visitor allocation).

Observed failures (py3.11/3.12/3.13):
- `TestVisitorAllocation::test_allocate_visitor_reuses_existing`
- `TestVisitorAllocation::test_allocate_visitor_stores_session_data`
- `TestVisitorAllocation::test_allocate_visitor_success`
- `TestVisitorAllocation::test_deallocate_visitor_clears_session`
- `TestVisitorAllocationExpiration::test_expired_allocation_allows_new_allocation`
- (plus one stragglers in some matrix rows)

## Fix

Gate Celery eager execution behind the same `SCITEX_HUB_USE_SQLITE_DEV`
env var the CI matrix already sets:

```python
if os.environ.get("SCITEX_HUB_USE_SQLITE_DEV"):
    CELERY_TASK_ALWAYS_EAGER = True
    CELERY_TASK_EAGER_PROPAGATES = True
    CELERY_BROKER_URL = "memory://"
```

- `ALWAYS_EAGER` makes `.delay()` invoke the task body synchronously in
  the caller's process — a real Celery configuration switch, not a mock.
- `EAGER_PROPAGATES` re-raises task exceptions to the caller. Per
  `CLAUDE.md`'s no-silent-fallback rule, failures must be loud.
- `BROKER_URL = "memory://"` keeps Celery's own broker probes
  (canvas, group/chord wiring) from accidentally hitting Redis at
  import time.

Production (`SCITEX_HUB_USE_SQLITE_DEV` unset) keeps the redis broker
unchanged.

## Test plan

- [x] `config.settings.settings_celery` import clean under the SQLite gate
- [x] `CELERY_TASK_ALWAYS_EAGER == True` and `BROKER_URL == "memory://"`
      after import under SQLite gate
- [ ] CI pytest-matrix: `tests/apps/project_app/services/visitor_pool/`
      drops from 6 fail to 0 fail on all of py3.11 / py3.12 / py3.13