### PR TITLE
docs(env): document SCITEX_CLOUD_* → SCITEX_HUB_POSTGRES_* rename (#150)

### DIFF
--- a/deployment/docker/docker_prod/docker-compose.yml
+++ b/deployment/docker/docker_prod/docker-compose.yml
@@ -144,6 +144,8 @@ services:
     env_file:
       - .env
     environment:
+      # SCITEX_HUB_POSTGRES_* (renamed from SCITEX_CLOUD_POSTGRES_*, see #150).
+      # If undefined, substitution yields empty and libpq falls back to OS user.
       - DATABASE_URL=postgresql://${SCITEX_HUB_POSTGRES_USER}:${SCITEX_HUB_POSTGRES_PASSWORD}@postgres:5432/${SCITEX_HUB_POSTGRES_DB}
     depends_on:
       postgres:
@@ -273,6 +275,9 @@ services:
     ports:
       - "${SCITEX_HUB_UMAMI_PORT_PROD:-3300}:3000"
     environment:
+      # SCITEX_HUB_POSTGRES_* (renamed from SCITEX_CLOUD_POSTGRES_*, see #150).
+      # If undefined, substitution yields empty and prisma reports 28P01
+      # "password authentication failed for user '<os-user>'".
       - DATABASE_URL=postgresql://${SCITEX_HUB_POSTGRES_USER}:${SCITEX_HUB_POSTGRES_PASSWORD}@postgres:5432/umami
       - DATABASE_TYPE=postgresql
       - APP_SECRET=${SCITEX_HUB_UMAMI_APP_SECRET:-scitex-umami-secret-2026}

--- a/deployment/docker/envs/.env.example
+++ b/deployment/docker/envs/.env.example
@@ -37,6 +37,15 @@ SCITEX_HUB_FORCE_HTTPS_COOKIES=false
 # ========================================
 # Database - PostgreSQL
 # ========================================
+# NOTE (2026-06-02, issue #150): the SCITEX_CLOUD_* prefix was renamed to
+# SCITEX_HUB_* during the scitex-cloud → scitex-hub rebrand. Compose files
+# (deployment/docker/docker_prod/docker-compose.yml:147,276 and others)
+# now reference ${SCITEX_HUB_POSTGRES_USER}/_PASSWORD/_DB with no default
+# fallback. Live .env.{dev,nas,prod,staging} files MUST use the SCITEX_HUB_
+# prefix — leaving SCITEX_CLOUD_POSTGRES_USER causes empty substitution
+# and libpq falls back to the OS user, producing 28P01 "password
+# authentication failed for user \"<os-user>\"" errors (e.g. umami restart
+# loop in #150).
 SCITEX_HUB_POSTGRES_DB=scitex_hub_dev
 SCITEX_HUB_POSTGRES_USER=scitex_dev
 SCITEX_HUB_POSTGRES_PASSWORD=CHANGE_ME_DB_PASSWORD


### PR DESCRIPTION
## Summary

- `.env.example` gains a multi-line NOTE above the `SCITEX_HUB_POSTGRES_*` block explaining the `SCITEX_CLOUD_* → SCITEX_HUB_*` prefix rename (scitex-cloud → scitex-hub rebrand) and the failure mode if the prefix is left wrong in live env files.
- `docker_prod/docker-compose.yml` gets two inline comments (above `DATABASE_URL` on lines ~147 and ~276) pointing at `#150` and the prisma 28P01 symptom.

## Why

`#150` reports umami in restart-loop with prisma `28P01 password authentication failed for user "admin"`. **The reported "admin" is not a wrong umami password** — it's the umami node container's libpq OS-user fallback after `${SCITEX_HUB_POSTGRES_USER}` substitutes to empty, because live `.env.prod` still uses the old `SCITEX_CLOUD_POSTGRES_USER` from before the rename.

## What this PR does NOT do

- Live `.env.{prod,nas,staging}` rename — handled host-side by lead (this agent does not have write access to secrets).
- Compose-side dual-prefix fallback (`${SCITEX_HUB_POSTGRES_USER:-${SCITEX_CLOUD_POSTGRES_USER}}`) — discussed and rejected in triage; clean break, prefix-rename happens via the env files.
- Umami container restart on prod — also lead-side once `.env.prod` is updated.

## Acceptance

Per `#150`:
- After lead's host-side `.env.prod` rename + umami restart: `docker compose -f deployment/docker/docker_prod/docker-compose.yml config` produces a `DATABASE_URL` with the real `SCITEX_HUB_POSTGRES_USER`, not empty.
- `umami-1` stays `Up (healthy)` > 1h.

## Test plan

- [ ] CI green (docs + 2 yaml-comment lines; no test exercise needed).

Refs: #150