### PR TITLE
chore(scitex-todo): scaffold .scitex/todo/ for agent operational state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ references.bib
 !.scitex/dev/
 .scitex/dev/*
 !.scitex/dev/config.yaml
+# Project-tracked agent operational state (HOLDs, candidates, in-flight tasks)
+!.scitex/todo/
 
 ### Source: /home/ywatanabe/.git-templates/.gitignore-templates/Custom/Claude.gitignore ###
 .claude

--- a/.scitex/todo/CANDIDATES.md
+++ b/.scitex/todo/CANDIDATES.md
@@ -1,0 +1,41 @@
+<!-- ---
+!-- File: <repo>/.scitex/todo/CANDIDATES.md
+!-- Owner: proj-scitex-hub (agent) — refreshed when state.md changes.
+!-- Last update: 2026-06-01T22:27Z
+!-- --- -->
+
+# CANDIDATES — tasks the operator can pick from
+
+Numbered, agent-curated. Each entry references the relevant issue/PR
+or source of truth. Operator can say "go on N" and the agent picks it
+up.
+
+## Active candidates
+
+1. **Finish NAS cutover (E-G)** — operator-only steps remaining after
+   pre-flight: quiesce source agent → rsync `~/.scitex/hub/` (and
+   telegrammer DB) → `sac agents start proj-scitex-hub` on NAS. See
+   the most recent `GITIGNORED/HANDOFF_*.md` for the full recipe and
+   `IN_FLIGHT.md` for current status.
+2. **Prod issue triage** — pick one (or more) of:
+   - #148 — bug(slurm): 95 zombie `[srun]` processes leaking under daphne PID 1
+   - #150 — bug(umami): container restart loop, prisma auth 28P01
+   - #151 — investigate(celery): worker CPU sustained high
+   - #152 — meta: scitex.ai 504 outage tracker
+   - #153 — infra(scale): gunicorn+uvicorn revisit once async middleware lands
+3. **Merge PR #215** — release: sync `main` with `develop` (alpha
+   release tag follow-up).
+4. **App-store work** — pick from #146 (writer_app figrecipe pattern),
+   #137 (Clew Registry REST+SVG), #134/#133 (writer inline-comment /
+   living-paper).
+5. **NAS stability ops** — #135 (OOM protection / memory limits /
+   watchdog), #142 (pgbouncer userlist failure), #136 (Vite build
+   EACCES restart loop).
+6. **Long-tail refactors** — #32 (gitea CLI migrate to scitex-cloud),
+   #30 (docs.scitex.ai mkdocs), #19 (scholar crossref delegate).
+
+## Recently completed (pruned to last week)
+
+- PR #226 — admin-squash merged 2026-06-01.
+- PR #228 — admin-squash merged 2026-06-01.
+- NAS handoff preparation (artifacts: `~/.scitex/hub/*` + `GITIGNORED/HANDOFF_2026-06-01T2214Z.md`).

--- a/.scitex/todo/CANDIDATES.md
+++ b/.scitex/todo/CANDIDATES.md
@@ -1,7 +1,7 @@
 <!-- ---
 !-- File: <repo>/.scitex/todo/CANDIDATES.md
 !-- Owner: proj-scitex-hub (agent) — refreshed when state.md changes.
-!-- Last update: 2026-06-01T22:27Z
+!-- Last update: 2026-06-01T22:40Z
 !-- --- -->
 
 # CANDIDATES — tasks the operator can pick from
@@ -12,26 +12,23 @@ up.
 
 ## Active candidates
 
-1. **Finish NAS cutover (E-G)** — operator-only steps remaining after
-   pre-flight: quiesce source agent → rsync `~/.scitex/hub/` (and
-   telegrammer DB) → `sac agents start proj-scitex-hub` on NAS. See
-   the most recent `GITIGNORED/HANDOFF_*.md` for the full recipe and
-   `IN_FLIGHT.md` for current status.
-2. **Prod issue triage** — pick one (or more) of:
+1. **Finish NAS cutover (lead-driven, A-H)** — see `IN_FLIGHT.md` and `GITIGNORED/CUTOVER_PLAN_2026-06-01T2231Z.md`. Lead executes; agent verifies post-H.
+2. **scitex-hub SOC layer diagram** (operator request 2026-06-01T22:34Z via msgs 152-158, routed via lead post-cutover) — operator wants a vertical layered diagram for the scitex-hub Django+TS platform, in the same visual style as proj-grant's `08_scitex_soc_layers.png` (the 6-layer scitex Python pkg SOC). Components hinted: `Gitea / chat / AI agent / terminal / ssh / HPC support / login Auth / App Store / app SDK (ui, app)`. Output target: a figure to embed in `draft_v04.docx` (grant). **Held until lead routes back post-cutover.**
+3. **Prod issue triage** — pick one (or more) of:
    - #148 — bug(slurm): 95 zombie `[srun]` processes leaking under daphne PID 1
    - #150 — bug(umami): container restart loop, prisma auth 28P01
    - #151 — investigate(celery): worker CPU sustained high
    - #152 — meta: scitex.ai 504 outage tracker
    - #153 — infra(scale): gunicorn+uvicorn revisit once async middleware lands
-3. **Merge PR #215** — release: sync `main` with `develop` (alpha
+4. **Merge PR #215** — release: sync `main` with `develop` (alpha
    release tag follow-up).
-4. **App-store work** — pick from #146 (writer_app figrecipe pattern),
+5. **App-store work** — pick from #146 (writer_app figrecipe pattern),
    #137 (Clew Registry REST+SVG), #134/#133 (writer inline-comment /
    living-paper).
-5. **NAS stability ops** — #135 (OOM protection / memory limits /
+6. **NAS stability ops** — #135 (OOM protection / memory limits /
    watchdog), #142 (pgbouncer userlist failure), #136 (Vite build
    EACCES restart loop).
-6. **Long-tail refactors** — #32 (gitea CLI migrate to scitex-cloud),
+7. **Long-tail refactors** — #32 (gitea CLI migrate to scitex-cloud),
    #30 (docs.scitex.ai mkdocs), #19 (scholar crossref delegate).
 
 ## Recently completed (pruned to last week)

--- a/.scitex/todo/HOLDS.md
+++ b/.scitex/todo/HOLDS.md
@@ -1,0 +1,27 @@
+<!-- ---
+!-- File: <repo>/.scitex/todo/HOLDS.md
+!-- Owner: proj-scitex-hub (agent) — updated as HOLDs come and go.
+!-- Last update: 2026-06-01T22:27Z
+!-- --- -->
+
+# HOLDs — tasks blocked on operator approval
+
+Each entry: `- [ID] one-line description` + a short context block.
+Move resolved entries to the bottom under `## Resolved` (with a date)
+rather than deleting them.
+
+## Active
+
+_None at the moment._
+
+The previous active HOLD `[NAS-SYNC]` ("NAS staging sync — execute
+`git fetch && reset --hard origin/develop` + `make ENV=staging
+build/start/migrate` on the NAS") was released by the operator at
+**2026-06-01T22:18Z**. See `IN_FLIGHT.md` for current progress and
+`GITIGNORED/HANDOFF_*.md` for the most recent NAS pre-flight snapshot.
+
+## Resolved
+
+- **[NAS-SYNC]** released 2026-06-01T22:18Z — operator GO. Pre-flight
+  ran successfully (no-sudo subset); remaining sudo/scp steps tracked
+  in `IN_FLIGHT.md`.

--- a/.scitex/todo/IN_FLIGHT.md
+++ b/.scitex/todo/IN_FLIGHT.md
@@ -1,7 +1,7 @@
 <!-- ---
 !-- File: <repo>/.scitex/todo/IN_FLIGHT.md
 !-- Owner: proj-scitex-hub (agent) — kept fresh while a task runs.
-!-- Last update: 2026-06-01T22:27Z
+!-- Last update: 2026-06-01T22:33Z
 !-- --- -->
 
 # IN-FLIGHT — currently active tasks
@@ -10,30 +10,37 @@ One section per active task. Move to `CANDIDATES.md` (Completed) or
 delete when done. Empty `## ...` heading is fine while nothing is
 running.
 
-## NAS cutover — operator hands required
+## NAS cutover — lead-driven, agent verifies
 
 **Started:** 2026-06-01T22:18Z (operator GO)
-**Status:** pre-flight (no-sudo subset) complete; awaiting operator on
-sudo + scp steps.
+**Coordination:** as of 2026-06-01T22:32Z, **LEAD has host autonomy
+and drives the host-side steps**. Operator routes agent questions
+through lead. Agent reports to lead (not operator) for this task.
 
-Pre-flight done (executed on NAS via `ssh nas-direct` by the agent):
-- [x] `sac` CLI upgrade `0.11.0 → 0.21.9`
-- [x] `~/proj/scitex-cloud` remote → `ywatanabe1989/scitex-hub.git`, reset --hard origin/develop → `5f14b9b79`
-- [x] `~/proj/claude-code-telegrammer` full clone (replaced stub) → `4371e99`
+**Plan (authoritative):** `/work/GITIGNORED/CUTOVER_PLAN_2026-06-01T2231Z.md`
+
+Pre-flight (no-sudo subset) — done by agent 2026-06-01T22:23Z:
+- [x] `sac` CLI upgrade `0.11.0 -> 0.21.9` on NAS
+- [x] `~/proj/scitex-cloud` remote -> `ywatanabe1989/scitex-hub.git`, reset --hard origin/develop -> `5f14b9b79`
+- [x] `~/proj/claude-code-telegrammer` full clone (replaced stub) -> `4371e99`
 - [x] `mkdir -p ~/.scitex/agent-container/agents/proj-scitex-hub`
 
-Remaining steps (operator hands — sudo password or host-side scp
-required, agent cannot reach them):
+Lead-owned steps (host autonomy required — sudo, host-side `scp`, or
+claude CLI device flow):
 
-- [ ] **A.** `ssh nas-direct 'sudo mkdir -p /state/proj-scitex-hub /run/hub-secrets && sudo chown ywatanabe:ywatanabe /state/proj-scitex-hub /run/hub-secrets'`
-- [ ] **B.** `scp -rp ~/.scitex/agent-container/agents/proj-scitex-hub nas-direct:~/.scitex/agent-container/agents/` (source-host `spec.yaml` + `to_home/` outside agent bind mounts)
-- [ ] **C.** (after A) `scp -p /run/hub-secrets/bot-token nas-direct:/run/hub-secrets/bot-token && ssh nas-direct 'chmod 0600 /run/hub-secrets/bot-token'`
-- [ ] **D.** (only if `sac agents start` later flags incompatibility) `ssh nas-direct 'sudo ~/.venv-3.11/bin/sac image build base --yes'` (~5 min)
-- [ ] **E.** Quiesce source: `sac agents stop proj-scitex-hub` on ywata-note-win
-- [ ] **F.** (after E) `rsync -aHAX --delete /state/proj-scitex-hub/home/.scitex/hub/ nas-direct:/state/proj-scitex-hub/home/.scitex/hub/` (+ `.claude-code-telegrammer-scitex-hub/` for Telegram DB continuity)
-- [ ] **G.** (after F) `ssh nas-direct 'sac agents start proj-scitex-hub'`
+- [ ] **A.** `ssh nas-direct 'sudo mkdir -p /state/proj-scitex-hub /run/hub-secrets && sudo chown ywatanabe:ywatanabe ...'`
+- [ ] **B.** `scp -rp ~/.scitex/agent-container/agents/proj-scitex-hub nas-direct:~/.scitex/agent-container/agents/` **+ edit NAS spec.yaml so `apptainer.image` points at NAS-local SIF** (`/home/ywatanabe/.scitex/agent-container/containers/sac-base/sac-base.sif`, not `~/.dotfiles/src/...`)
+- [ ] **B'.** (alt to B's edit) Fix the broken `~/.dotfiles/src/.scitex` symlink on NAS so it resolves locally
+- [ ] **C.** Refresh `~/.claude` auth on NAS (claude CLI device flow as user `ywatanabe`)
+- [ ] **D.** (after A) `scp -p /run/hub-secrets/bot-token nas-direct:/run/hub-secrets/bot-token && ssh nas-direct 'chmod 0600 /run/hub-secrets/bot-token'`
+- [ ] **E.** (optional, fallback) `ssh nas-direct 'sudo ~/.venv-3.11/bin/sac image build base --yes'` — only if H fails on v3 incompat
+- [ ] **F.** `sac agents stop proj-scitex-hub` on ywata-note-win (quiesce source — Telegram silence starts here)
+- [ ] **G.** Rsync state (post-F): `~/.scitex/hub/` + `.claude-code-telegrammer-scitex-hub/` (+ optionally `state.db`, `session.jsonl`, `instance_id`, `session_id`). Full block in CUTOVER_PLAN.
+- [ ] **H.** `ssh nas-direct '~/.venv-3.11/bin/sac agents start proj-scitex-hub'`
 
-Once G is run, the new agent on NAS will execute its STARTUP PROTOCOL,
-post `[REPORT] proj-scitex-hub back online (account ywatanabe-scitex-ai).`
-to Telegram chat `8379369979`, and append a cutover entry to
-`~/.scitex/hub/decisions.md`.
+Once H is run, the new NAS-side agent will execute its STARTUP
+PROTOCOL, post `[REPORT] proj-scitex-hub back online (account
+ywatanabe-scitex-ai).` to Telegram chat `8379369979`, and append a
+cutover entry to `~/.scitex/hub/decisions.md`. Agent then updates this
+file to mark all steps `[x]` and moves the task into the recently-
+completed section of `CANDIDATES.md`.

--- a/.scitex/todo/IN_FLIGHT.md
+++ b/.scitex/todo/IN_FLIGHT.md
@@ -1,0 +1,39 @@
+<!-- ---
+!-- File: <repo>/.scitex/todo/IN_FLIGHT.md
+!-- Owner: proj-scitex-hub (agent) — kept fresh while a task runs.
+!-- Last update: 2026-06-01T22:27Z
+!-- --- -->
+
+# IN-FLIGHT — currently active tasks
+
+One section per active task. Move to `CANDIDATES.md` (Completed) or
+delete when done. Empty `## ...` heading is fine while nothing is
+running.
+
+## NAS cutover — operator hands required
+
+**Started:** 2026-06-01T22:18Z (operator GO)
+**Status:** pre-flight (no-sudo subset) complete; awaiting operator on
+sudo + scp steps.
+
+Pre-flight done (executed on NAS via `ssh nas-direct` by the agent):
+- [x] `sac` CLI upgrade `0.11.0 → 0.21.9`
+- [x] `~/proj/scitex-cloud` remote → `ywatanabe1989/scitex-hub.git`, reset --hard origin/develop → `5f14b9b79`
+- [x] `~/proj/claude-code-telegrammer` full clone (replaced stub) → `4371e99`
+- [x] `mkdir -p ~/.scitex/agent-container/agents/proj-scitex-hub`
+
+Remaining steps (operator hands — sudo password or host-side scp
+required, agent cannot reach them):
+
+- [ ] **A.** `ssh nas-direct 'sudo mkdir -p /state/proj-scitex-hub /run/hub-secrets && sudo chown ywatanabe:ywatanabe /state/proj-scitex-hub /run/hub-secrets'`
+- [ ] **B.** `scp -rp ~/.scitex/agent-container/agents/proj-scitex-hub nas-direct:~/.scitex/agent-container/agents/` (source-host `spec.yaml` + `to_home/` outside agent bind mounts)
+- [ ] **C.** (after A) `scp -p /run/hub-secrets/bot-token nas-direct:/run/hub-secrets/bot-token && ssh nas-direct 'chmod 0600 /run/hub-secrets/bot-token'`
+- [ ] **D.** (only if `sac agents start` later flags incompatibility) `ssh nas-direct 'sudo ~/.venv-3.11/bin/sac image build base --yes'` (~5 min)
+- [ ] **E.** Quiesce source: `sac agents stop proj-scitex-hub` on ywata-note-win
+- [ ] **F.** (after E) `rsync -aHAX --delete /state/proj-scitex-hub/home/.scitex/hub/ nas-direct:/state/proj-scitex-hub/home/.scitex/hub/` (+ `.claude-code-telegrammer-scitex-hub/` for Telegram DB continuity)
+- [ ] **G.** (after F) `ssh nas-direct 'sac agents start proj-scitex-hub'`
+
+Once G is run, the new agent on NAS will execute its STARTUP PROTOCOL,
+post `[REPORT] proj-scitex-hub back online (account ywatanabe-scitex-ai).`
+to Telegram chat `8379369979`, and append a cutover entry to
+`~/.scitex/hub/decisions.md`.

--- a/.scitex/todo/IN_FLIGHT.md
+++ b/.scitex/todo/IN_FLIGHT.md
@@ -1,7 +1,7 @@
 <!-- ---
 !-- File: <repo>/.scitex/todo/IN_FLIGHT.md
 !-- Owner: proj-scitex-hub (agent) — kept fresh while a task runs.
-!-- Last update: 2026-06-01T22:33Z
+!-- Last update: 2026-06-01T22:37Z
 !-- --- -->
 
 # IN-FLIGHT — currently active tasks
@@ -25,17 +25,18 @@ Pre-flight (no-sudo subset) — done by agent 2026-06-01T22:23Z:
 - [x] `~/proj/claude-code-telegrammer` full clone (replaced stub) -> `4371e99`
 - [x] `mkdir -p ~/.scitex/agent-container/agents/proj-scitex-hub`
 
-Lead-owned steps (host autonomy required — sudo, host-side `scp`, or
-claude CLI device flow):
+**Lead decisions locked in 2026-06-01T22:35Z:** SIF rebuild = LAZY (try H first), `session.jsonl` = YES preserve, Telegram `messages.db` = TRANSFER, claude OAuth = scp account snapshot (no browser flow).
+
+Lead-owned steps (host autonomy required — sudo, host-side `scp`):
 
 - [ ] **A.** `ssh nas-direct 'sudo mkdir -p /state/proj-scitex-hub /run/hub-secrets && sudo chown ywatanabe:ywatanabe ...'`
-- [ ] **B.** `scp -rp ~/.scitex/agent-container/agents/proj-scitex-hub nas-direct:~/.scitex/agent-container/agents/` **+ edit NAS spec.yaml so `apptainer.image` points at NAS-local SIF** (`/home/ywatanabe/.scitex/agent-container/containers/sac-base/sac-base.sif`, not `~/.dotfiles/src/...`)
-- [ ] **B'.** (alt to B's edit) Fix the broken `~/.dotfiles/src/.scitex` symlink on NAS so it resolves locally
-- [ ] **C.** Refresh `~/.claude` auth on NAS (claude CLI device flow as user `ywatanabe`)
+- [ ] **B.** `scp -rp ~/.scitex/agent-container/agents/proj-scitex-hub nas-direct:~/.scitex/agent-container/agents/` **+ edit NAS spec.yaml so `apptainer.image` points at NAS-local SIF**
+- [ ] **B'.** (alt to B's edit) fix `~/.dotfiles/src/.scitex` symlink on NAS to resolve locally
+- [ ] **C.** `scp -rp ~/.scitex/agent-container/accounts/ywatanabe-scitex-ai/ nas-direct:~/.scitex/agent-container/accounts/` — per-account OAuth snapshot (bound at `/tmp/sac-claude` per PR#284). Replaces interactive claude login.
 - [ ] **D.** (after A) `scp -p /run/hub-secrets/bot-token nas-direct:/run/hub-secrets/bot-token && ssh nas-direct 'chmod 0600 /run/hub-secrets/bot-token'`
-- [ ] **E.** (optional, fallback) `ssh nas-direct 'sudo ~/.venv-3.11/bin/sac image build base --yes'` — only if H fails on v3 incompat
-- [ ] **F.** `sac agents stop proj-scitex-hub` on ywata-note-win (quiesce source — Telegram silence starts here)
-- [ ] **G.** Rsync state (post-F): `~/.scitex/hub/` + `.claude-code-telegrammer-scitex-hub/` (+ optionally `state.db`, `session.jsonl`, `instance_id`, `session_id`). Full block in CUTOVER_PLAN.
+- [ ] **E.** (FALLBACK only) `ssh nas-direct 'sudo ~/.venv-3.11/bin/sac image build base --yes'` — only if H surfaces v3 incompat
+- [ ] **F.** Lead pings agent first; agent ACKs "freeze acknowledged"; then `sac agents stop proj-scitex-hub` on ywata-note-win (quiesce — Telegram silence starts here)
+- [ ] **G.** Rsync state (post-F): `~/.scitex/hub/`, `.claude-code-telegrammer-scitex-hub/`, `state.db`, `session.jsonl`, `instance_id`, `session_id` (full block in CUTOVER_PLAN)
 - [ ] **H.** `ssh nas-direct '~/.venv-3.11/bin/sac agents start proj-scitex-hub'`
 
 Once H is run, the new NAS-side agent will execute its STARTUP

--- a/.scitex/todo/README.md
+++ b/.scitex/todo/README.md
@@ -1,0 +1,42 @@
+<!-- ---
+!-- File: <repo>/.scitex/todo/README.md
+!-- Owner: proj-scitex-hub (agent) + operator
+!-- --- -->
+
+# `.scitex/todo/` — Project-Tracked Operational State
+
+This directory holds the **agent's working state that is useful for
+humans to see in the repo**: HOLDs awaiting operator approval, candidate
+tasks the operator can pick from, and tasks currently in-flight.
+
+## Layout
+
+| file | purpose | who updates |
+| --- | --- | --- |
+| `HOLDS.md` | tasks blocked on operator approval | agent (proj-scitex-hub) appends/clears; operator reviews |
+| `CANDIDATES.md` | candidate tasks the operator can pick (numbered options) | agent maintains based on open issues / state |
+| `IN_FLIGHT.md` | tasks currently being executed by the agent | agent updates as it works |
+
+## Conventions
+
+- **Plain Markdown**, one task per bullet, with a stable `[ID]` prefix
+  so cross-file references survive renames.
+- Agent rewrites these files freely (no PR review needed for state
+  changes) but a human-readable, time-stamped section header at the top
+  of each file records the last update.
+- For **per-event heavy snapshots** (full host inventory, NAS migration
+  recipes, etc.) use `<repo>/GITIGNORED/HANDOFF_<TIMESTAMP>.md` instead
+  — those are intentionally not committed.
+- For **agent-private cross-event ledgers** (decisions, sync-manifest)
+  use `~/.scitex/hub/` (= `/state/proj-scitex-hub/home/.scitex/hub/` on
+  the host).
+
+## Why both `.scitex/todo/` (tracked) and `~/.scitex/hub/` (private) exist
+
+- **Tracked** (`.scitex/todo/`) — what the *project* needs visible. PRs
+  and other developers benefit from seeing what's HOLD'd or in-flight.
+- **Private** (`~/.scitex/hub/`) — what the *agent* needs to remember
+  across restarts but does not belong in git (absolute host paths,
+  bot-token paths, append-only decision logs).
+
+The two never store the same fact; they serve different audiences.


### PR DESCRIPTION
## Summary
Scaffolds \`.scitex/todo/\` so the agent has a project-tracked place for HOLDs / candidates / in-flight tasks. Per operator direction:

| location | purpose | git? |
| --- | --- | --- |
| \`.scitex/todo/\` (this PR) | project-tracked operational state (HOLDs, candidates, in-flight) | YES |
| \`GITIGNORED/HANDOFF_<TIMESTAMP>.md\` | per-event heavy snapshots (host inventory, migration recipes) | NO (gitignored) |
| \`~/.scitex/hub/\` (agent-private) | cross-event ledgers (decisions, sync-manifest) | NO |

Bootstrap files (all auto-managed by \`proj-scitex-hub\` agent going forward):
- \`README.md\` — layout conventions
- \`HOLDS.md\` — currently empty (the NAS-SYNC HOLD was released 2026-06-01T22:18Z)
- \`CANDIDATES.md\` — current pickable tasks (NAS cutover finish, prod triage, release sync, etc.)
- \`IN_FLIGHT.md\` — current task: NAS cutover (pre-flight done, sudo/scp remaining)

Also whitelists \`.scitex/todo/\` in \`.gitignore\` (rest of \`.scitex/*\` stays ignored).

## Test plan
- [x] \`git check-ignore .scitex/todo/README.md\` returns nothing (whitelist works)
- [x] Pre-commit hooks pass
- [ ] Operator confirms the layout convention is what they had in mind