### PR TITLE
fix(prod): add init: true to django + celery_worker to reap zombies (#148)

### DIFF
--- a/deployment/docker/docker_prod/docker-compose.yml
+++ b/deployment/docker/docker_prod/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
     image: scitex-hub-prod-django:latest
+    # tini reaps SIGCHLD so subprocess/pty.fork+execvpe("srun", ...) children
+    # don't accumulate as zombies under daphne PID 1 (issue #148).
+    init: true
     entrypoint: ["/root-init.sh", "/entrypoint.sh"]
     command: ["daphne", "-b", "0.0.0.0", "-p", "8000", "--access-log", "-", "--verbosity", "1", "config.asgi:application"]
     volumes:
@@ -174,6 +177,9 @@ services:
   # Celery Worker (Async Task Processing)
   celery_worker:
     image: scitex-hub-prod-django:latest
+    # tini reaps SIGCHLD so compute_queue tasks that spawn srun/subprocess
+    # don't leave zombies under celery PID 1 (issue #148).
+    init: true
     entrypoint: ["/entrypoint.sh"]
     command: >
       celery -A config --broker=redis://redis:6379/1 worker


### PR DESCRIPTION
## Summary

- Add `init: true` to both `django` and `celery_worker` services in `deployment/docker/docker_prod/docker-compose.yml`.
- Tini (injected by docker via `init: true`) becomes PID 1 and reaps orphaned children, eliminating zombie accumulation from `pty.fork() + os.execvpe(\"srun\", ...)` in the terminal direct path, and from any subprocess paths in celery's `compute_queue` tasks.

## Why

`#148` reports 95 `[srun] <defunct>` processes under daphne PID 1 in `scitex-cloud-prod-django-1`, accumulated since Apr 15. Root cause:

- Daphne (asgi) runs as PID 1 with no SIGCHLD handler installed.
- `apps/workspace/console_app/views/terminal/execution.py:196` does `os.execvpe(\"srun\", cmd, env)` inside a `pty.fork()` child path; the child exit goes unreaped under PID 1.
- All other `subprocess.run` paths in the codebase are synchronous and self-reaping, so this is the only zombie source.

`init: true` is the smallest, safest fix and covers all current and future subprocess pathways. The long-tail option (force-broker-only terminal path / delete `pty.fork()` fallback) is out of scope here.

## Acceptance

Per `#148`:
- After 24h of prod traffic: `docker exec scitex-cloud-prod-django-1 ps -eo stat | grep -c ^Z` should report `0`.
- Same for `celery_worker` container.

## Test plan

- [ ] CI green (this is pure docker compose YAML, no python tests should exercise it)
- [ ] On prod: `make ENV=prod restart` → `docker inspect scitex-cloud-prod-django-1 | jq '.[0].HostConfig.Init'` returns `true`.
- [ ] After 1h prod traffic: zombie count stays at 0.

Refs: #148