### PR TITLE
fix(tests): resolve 44 residual release-gate failures after #196

### DIFF
--- a/apps/infra/accounts_app/migrations/0013_alter_apikey_key_prefix.py
+++ b/apps/infra/accounts_app/migrations/0013_alter_apikey_key_prefix.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("accounts_app", "0012_userprofile_analytics_opt_out"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="apikey",
+            name="key_prefix",
+            field=models.CharField(
+                help_text="First 15 characters of the key (for display)",
+                max_length=15,
+                unique=True,
+            ),
+        ),
+    ]

--- a/apps/infra/accounts_app/models/api_key.py
+++ b/apps/infra/accounts_app/models/api_key.py
@@ -19,9 +19,9 @@ class APIKey(models.Model):
         max_length=100, help_text="Descriptive name for this API key"
     )
     key_prefix = models.CharField(
-        max_length=8,
+        max_length=15,
         unique=True,
-        help_text="First 8 characters of the key (for display)",
+        help_text="First 15 characters of the key (for display)",
     )
     key_hash = models.CharField(
         max_length=64, unique=True, help_text="SHA256 hash of the full key"
@@ -83,7 +83,10 @@ class APIKey(models.Model):
         """
         full_key = cls.generate_key()
         key_hash = cls.hash_key(full_key)
-        key_prefix = full_key[:8]  # "scitex_x"
+        # "scitex_" + 8 hex chars (32 bits entropy) keeps the display prefix
+        # unique in practice; an 8-char prefix only captured 1 hex char and
+        # collided on the unique constraint after a handful of keys.
+        key_prefix = full_key[:15]
 
         api_key = cls.objects.create(
             user=user,

--- a/apps/infra/llm_app/views/chat.py
+++ b/apps/infra/llm_app/views/chat.py
@@ -131,17 +131,16 @@ def api_tts_relay(request):
     group_name = f"speech_{username}"
 
     try:
-        import asyncio
+        from asgiref.sync import async_to_sync
 
         channel_layer = get_channel_layer()
-        loop = asyncio.new_event_loop()
-        loop.run_until_complete(
-            channel_layer.group_send(
-                group_name,
-                {"type": "tts_speak", "text": text},
-            )
+        # Use async_to_sync rather than a fresh event loop: a brand-new loop
+        # does not share the InMemoryChannelLayer state (queues are bound to
+        # the running loop), so group_send would silently drop the message.
+        async_to_sync(channel_layer.group_send)(
+            group_name,
+            {"type": "tts_speak", "text": text},
         )
-        loop.close()
         return JsonResponse({"success": True, "relayed_to": group_name})
     except Exception as e:
         logger.error("TTS relay failed: %s", e)

--- a/apps/infra/project_app/services/project_filesystem/template_ops.py
+++ b/apps/infra/project_app/services/project_filesystem/template_ops.py
@@ -43,10 +43,29 @@ class TemplateOperationsManager:
         self.manager = filesystem_manager
 
     def create_minimal_readme(self, project: Project, project_path: Path):
-        """Create minimal README file for empty projects."""
-        from scitex.template import create_minimal_readme
+        """Create minimal README file for empty projects.
 
-        create_minimal_readme(str(project_path), _project_metadata(project))
+        Delegates to scitex.template when available. The ``scitex_template``
+        package is an optional extra; when it is not installed we fall back to
+        writing a basic README directly so that project/demo directory creation
+        still succeeds rather than hard-failing on a missing optional dep.
+        """
+        meta = _project_metadata(project)
+        try:
+            from scitex.template import create_minimal_readme
+
+            create_minimal_readme(str(project_path), meta)
+        except ImportError:
+            logger.warning(
+                "scitex.template unavailable (scitex_template not installed); "
+                "writing fallback README for %s",
+                project.slug,
+            )
+            readme = Path(project_path) / "README.md"
+            readme.write_text(
+                f"# {meta['name']}\n\n{meta['description']}\n",
+                encoding="utf-8",
+            )
 
     def create_project_readme(self, project: Project, project_path: Path):
         """Create comprehensive README file for the project."""

--- a/apps/infra/project_app/services/visitor_pool/pool_manager.py
+++ b/apps/infra/project_app/services/visitor_pool/pool_manager.py
@@ -40,15 +40,19 @@ class PoolAllocator:
 
     @classmethod
     def _check_table_exists(cls) -> bool:
-        """Check if VisitorAllocation table exists."""
+        """Check if VisitorAllocation table exists.
+
+        Uses Django's backend-agnostic introspection rather than a raw
+        ``information_schema`` query: ``information_schema`` does not exist on
+        SQLite, so the raw query silently failed and forced the DemoProjectPool
+        fallback on SQLite (incl. the CI test database).
+        """
         try:
             from django.db import connection
 
+            table = VisitorAllocation._meta.db_table
             with connection.cursor() as cursor:
-                cursor.execute(
-                    "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'project_app_visitorallocation'"
-                )
-                return cursor.fetchone()[0] > 0
+                return table in connection.introspection.table_names(cursor)
         except Exception:
             return False
 
@@ -204,10 +208,24 @@ class PoolAllocator:
                     f"(expires_at={expires_at.isoformat()}), queuing workspace init"
                 )
 
-                # Phase 2: queue async workspace initialization
-                from apps.infra.project_app.tasks import initialize_visitor_workspace
+                # Phase 2: queue async workspace initialization.
+                # Best-effort: a missing/unreachable Celery broker must not undo
+                # the Phase 1 allocation that already succeeded above (and must
+                # not hang the synchronous request). The workspace is created
+                # lazily on first use if the task never runs.
+                from apps.infra.project_app.tasks import (
+                    initialize_visitor_workspace,
+                )
 
-                initialize_visitor_workspace.delay(allocation.id)
+                try:
+                    initialize_visitor_workspace.delay(allocation.id)
+                except Exception as exc:
+                    logger.warning(
+                        "[VisitorPool] Could not queue workspace init for "
+                        "visitor-%03d (broker unavailable?): %s",
+                        visitor_num,
+                        exc,
+                    )
 
                 return project, user
 

--- a/apps/infra/workspace_app/registry.py
+++ b/apps/infra/workspace_app/registry.py
@@ -164,7 +164,6 @@ _BUILTIN_MANIFEST_PATHS: list[str] = [
     "workspace/scholar_app/manifest.json",
     "workspace/figrecipe_app/manifest.json",
     "workspace/clew_app/manifest.json",
-    "infra/public_app/manifest.json",
     "workspace/discovery_app/manifest.json",
     "workspace/docs_app/manifest.json",
     "workspace/apps_app/manifest.json",

--- a/apps/workspace/scholar_app/services/project_library_linker.py
+++ b/apps/workspace/scholar_app/services/project_library_linker.py
@@ -333,6 +333,30 @@ class ProjectLibraryLinker:
             .order_by("-saved_at")
         )
 
+    def setup_project_workspace(self, project) -> Dict[str, str]:
+        """Ensure scholar workspace exists for a project.
+
+        Delegates to scitex.scholar.ensure_workspace().
+        Returns workspace paths for display in the UI.
+
+        Args:
+            project: Project instance
+
+        Returns:
+            Dict with workspace path strings
+        """
+        from scitex.scholar import ensure_workspace
+
+        project_dir = project.get_local_path()
+        workspace = ensure_workspace(project_dir)
+
+        return {
+            "workspace_dir": str(workspace),
+            "bib_dir": str(workspace / "bib_files"),
+            "library_dir": str(workspace / "library"),
+            "project_bib": str(project_dir / "scitex" / "scholar" / "project.bib"),
+        }
+
     def get_linkable_papers(self) -> QuerySet:
         """
         Get all papers in user library that can be linked to projects.

--- a/apps/workspace/scholar_app/urls/library.py
+++ b/apps/workspace/scholar_app/urls/library.py
@@ -57,11 +57,8 @@ library_patterns = [
         name="api_remove_library_paper",
     ),
     # Integration status stubs (return available=false until implemented)
-    path(
-        "api/library/zotero/status/",
-        library_views.api_zotero_status,
-        name="api_zotero_status",
-    ),
+    # NOTE: Zotero status is served by the real (login-gated) view in
+    # zotero_patterns below, not the stub here.
     path(
         "api/library/connected-papers/status/",
         library_views.api_connected_papers_status,
@@ -73,6 +70,7 @@ library_patterns = [
 from ..views.library.project_linking import (
     api_link_paper_to_project,
     api_project_papers,
+    api_setup_project_workspace,
     api_unlink_paper_from_project,
 )
 
@@ -91,6 +89,43 @@ project_linking_patterns = [
         "api/library/projects/<uuid:project_id>/papers/",
         api_project_papers,
         name="api_project_papers",
+    ),
+    path(
+        "api/library/projects/<uuid:project_id>/setup-workspace/",
+        api_setup_project_workspace,
+        name="api_setup_project_workspace",
+    ),
+]
+
+# Zotero integration endpoints (import/collections/tags; status lives in
+# library_patterns above as api_zotero_status)
+from ..views.library.zotero_import import (
+    zotero_collections,
+    zotero_import,
+    zotero_status,
+    zotero_tags,
+)
+
+zotero_patterns = [
+    path(
+        "api/library/zotero/status/",
+        zotero_status,
+        name="api_zotero_status",
+    ),
+    path(
+        "api/library/zotero/import/",
+        zotero_import,
+        name="zotero_import",
+    ),
+    path(
+        "api/library/zotero/collections/",
+        zotero_collections,
+        name="zotero_collections",
+    ),
+    path(
+        "api/library/zotero/tags/",
+        zotero_tags,
+        name="zotero_tags",
     ),
 ]
 
@@ -177,6 +212,7 @@ urlpatterns = (
     export_patterns
     + library_patterns
     + project_linking_patterns
+    + zotero_patterns
     + trend_patterns
     + annotation_patterns
     + recommendation_patterns

--- a/apps/workspace/scholar_app/views/library/project_linking.py
+++ b/apps/workspace/scholar_app/views/library/project_linking.py
@@ -288,4 +288,33 @@ def api_project_papers(request, project_id):
         )
 
 
+@login_required
+@require_http_methods(["POST"])
+def api_setup_project_workspace(request, project_id):
+    """Ensure scholar workspace exists for a project.
+
+    POST /api/library/projects/<project_id>/setup-workspace/
+
+    Returns workspace paths for display in the UI.
+    """
+    try:
+        from apps.infra.project_app.models import Project
+
+        project_id = UUID(str(project_id))
+        try:
+            project = Project.objects.get(id=project_id, owner=request.user)
+        except Project.DoesNotExist:
+            return JsonResponse(
+                {"success": False, "error": "Project not found"}, status=404
+            )
+
+        linker = ProjectLibraryLinker(request.user)
+        paths = linker.setup_project_workspace(project)
+        return JsonResponse({"success": True, **paths})
+
+    except Exception as e:
+        logger.error(f"Error setting up project workspace: {e}", exc_info=True)
+        return JsonResponse({"success": False, "error": str(e)}, status=500)
+
+
 # EOF

--- a/config/settings/settings_dev.py
+++ b/config/settings/settings_dev.py
@@ -194,6 +194,14 @@ if os.environ.get("SCITEX_HUB_USE_SQLITE_DEV"):
             "NAME": BASE_DIR / "data" / "db" / "sqlite" / "scitex_hub_dev.db",
         }
     }
+    # The SQLite path is the brokerless CI/test environment. Run Celery tasks
+    # eagerly (in-process, synchronously) so .delay() does not block trying to
+    # reach a Redis broker that isn't running, which otherwise hangs and fails
+    # any code path that enqueues a task (e.g. visitor workspace init).
+    CELERY_TASK_ALWAYS_EAGER = True
+    CELERY_TASK_EAGER_PROPAGATES = False
+    CELERY_BROKER_URL = "memory://"
+    CELERY_RESULT_BACKEND = "cache+memory://"
 else:
     # PostgreSQL (default for development)
     DATABASES = {

--- a/tests/apps/accounts_app/views/test_api_keys_views.py
+++ b/tests/apps/accounts_app/views/test_api_keys_views.py
@@ -163,7 +163,7 @@ class TestAPIKeysView:
     def test_api_keys_view_requires_login(self):
         """GET to /settings/api-keys/ requires authentication"""
         client = Client()
-        response = client.get("/settings/api-keys/", follow=True)
+        response = client.get("/accounts/settings/api-keys/", follow=True)
         # Should redirect to login
         assert response.status_code == 200
         # Check we ended up at login page or redirected
@@ -184,7 +184,7 @@ class TestAPIKeysView:
             password="testpass123",  # pragma: allowlist secret
         )
 
-        response = client.get("/settings/api-keys/")
+        response = client.get("/accounts/settings/api-keys/")
         assert response.status_code == 200
 
     def test_api_keys_view_context_data(self):
@@ -203,7 +203,7 @@ class TestAPIKeysView:
         APIKey.create_key(user=user, name="key1", scopes=["*"])
         APIKey.create_key(user=user, name="key2", scopes=["mcp"])
 
-        response = client.get("/settings/api-keys/")
+        response = client.get("/accounts/settings/api-keys/")
         assert response.status_code == 200
         # Check context has api_keys
         assert "api_keys" in response.context
@@ -225,7 +225,7 @@ class TestAPIKeyModel:
         assert api_key_obj.name == "test-key"
         assert api_key_obj.scopes == ["*"]
         assert full_key.startswith("scitex_")
-        assert api_key_obj.key_prefix == full_key[:8]
+        assert api_key_obj.key_prefix == full_key[:15]
 
     def test_api_key_hash_verification(self):
         """APIKey stores and verifies key hash correctly"""

--- a/tests/apps/apps_app/test_views.py
+++ b/tests/apps/apps_app/test_views.py
@@ -33,15 +33,15 @@ class AppsBrowseTest(TestCase):
         )
 
     def test_browse_page_200(self):
-        resp = self.client.get("/apps/")
+        resp = self.client.get("/apps/store/")
         self.assertEqual(resp.status_code, 200)
 
     def test_browse_with_category_filter(self):
-        resp = self.client.get("/apps/?category=writing")
+        resp = self.client.get("/apps/store/?category=writing")
         self.assertEqual(resp.status_code, 200)
 
     def test_browse_with_search(self):
-        resp = self.client.get("/apps/?q=t-browse")
+        resp = self.client.get("/apps/store/?q=t-browse")
         self.assertEqual(resp.status_code, 200)
 
 
@@ -58,7 +58,7 @@ class AppsDetailTest(TestCase):
         )
 
     def test_detail_page_200(self):
-        resp = self.client.get("/apps/t-detail/")
+        resp = self.client.get("/apps/store/t-detail/")
         self.assertEqual(resp.status_code, 200)
 
     def test_detail_page_404(self):

--- a/tests/apps/console_app/views/terminal/test_config.py
+++ b/tests/apps/console_app/views/terminal/test_config.py
@@ -19,6 +19,19 @@ class TestDevReposParsing:
         importlib.reload(cfg)
         return cfg
 
+    def teardown_method(self, method):
+        """Reload config under the restored (post-patch) environment.
+
+        Each test reloads the shared config module under a patched env; without
+        restoring it, the module is left holding test-specific values, which
+        leaks into unrelated tests that later import/patch this module (e.g.
+        terminal_broker tests patching config.SHOW_MOTD). Reloading here returns
+        the module to its real-environment state.
+        """
+        import apps.workspace.console_app.views.terminal.config as cfg
+
+        importlib.reload(cfg)
+
     @mock.patch.dict(os.environ, {"SCITEX_HUB_DEV_REPOS": ""}, clear=False)
     def test_empty_env_returns_empty_list(self):
         cfg = self._reload_config()

--- a/tests/apps/llm_app/views/test_bash.py
+++ b/tests/apps/llm_app/views/test_bash.py
@@ -94,7 +94,7 @@ class TestBashExecAuthentication(TestCase):
 
     def test_unauthenticated_request_redirects(self):
         response = self.client.post(
-            "/llm/api/bash/",
+            "/apps/llm/api/bash/",
             data=json.dumps({"command": "ls"}),
             content_type="application/json",
         )
@@ -103,13 +103,13 @@ class TestBashExecAuthentication(TestCase):
 
     def test_get_method_not_allowed(self):
         self._login("bash_test_alice")
-        response = self.client.get("/llm/api/bash/")
+        response = self.client.get("/apps/llm/api/bash/")
         assert response.status_code == 405
 
     def test_missing_command_returns_400(self):
         self._login("bash_test_alice2")
         response = self.client.post(
-            "/llm/api/bash/",
+            "/apps/llm/api/bash/",
             data=json.dumps({}),
             content_type="application/json",
         )
@@ -120,7 +120,7 @@ class TestBashExecAuthentication(TestCase):
     def test_invalid_json_returns_400(self):
         self._login("bash_test_alice3")
         response = self.client.post(
-            "/llm/api/bash/",
+            "/apps/llm/api/bash/",
             data="not-json",
             content_type="application/json",
         )

--- a/tests/apps/llm_app/views/test_chat_tts_relay.py
+++ b/tests/apps/llm_app/views/test_chat_tts_relay.py
@@ -35,18 +35,31 @@ def _post_json(client, body):
     return client.post(_RELAY_URL, data=body, content_type="application/json")
 
 
-def _receive_group_message(group_name):
-    """Subscribe a temporary channel to the group and return one message.
+def _subscribe(group_name):
+    """Subscribe a fresh channel to the group and return it.
 
-    Returns the delivered dict, or None if nothing was delivered within the
-    timeout. Uses the real default channel layer (InMemoryChannelLayer under
-    the override_settings applied to the test classes).
+    Must be called BEFORE the relay POST: a channel layer only delivers a
+    group_send to channels already in the group at send time, so the
+    subscriber has to be registered before the message is sent.
+    """
+    layer = get_channel_layer()
+
+    async def _add():
+        channel = await layer.new_channel()
+        await layer.group_add(group_name, channel)
+        return channel
+
+    return async_to_sync(_add)()
+
+
+def _receive(channel):
+    """Receive one message on a previously subscribed channel.
+
+    Returns the delivered dict, or None if nothing arrived within the timeout.
     """
     layer = get_channel_layer()
 
     async def _pull():
-        channel = await layer.new_channel()
-        await layer.group_add(group_name, channel)
         try:
             return await asyncio.wait_for(layer.receive(channel), timeout=1.0)
         except asyncio.TimeoutError:
@@ -163,20 +176,20 @@ class TestTtsRelayChannelSend(TestCase):
     def test_relay_delivers_message_to_user_speech_group(self):
         """A subscriber on speech_<username> must receive the relayed message."""
         # Arrange
-        group_name = self.group_name
+        channel = _subscribe(self.group_name)
         # Act
         _post_json(self.client, json.dumps({"text": "hello from container"}))
-        message = _receive_group_message(group_name)
+        message = _receive(channel)
         # Assert
         assert message is not None
 
     def test_relay_message_has_tts_speak_type(self):
         """The message delivered to the group must have type tts_speak."""
         # Arrange
-        group_name = self.group_name
+        channel = _subscribe(self.group_name)
         # Act
         _post_json(self.client, json.dumps({"text": "speak this"}))
-        message = _receive_group_message(group_name)
+        message = _receive(channel)
         # Assert
         assert message["type"] == "tts_speak"
 
@@ -184,9 +197,10 @@ class TestTtsRelayChannelSend(TestCase):
         """The delivered message must carry the exact text from the request body."""
         # Arrange
         expected_text = "precise text payload"
+        channel = _subscribe(self.group_name)
         # Act
         _post_json(self.client, json.dumps({"text": expected_text}))
-        message = _receive_group_message(self.group_name)
+        message = _receive(channel)
         # Assert
         assert message["text"] == expected_text
 
@@ -232,9 +246,10 @@ class TestTtsRelaySuccessResponse(TestCase):
         """Text longer than 4096 chars must be truncated to 4096 on the wire."""
         # Arrange
         group_name = f"speech_{self.user.username}"
+        channel = _subscribe(group_name)
         # Act
         _post_json(self.client, json.dumps({"text": "a" * 5000}))
-        message = _receive_group_message(group_name)
+        message = _receive(channel)
         # Assert
         assert len(message["text"]) <= 4096
 

--- a/tests/apps/scholar_app/api/test_crossref_api.py
+++ b/tests/apps/scholar_app/api/test_crossref_api.py
@@ -23,14 +23,14 @@ class TestCrossRefSearchAPI:
     @pytest.mark.django_db
     def test_search_endpoint_exists(self, client):
         """CrossRef search endpoint should exist."""
-        response = client.get("/scholar/api/crossref/search/")
+        response = client.get("/apps/scholar/api/crossref/search/")
         # Should return 400 (missing query) or 200, not 404
         assert response.status_code != 404
 
     @pytest.mark.django_db
     def test_search_requires_query(self, client):
         """Search should require query parameter."""
-        response = client.get("/scholar/api/crossref/search/")
+        response = client.get("/apps/scholar/api/crossref/search/")
         # Expect 400 or 200 (missing param), or 503 if CrossRef service is unavailable
         assert response.status_code in (400, 200, 503)
 
@@ -45,7 +45,7 @@ class TestCrossRefCitationsAPI:
     @pytest.mark.django_db
     def test_citations_endpoint_exists(self, client):
         """CrossRef citations endpoint should exist."""
-        response = client.get("/scholar/api/crossref/citations/")
+        response = client.get("/apps/scholar/api/crossref/citations/")
         assert response.status_code != 404
 
 
@@ -59,13 +59,13 @@ class TestCrossRefHealthAPI:
     @pytest.mark.django_db
     def test_health_endpoint_returns_200(self, client):
         """Health endpoint should return 200 when service is available, 503 when not."""
-        response = client.get("/scholar/api/crossref/health/")
+        response = client.get("/apps/scholar/api/crossref/health/")
         assert response.status_code in (200, 503)
 
     @pytest.mark.django_db
     def test_health_returns_json(self, client):
         """Health endpoint should return JSON."""
-        response = client.get("/scholar/api/crossref/health/")
+        response = client.get("/apps/scholar/api/crossref/health/")
         assert response["Content-Type"].startswith("application/json")
 
 
@@ -79,5 +79,5 @@ class TestCrossRefStatsAPI:
     @pytest.mark.django_db
     def test_stats_endpoint_exists(self, client):
         """Stats endpoint should exist."""
-        response = client.get("/scholar/api/crossref/stats/")
+        response = client.get("/apps/scholar/api/crossref/stats/")
         assert response.status_code != 404

--- a/tests/apps/scholar_app/api/test_pdf_api.py
+++ b/tests/apps/scholar_app/api/test_pdf_api.py
@@ -23,14 +23,16 @@ class TestPDFDownloadAPI:
     @pytest.mark.django_db
     def test_download_endpoint_exists(self, client):
         """PDF download endpoint should exist."""
-        response = client.post("/scholar/api/pdf/download/")
+        response = client.post("/apps/scholar/api/pdf/download/")
         # Should not be 404
         assert response.status_code != 404
 
     @pytest.mark.django_db
     def test_download_requires_authentication(self, client):
         """PDF download should require authentication or return appropriate error."""
-        response = client.post("/scholar/api/pdf/download/", {"doi": "10.1234/test"})
+        response = client.post(
+            "/apps/scholar/api/pdf/download/", {"doi": "10.1234/test"}
+        )
         # Expect 401/403 for unauthenticated or 400 for missing params
         assert response.status_code in (400, 401, 403, 200)
 
@@ -45,7 +47,7 @@ class TestPDFStatusAPI:
     @pytest.mark.django_db
     def test_status_endpoint_exists(self, client):
         """PDF status endpoint should exist."""
-        response = client.get("/scholar/api/pdf/status/")
+        response = client.get("/apps/scholar/api/pdf/status/")
         assert response.status_code != 404
 
 
@@ -59,7 +61,7 @@ class TestPDFBulkDownloadAPI:
     @pytest.mark.django_db
     def test_bulk_download_endpoint_exists(self, client):
         """Bulk PDF download endpoint should exist."""
-        response = client.post("/scholar/api/pdf/download-bulk/")
+        response = client.post("/apps/scholar/api/pdf/download-bulk/")
         assert response.status_code != 404
 
 
@@ -73,5 +75,5 @@ class TestPDFServeAPI:
     @pytest.mark.django_db
     def test_serve_endpoint_exists(self, client):
         """PDF serve endpoint should exist."""
-        response = client.get("/scholar/api/pdf/serve/")
+        response = client.get("/apps/scholar/api/pdf/serve/")
         assert response.status_code != 404

--- a/tests/apps/scholar_app/views/library/test_zotero_import.py
+++ b/tests/apps/scholar_app/views/library/test_zotero_import.py
@@ -30,7 +30,7 @@ class TestZoteroStatus:
             "scitex.scholar.integration.zotero.ZoteroLocalReader",
             side_effect=FileNotFoundError("No Zotero DB"),
         ):
-            response = client.get("/scholar/api/library/zotero/status/")
+            response = client.get("/apps/scholar/api/library/zotero/status/")
         assert response.status_code == 200
         data = response.json()
         assert data["available"] is False
@@ -38,7 +38,7 @@ class TestZoteroStatus:
     @pytest.mark.django_db
     def test_status_requires_login(self, client):
         """Unauthenticated users are redirected."""
-        response = client.get("/scholar/api/library/zotero/status/")
+        response = client.get("/apps/scholar/api/library/zotero/status/")
         assert response.status_code in (302, 403)
 
 
@@ -62,7 +62,7 @@ class TestZoteroImport:
         import json
 
         response = client.post(
-            "/scholar/api/library/zotero/import/",
+            "/apps/scholar/api/library/zotero/import/",
             data=json.dumps({"mode": "all"}),
             content_type="application/json",
         )
@@ -73,7 +73,7 @@ class TestZoteroImport:
         """Invalid JSON body returns 400."""
         client.force_login(user)
         response = client.post(
-            "/scholar/api/library/zotero/import/",
+            "/apps/scholar/api/library/zotero/import/",
             data="not-json",
             content_type="application/json",
         )
@@ -154,7 +154,7 @@ class TestProjectWorkspace:
         import uuid
 
         response = client.post(
-            f"/scholar/api/library/projects/{uuid.uuid4()}/setup-workspace/"
+            f"/apps/scholar/api/library/projects/{uuid.uuid4()}/setup-workspace/"
         )
         assert response.status_code in (302, 403)
 
@@ -165,7 +165,7 @@ class TestProjectWorkspace:
 
         client.force_login(user)
         response = client.post(
-            f"/scholar/api/library/projects/{uuid.uuid4()}/setup-workspace/"
+            f"/apps/scholar/api/library/projects/{uuid.uuid4()}/setup-workspace/"
         )
         assert response.status_code == 404
 

--- a/tests/apps/workspace_app/test_module_registry.py
+++ b/tests/apps/workspace_app/test_module_registry.py
@@ -88,17 +88,20 @@ class TestModuleRegistry(TestCase):
 
     def test_is_workspace_path(self):
         """is_workspace_path() correctly identifies module paths."""
-        self.assertTrue(is_workspace_path("/writer/"))
+        # Workspace modules now live under the /apps/<name>/ prefix.
+        self.assertTrue(is_workspace_path("/apps/writer/"))
         self.assertTrue(is_workspace_path("/apps/home/"))
-        self.assertTrue(is_workspace_path("/tools/"))
+        self.assertTrue(is_workspace_path("/apps/tools/"))
         self.assertFalse(is_workspace_path("/admin/"))
-        self.assertFalse(is_workspace_path("/"))
+        # Root renders inside the workspace layout (root dispatch).
+        self.assertTrue(is_workspace_path("/"))
 
     def test_get_module_names(self):
         """get_module_names() returns all registered names."""
         names = get_module_names()
         self.assertIn("writer", names)
-        self.assertIn("hub", names)
+        # The repo/hub module is registered under the name "home".
+        self.assertIn("home", names)
         self.assertIn("tools", names)
 
     def test_modules_ordered(self):

--- a/tests/scitex_hub/test_appmaker_api.py
+++ b/tests/scitex_hub/test_appmaker_api.py
@@ -17,14 +17,13 @@ class TestRegistryManifestLoading:
         from apps.infra.workspace_app.registry import get_all_modules
 
         modules = get_all_modules()
-        assert len(modules) == 12
+        assert len(modules) == 11
 
     def test_module_names(self):
         from apps.infra.workspace_app.registry import get_module_names
 
         names = get_module_names()
-        # Unique module names. There are 12 registered modules but two share
-        # the "tools" name (apps_app + tools_app), so the unique-name set has 11.
+        # 11 registered modules, each with a unique name.
         expected = {
             "writer",
             "scholar",
@@ -119,7 +118,7 @@ class TestAppManagementAPI:
         from scitex_hub.appmaker import list_all
 
         apps = list_all()
-        assert len(apps) == 12
+        assert len(apps) == 11
         names = {a["name"] for a in apps}
         assert "writer" in names
         assert "scholar" in names


### PR DESCRIPTION
## Summary
Brings the headless release gate (`pytest tests/ -m "not e2e" -p no:randomly`, SQLite) from **45 failed → 1 failed**. The only remaining failure is `tests/develop/test_audit.py::test_audit_all_clean` (handled separately by the lead). Result: **1485 passed, 1 failed**.

All real fixes — no mocks, skips, or xfail.

## Clusters fixed
**URL-routing 404s** — the apps/infra + apps/workspace reorg moved app modules under the `/apps/<app>/` prefix; stale test paths pointed at pre-reorg URLs. Repointed tests to the canonical current routes (`/accounts/settings/api-keys/`, `/apps/llm/...`, `/apps/scholar/...`, `/apps/store/`).

**Lost-in-reorg scholar routes** — `zotero_import` view, `api_setup_project_workspace` view + service method, and their URL wiring were dropped during consolidation (present in 2c386e37). Restored them; routed `zotero/status/` to the real login-gated view instead of the stub.

**`key_prefix` UNIQUE collisions** — model generated only `scitex_` + 1 hex char (16 possible values) for a `unique=True` field. Widened to 15 chars (8 hex chars of entropy) + migration `0013`.

**Duplicate "tools" module** — `public_app` and `tools_app` both registered module name `tools` / url `/apps/tools/`; public_app's was shadowed at the URL layer. Removed it from the builtin manifest list; adjusted module-count assertions 12 → 11.

**visitor_pool RuntimeError** — three real bugs surfaced in sequence:
- `_check_table_exists` queried `information_schema` (nonexistent on SQLite) → always fell back to DemoProjectPool; switched to backend-agnostic introspection.
- `create_minimal_readme` hard-failed when the optional `scitex_template` package was absent; added a plain-README fallback.
- Phase-2 `initialize_visitor_workspace.delay()` hung/raised with no Celery broker; guarded the dispatch and enabled eager Celery under the SQLite/CI settings.

**tts_relay** — the view sent group messages on a throwaway event loop (silently dropped by InMemoryChannelLayer); switched to `async_to_sync`. Tests now subscribe before posting (a channel layer only delivers to members present at send time).

**terminal_broker handlers_shared** — order-dependent flake: `test_config`'s `importlib.reload` left the shared config module mutated, breaking a later patch of `config.SHOW_MOTD`. Reload to baseline in teardown.

## Verification
Full headless run (hub `.venv`, Django 6.0.5, SQLite): `1 failed, 1485 passed, 707 skipped` — sole failure is `test_audit_all_clean`. All 12 originally-failing files also pass together in an isolated 142-test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)