### PR TITLE
fix(celery): soft-time-limit + acks_late + reject_on_worker_lost (#151)

### DIFF
--- a/config/settings/settings_celery.py
+++ b/config/settings/settings_celery.py
@@ -15,7 +15,17 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = "UTC"
 CELERY_TASK_TRACK_STARTED = True
-CELERY_TASK_TIME_LIMIT = 30 * 60  # 30 minutes max per task
+CELERY_TASK_TIME_LIMIT = 30 * 60  # 30 minutes hard kill (SIGKILL) per task
+# Soft limit fires SoftTimeLimitExceeded 5 minutes before hard kill so tasks
+# get a window to clean up (close cursors, release locks). Without this, a
+# stuck task burns the full 30 minutes before being killed (issue #151).
+CELERY_TASK_SOFT_TIME_LIMIT = 25 * 60
+# Ack after task finishes so a stuck task that gets killed (worker lost,
+# OOM, SIGKILL on hard limit) is requeued instead of silently dropped.
+CELERY_TASK_ACKS_LATE = True
+# Reject tasks back to the broker when the worker process dies, so the
+# next worker picks them up rather than the message being lost (issue #151).
+CELERY_TASK_REJECT_ON_WORKER_LOST = True
 CELERY_RESULT_EXTENDED = True
 
 # Test-mode eager execution


### PR DESCRIPTION
## Summary

Adds three Celery task-lifecycle safety settings to `config/settings/settings_celery.py`:

- `CELERY_TASK_SOFT_TIME_LIMIT = 25 * 60` — fires `SoftTimeLimitExceeded` 5 minutes before the existing 30-minute hard SIGKILL, giving tasks a window to release DB cursors, close files, drop locks.
- `CELERY_TASK_ACKS_LATE = True` — only ack the broker message after the task finishes (or hard-fails), so a SIGKILL'd / worker-lost / OOM'd task gets requeued instead of silently dropped.
- `CELERY_TASK_REJECT_ON_WORKER_LOST = True` — when the worker process dies, push the in-flight task back to the broker so another worker picks it up.

## Why

`#151` reports sustained 98% container CPU in `scitex-cloud-prod-celery_worker-1` with multiple children in `S` (not `R`). Diagnosis: a slow/stuck task in `compute_queue` / `ai_queue` / `search_queue` holds its worker slot for the full 30-minute hard limit with no cooperative cleanup signal, and if the worker dies the message is silently lost (default `acks_late=False`).

## Follow-up (not in this PR)

Per-queue overrides via `CELERY_TASK_ANNOTATIONS` for the heavy queues (e.g. `ai_queue` soft=300s/hard=360s, `compute_queue` soft=600s/hard=720s) — kept separate so this PR remains a pure safety-net config change with an obvious rollback.

## Acceptance

Per `#151`:
- No task accumulates beyond the soft limit without `SoftTimeLimitExceeded` being raised.
- Sustained worker CPU drops to background level between active jobs.

## Test plan

- [ ] CI green (config-only; existing celery test gate via `SCITEX_HUB_USE_SQLITE_DEV=1` still uses `CELERY_TASK_ALWAYS_EAGER=True` so soft limits are no-ops in test).
- [ ] On prod, after `make ENV=prod restart`: `celery -A config inspect conf` shows `task_soft_time_limit=1500`, `task_acks_late=True`, `task_reject_on_worker_lost=True`.

Refs: #151