### PR TITLE
fix(tests): URL + TTS test repairs (v0.18.1 gate, split from #213)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -422,7 +422,7 @@
         "filename": "tests/apps/accounts_app/views/test_api_keys_views.py",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 48
       }
     ],
     "tests/apps/console_app/test_tests.py": [
@@ -528,5 +528,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-23T08:25:38Z"
+  "generated_at": "2026-05-31T23:45:21Z"
 }

--- a/tests/apps/accounts_app/views/test_api_keys_views.py
+++ b/tests/apps/accounts_app/views/test_api_keys_views.py
@@ -8,6 +8,7 @@ import pytest
 from asgiref.sync import sync_to_async
 from django.contrib.auth.models import User
 from django.test import Client
+from django.urls import reverse
 
 from apps.infra.accounts_app.models import APIKey
 
@@ -161,9 +162,14 @@ class TestAPIKeysView:
     """Test API keys management view"""
 
     def test_api_keys_view_requires_login(self):
-        """GET to /settings/api-keys/ requires authentication"""
+        """GET to the api-keys page requires authentication.
+
+        The page now lives under /accounts/ after the apps/config
+        standardization (see ADR-0002). Use reverse() so the test does
+        not regress if the mount point moves again.
+        """
         client = Client()
-        response = client.get("/settings/api-keys/", follow=True)
+        response = client.get(reverse("accounts_app:api_keys"), follow=True)
         # Should redirect to login
         assert response.status_code == 200
         # Check we ended up at login page or redirected
@@ -173,7 +179,7 @@ class TestAPIKeysView:
         )
 
     def test_api_keys_view_logged_in_user(self):
-        """GET to /settings/api-keys/ returns 200 for logged-in user"""
+        """GET to the api-keys page returns 200 for logged-in user."""
         client = Client()
         user = User.objects.create_user(
             username="testuser6",
@@ -184,7 +190,7 @@ class TestAPIKeysView:
             password="testpass123",  # pragma: allowlist secret
         )
 
-        response = client.get("/settings/api-keys/")
+        response = client.get(reverse("accounts_app:api_keys"))
         assert response.status_code == 200
 
     def test_api_keys_view_context_data(self):
@@ -203,7 +209,7 @@ class TestAPIKeysView:
         APIKey.create_key(user=user, name="key1", scopes=["*"])
         APIKey.create_key(user=user, name="key2", scopes=["mcp"])
 
-        response = client.get("/settings/api-keys/")
+        response = client.get(reverse("accounts_app:api_keys"))
         assert response.status_code == 200
         # Check context has api_keys
         assert "api_keys" in response.context

--- a/tests/apps/llm_app/views/test_chat_tts_relay.py
+++ b/tests/apps/llm_app/views/test_chat_tts_relay.py
@@ -35,20 +35,36 @@ def _post_json(client, body):
     return client.post(_RELAY_URL, data=body, content_type="application/json")
 
 
-def _receive_group_message(group_name):
-    """Subscribe a temporary channel to the group and return one message.
+def _subscribe_to_group(group_name):
+    """Subscribe a fresh channel to ``group_name`` BEFORE the sender runs.
 
-    Returns the delivered dict, or None if nothing was delivered within the
-    timeout. Uses the real default channel layer (InMemoryChannelLayer under
-    the override_settings applied to the test classes).
+    InMemoryChannelLayer's ``group_send`` fans out to whichever channels are
+    currently in the group — there is no replay of missed messages to late
+    subscribers. So to test that a view's ``group_send`` reached the group,
+    the test must subscribe first, trigger the view, then receive.
+
+    Returns the channel name; pass to :func:`_receive_on_channel`.
+    """
+    layer = get_channel_layer()
+
+    async def _subscribe():
+        channel = await layer.new_channel()
+        await layer.group_add(group_name, channel)
+        return channel
+
+    return async_to_sync(_subscribe)()
+
+
+def _receive_on_channel(channel, timeout=1.0):
+    """Pull one message from a channel previously added to a group.
+
+    Returns the delivered dict, or None if nothing arrived within timeout.
     """
     layer = get_channel_layer()
 
     async def _pull():
-        channel = await layer.new_channel()
-        await layer.group_add(group_name, channel)
         try:
-            return await asyncio.wait_for(layer.receive(channel), timeout=1.0)
+            return await asyncio.wait_for(layer.receive(channel), timeout=timeout)
         except asyncio.TimeoutError:
             return None
 
@@ -162,21 +178,22 @@ class TestTtsRelayChannelSend(TestCase):
 
     def test_relay_delivers_message_to_user_speech_group(self):
         """A subscriber on speech_<username> must receive the relayed message."""
-        # Arrange
-        group_name = self.group_name
+        # Arrange — subscribe BEFORE the view runs (InMemoryChannelLayer
+        # does not replay missed messages to late subscribers).
+        channel = _subscribe_to_group(self.group_name)
         # Act
         _post_json(self.client, json.dumps({"text": "hello from container"}))
-        message = _receive_group_message(group_name)
+        message = _receive_on_channel(channel)
         # Assert
         assert message is not None
 
     def test_relay_message_has_tts_speak_type(self):
         """The message delivered to the group must have type tts_speak."""
         # Arrange
-        group_name = self.group_name
+        channel = _subscribe_to_group(self.group_name)
         # Act
         _post_json(self.client, json.dumps({"text": "speak this"}))
-        message = _receive_group_message(group_name)
+        message = _receive_on_channel(channel)
         # Assert
         assert message["type"] == "tts_speak"
 
@@ -184,9 +201,10 @@ class TestTtsRelayChannelSend(TestCase):
         """The delivered message must carry the exact text from the request body."""
         # Arrange
         expected_text = "precise text payload"
+        channel = _subscribe_to_group(self.group_name)
         # Act
         _post_json(self.client, json.dumps({"text": expected_text}))
-        message = _receive_group_message(self.group_name)
+        message = _receive_on_channel(channel)
         # Assert
         assert message["text"] == expected_text
 
@@ -230,11 +248,12 @@ class TestTtsRelaySuccessResponse(TestCase):
 
     def test_relay_long_text_is_truncated_to_4096_chars(self):
         """Text longer than 4096 chars must be truncated to 4096 on the wire."""
-        # Arrange
+        # Arrange — subscribe first (see _subscribe_to_group docstring).
         group_name = f"speech_{self.user.username}"
+        channel = _subscribe_to_group(group_name)
         # Act
         _post_json(self.client, json.dumps({"text": "a" * 5000}))
-        message = _receive_group_message(group_name)
+        message = _receive_on_channel(channel)
         # Assert
         assert len(message["text"]) <= 4096
 


### PR DESCRIPTION
## Summary

This is the URL + TTS portion of #213, split out so it can land
immediately. The audit `skip_rules` portion is deliberately held back
because it changes the brand-quality gate and is being deliberated
with the operator.

### Two root causes, both real fixes (no skips, no mocks)

1. **accounts_app/views/test_api_keys_views.py** — restore `reverse()`.
   The three `TestAPIKeysView.client.get` calls were migrated to
   `reverse('accounts_app:api_keys')` in PR #204, but the subsequent
   merges of #202 / #203 carried the stale hard-coded
   `/settings/api-keys/` path in overlapping hunks and the
   merge-resolution kept HEAD's copy. Without `reverse()`, the tests
   hit `/settings/api-keys/` — which no longer resolves at the top
   level: settings pages were moved under `/accounts/` in the
   apps/config standardization (ADR-0002) — so the tests returned
   `404 == 200`. Re-apply `reverse()` and re-add the `django.urls`
   import.

2. **llm_app/views/test_chat_tts_relay.py** — subscribe BEFORE send.
   Four `TestTtsRelayChannelSend` tests plus
   `test_relay_long_text_is_truncated_to_4096_chars` called
   `_post_json` (which triggers the view's `group_send`) BEFORE
   subscribing to the group. `InMemoryChannelLayer.group_send` fans
   out to whichever channels are currently in the group — there is
   no replay for late subscribers, so the post-send subscriber
   always saw `None` (the `'NoneType' object is not subscriptable`
   failure).

   Split the helper into `_subscribe_to_group` (registers a channel
   first) and `_receive_on_channel` (pulls one message). Each
   affected test now subscribes, posts, then receives — the canonical
   channels-test pattern. The view's `async_to_sync(group_send)`
   from #206 stays; that production-side fix was correct, the
   test-side ordering was the remaining bug.

## Test plan

- [x] Both test files compile clean
- [ ] CI pytest-matrix: `tests/apps/accounts_app/views/test_api_keys_views.py`
      `TestAPIKeysView` ×3 → pass on py3.11 / 3.12 / 3.13
- [ ] CI pytest-matrix: `tests/apps/llm_app/views/test_chat_tts_relay.py`
      `TestTtsRelayChannelSend` ×3 + `test_relay_long_text_is_truncated_to_4096_chars`
      → pass on py3.11 / 3.12 / 3.13

## Out of scope

`tests/develop/test_audit.py::test_audit_all_clean` and the audit
`skip_rules` change. See #213 (kept open for operator review).