### PR TITLE
fix(settings): route SCITEX_HUB_* env reads through alias helper

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -266,7 +266,7 @@
         "filename": "config/settings/settings_prod.py",
         "hashed_secret": "ec5885ea078711897661eefcb53aa60ec64c6b99",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 103
       }
     ],
     "deployment/.archive/manual/postgres/setup_postgres.sh": [
@@ -528,5 +528,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-01T00:41:43Z"
+  "generated_at": "2026-06-06T12:26:55Z"
 }

--- a/config/settings/settings_prod.py
+++ b/config/settings/settings_prod.py
@@ -17,6 +17,13 @@ Optimized for deployment with Cloudflare Tunnel.
 
 from dotenv import load_dotenv
 
+from config._env import (
+    getenv_with_legacy_alias as _getenv_alias,
+)
+from config._env import (
+    require_env_with_legacy_alias as _require_env_alias,
+)
+
 from .settings_shared import *
 
 # ---------------------------------------
@@ -41,9 +48,12 @@ DEBUG = os.getenv("DEBUG", "False").lower() in ("true", "1", "yes")
 SCITEX_WRITER_TEMPLATE_BRANCH = os.getenv("SCITEX_WRITER_TEMPLATE_BRANCH", "main")
 SCITEX_WRITER_TEMPLATE_TAG = os.getenv("SCITEX_WRITER_TEMPLATE_TAG", None)
 
-SECRET_KEY = os.environ.get("SCITEX_HUB_DJANGO_SECRET_KEY")
+# Fail-loud if SECRET_KEY is unset under BOTH canonical and legacy aliases.
+# Honors SCITEX_CLOUD_DJANGO_SECRET_KEY (ADR-0001 legacy) with a
+# DeprecationWarning when used.
+SECRET_KEY = _require_env_alias("SCITEX_HUB_DJANGO_SECRET_KEY")
 
-ALLOWED_HOSTS = os.environ.get("SCITEX_HUB_ALLOWED_HOSTS", "127.0.0.1,localhost").split(
+ALLOWED_HOSTS = _getenv_alias("SCITEX_HUB_ALLOWED_HOSTS", "127.0.0.1,localhost").split(
     ","
 )
 # Allow internal Docker container-to-container OAuth2 requests
@@ -58,7 +68,7 @@ SECURE_REDIRECT_EXEMPT = []
 
 # SSL handled by Cloudflare Tunnel
 SECURE_SSL_REDIRECT = (
-    os.environ.get("SCITEX_HUB_ENABLE_SSL_REDIRECT", "false").lower() == "true"
+    _getenv_alias("SCITEX_HUB_ENABLE_SSL_REDIRECT", "false").lower() == "true"
 )
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 X_FRAME_OPTIONS = "SAMEORIGIN"  # Allow same-site iframes (needed for PDF viewer)
@@ -68,10 +78,10 @@ SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 # Cookie
 # ---------------------------------------
 SESSION_COOKIE_SECURE = (
-    os.environ.get("SCITEX_HUB_FORCE_HTTPS_COOKIES", "true").lower() == "true"
+    _getenv_alias("SCITEX_HUB_FORCE_HTTPS_COOKIES", "true").lower() == "true"
 )
 CSRF_COOKIE_SECURE = (
-    os.environ.get("SCITEX_HUB_FORCE_HTTPS_COOKIES", "true").lower() == "true"
+    _getenv_alias("SCITEX_HUB_FORCE_HTTPS_COOKIES", "true").lower() == "true"
 )
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_HTTPONLY = True
@@ -79,7 +89,7 @@ CSRF_COOKIE_HTTPONLY = True
 # ---------------------------------------
 # Database
 # ---------------------------------------
-if os.environ.get("SCITEX_HUB_USE_SQLITE_PROD"):
+if _getenv_alias("SCITEX_HUB_USE_SQLITE_PROD"):
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
@@ -88,19 +98,19 @@ if os.environ.get("SCITEX_HUB_USE_SQLITE_PROD"):
     }
 else:
     # PostgreSQL (default for production)
-    DB_PASSWORD = os.environ.get("SCITEX_HUB_DB_PASSWORD")
+    DB_PASSWORD = _getenv_alias("SCITEX_HUB_DB_PASSWORD")
 
     if DB_PASSWORD and DB_PASSWORD != "CHANGE-THIS-DATABASE-PASSWORD-FOR-PROD":
         # Remote PostgreSQL via PgBouncer (for production deployment)
         DATABASES = {
             "default": {
                 "ENGINE": "django.db.backends.postgresql",
-                "NAME": os.environ.get("SCITEX_HUB_DB_NAME", "scitex_hub_prod"),
-                "USER": os.environ.get("SCITEX_HUB_DB_USER", "scitex_prod"),
+                "NAME": _getenv_alias("SCITEX_HUB_DB_NAME", "scitex_hub_prod"),
+                "USER": _getenv_alias("SCITEX_HUB_DB_USER", "scitex_prod"),
                 "PASSWORD": DB_PASSWORD,
                 # Connect via PgBouncer for connection pooling
-                "HOST": os.environ.get("SCITEX_HUB_DB_HOST", "pgbouncer"),
-                "PORT": os.environ.get("SCITEX_HUB_DB_PORT", "6432"),
+                "HOST": _getenv_alias("SCITEX_HUB_DB_HOST", "pgbouncer"),
+                "PORT": _getenv_alias("SCITEX_HUB_DB_PORT", "6432"),
                 # ATOMIC_REQUESTS disabled: incompatible with ASGI (Daphne)
                 # + PgBouncer transaction pooling.  Middleware and views run
                 # in different threads under ASGI, so a dirty connection in
@@ -126,14 +136,14 @@ else:
         DATABASES = {
             "default": {
                 "ENGINE": "django.db.backends.postgresql",
-                "NAME": os.environ.get("SCITEX_HUB_POSTGRES_DB", "scitex_hub_prod"),
-                "USER": os.environ.get("SCITEX_HUB_POSTGRES_USER", "scitex_prod"),
-                "PASSWORD": os.environ.get(
+                "NAME": _getenv_alias("SCITEX_HUB_POSTGRES_DB", "scitex_hub_prod"),
+                "USER": _getenv_alias("SCITEX_HUB_POSTGRES_USER", "scitex_prod"),
+                "PASSWORD": _getenv_alias(
                     "SCITEX_HUB_POSTGRES_PASSWORD", "CHANGE_THIS_IN_PROD"
                 ),
                 # Connect via PgBouncer for connection pooling
-                "HOST": os.environ.get("SCITEX_HUB_DB_HOST", "pgbouncer"),
-                "PORT": os.environ.get("SCITEX_HUB_DB_PORT", "6432"),
+                "HOST": _getenv_alias("SCITEX_HUB_DB_HOST", "pgbouncer"),
+                "PORT": _getenv_alias("SCITEX_HUB_DB_PORT", "6432"),
                 "ATOMIC_REQUESTS": False,
                 "CONN_MAX_AGE": 0,
                 "CONN_HEALTH_CHECKS": True,
@@ -153,16 +163,16 @@ ADMINS = [
 # Integration
 # ---------------------------------------
 # Gitea - Always enabled (core feature)
-GITEA_URL = os.environ.get("SCITEX_HUB_GITEA_URL", "https://git.scitex.ai")
-GITEA_API_URL = os.environ.get(
+GITEA_URL = _getenv_alias("SCITEX_HUB_GITEA_URL", "https://git.scitex.ai")
+GITEA_API_URL = _getenv_alias(
     "SCITEX_HUB_GITEA_API_URL", "https://git.scitex.ai/api/v1"
 )
-GITEA_TOKEN = os.environ.get("SCITEX_HUB_GITEA_TOKEN", "")
+GITEA_TOKEN = _getenv_alias("SCITEX_HUB_GITEA_TOKEN", "")
 GITEA_INTEGRATION_ENABLED = True  # Core feature, always enabled
 
 # Gitea Clone URLs (for user-facing clone button)
-SCITEX_HUB_GITEA_URL = os.environ.get("SCITEX_HUB_GITEA_URL", "https://git.scitex.ai")
-SCITEX_HUB_GIT_DOMAIN = os.environ.get("SCITEX_HUB_GIT_DOMAIN", "git.scitex.ai")
+SCITEX_HUB_GITEA_URL = _getenv_alias("SCITEX_HUB_GITEA_URL", "https://git.scitex.ai")
+SCITEX_HUB_GIT_DOMAIN = _getenv_alias("SCITEX_HUB_GIT_DOMAIN", "git.scitex.ai")
 SCITEX_HUB_GITEA_SSH_PORT = require_env("SCITEX_HUB_GITEA_SSH_PORT")
 
 # ---------------------------------------

--- a/config/settings/settings_staging.py
+++ b/config/settings/settings_staging.py
@@ -3,6 +3,7 @@
 # File: /home/ywatanabe/proj/scitex-hub/config/settings/settings_staging.py
 # ----------------------------------------
 from __future__ import annotations
+
 import os
 
 __FILE__ = "./config/settings/settings_staging.py"
@@ -15,8 +16,16 @@ Production-like setup for local testing before deployment.
 Uses daphne (ASGI) but without SSL/Cloudflare.
 """
 
-from .settings_shared import *
 from dotenv import load_dotenv
+
+from config._env import (
+    getenv_with_legacy_alias as _getenv_alias,
+)
+from config._env import (
+    require_env_with_legacy_alias as _require_env_alias,
+)
+
+from .settings_shared import *
 
 # ---------------------------------------
 # Env
@@ -39,10 +48,13 @@ DEBUG = os.getenv("DEBUG", "False").lower() in ("true", "1", "yes")
 SCITEX_WRITER_TEMPLATE_BRANCH = os.getenv("SCITEX_WRITER_TEMPLATE_BRANCH", "main")
 SCITEX_WRITER_TEMPLATE_TAG = os.getenv("SCITEX_WRITER_TEMPLATE_TAG", None)
 
-SECRET_KEY = os.environ.get("SCITEX_HUB_DJANGO_SECRET_KEY")
+# Fail-loud if SECRET_KEY is unset under BOTH canonical and legacy aliases.
+# Honors SCITEX_CLOUD_DJANGO_SECRET_KEY (ADR-0001 legacy) with a
+# DeprecationWarning when used.
+SECRET_KEY = _require_env_alias("SCITEX_HUB_DJANGO_SECRET_KEY")
 
 # Allow localhost and internal IPs for staging
-ALLOWED_HOSTS = os.environ.get(
+ALLOWED_HOSTS = _getenv_alias(
     "SCITEX_HUB_ALLOWED_HOSTS", "localhost,127.0.0.1,0.0.0.0"
 ).split(",")
 
@@ -67,7 +79,7 @@ SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_HTTPONLY = True
 
 # CSRF trusted origins for staging (port 31294 per 3129X scheme)
-CSRF_TRUSTED_ORIGINS = os.environ.get(
+CSRF_TRUSTED_ORIGINS = _getenv_alias(
     "SCITEX_HUB_CSRF_TRUSTED_ORIGINS",
     "http://localhost:31294,http://127.0.0.1:31294",
 ).split(",")
@@ -79,14 +91,14 @@ CSRF_TRUSTED_ORIGINS = os.environ.get(
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.environ.get("SCITEX_HUB_POSTGRES_DB", "scitex_hub_staging"),
-        "USER": os.environ.get("SCITEX_HUB_POSTGRES_USER", "scitex_staging"),
-        "PASSWORD": os.environ.get(
+        "NAME": _getenv_alias("SCITEX_HUB_POSTGRES_DB", "scitex_hub_staging"),
+        "USER": _getenv_alias("SCITEX_HUB_POSTGRES_USER", "scitex_staging"),
+        "PASSWORD": _getenv_alias(
             "SCITEX_HUB_POSTGRES_PASSWORD", "scitex_staging_2025"
         ),
         # Connect via PgBouncer for connection pooling
-        "HOST": os.environ.get("SCITEX_HUB_DB_HOST", "pgbouncer"),
-        "PORT": os.environ.get("SCITEX_HUB_DB_PORT", "6432"),
+        "HOST": _getenv_alias("SCITEX_HUB_DB_HOST", "pgbouncer"),
+        "PORT": _getenv_alias("SCITEX_HUB_DB_PORT", "6432"),
         "ATOMIC_REQUESTS": True,
         # CONN_MAX_AGE=0: Let PgBouncer handle connection pooling
         "CONN_MAX_AGE": 0,
@@ -103,7 +115,7 @@ DATABASES = {
 # Email
 # ---------------------------------------
 # Console backend for staging (no actual emails sent)
-EMAIL_BACKEND = os.getenv(
+EMAIL_BACKEND = _getenv_alias(
     "SCITEX_HUB_EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
 )
 
@@ -111,17 +123,17 @@ EMAIL_BACKEND = os.getenv(
 # Integration
 # ---------------------------------------
 # Gitea - Local staging instance
-GITEA_URL = os.environ.get("SCITEX_HUB_GITEA_URL_IN_CONTAINER", "http://gitea:3000")
+GITEA_URL = _getenv_alias("SCITEX_HUB_GITEA_URL_IN_CONTAINER", "http://gitea:3000")
 GITEA_API_URL = f"{GITEA_URL}/api/v1"
-GITEA_TOKEN = os.environ.get("SCITEX_HUB_GITEA_TOKEN", "")
+GITEA_TOKEN = _getenv_alias("SCITEX_HUB_GITEA_TOKEN", "")
 GITEA_INTEGRATION_ENABLED = True
 
 # Gitea Clone URLs (for user-facing clone button)
-SCITEX_HUB_GITEA_URL = os.environ.get(
+SCITEX_HUB_GITEA_URL = _getenv_alias(
     "SCITEX_HUB_GITEA_URL_IN_HOST", "http://localhost:3013"
 )
-SCITEX_HUB_GIT_DOMAIN = os.environ.get("SCITEX_HUB_GIT_DOMAIN", "127.0.0.1")
-SCITEX_HUB_GITEA_SSH_PORT = os.environ.get("SCITEX_HUB_GITEA_SSH_PORT", "2232")
+SCITEX_HUB_GIT_DOMAIN = _getenv_alias("SCITEX_HUB_GIT_DOMAIN", "127.0.0.1")
+SCITEX_HUB_GITEA_SSH_PORT = _getenv_alias("SCITEX_HUB_GITEA_SSH_PORT", "2232")
 
 # ---------------------------------------
 # Logging


### PR DESCRIPTION
## Summary
- `config/settings/settings_staging.py` and `settings_prod.py` called `os.environ.get("SCITEX_HUB_<X>", default)` directly, bypassing the `SCITEX_CLOUD_<X>` legacy fallback in `config/_env.getenv_with_legacy_alias` (ADR-0001).
- With only the deprecated `SCITEX_CLOUD_*` keys in `.env.staging` (or `.env.prod`), `SECRET_KEY` and DB/Gitea/cookie settings silently received empty values, causing `ImproperlyConfigured: SECRET_KEY must not be empty` at boot. Exactly the silent-empty fall-through the alias helper exists to prevent.
- Hits SECRET_KEY first, then DB auth, etc.

## Fix
- Import `getenv_with_legacy_alias` / `require_env_with_legacy_alias` in both `settings_staging.py` and `settings_prod.py`.
- Replace every raw `os.environ.get("SCITEX_HUB_...")` for vars in the rename surface with `_getenv_alias(...)`.
- Replace `os.environ.get("SCITEX_HUB_DJANGO_SECRET_KEY")` (which silently returned `None`) with `_require_env_alias(...)` so a missing secret fails loud at boot under BOTH canonical and legacy names.
- Non-SCITEX_HUB_* reads (`DEBUG`, `SCITEX_WRITER_TEMPLATE_*`) keep raw `os.getenv` — they aren't part of the rename surface.

## Behavior
- No change when `SCITEX_HUB_*` is set (canonical path).
- When only `SCITEX_CLOUD_*` is set, value now resolves with `DeprecationWarning` (the ADR-0001 contract) instead of silently returning `""`.
- When neither is set for a `_require_env_alias(...)` var, boot fails loud with a clear `EnvironmentError`.

## Test plan
- [x] Surfaced naturally during staging bring-up on NAS — boot failed with `ImproperlyConfigured: SECRET_KEY must not be empty` while `.env.staging` had `SCITEX_CLOUD_DJANGO_SECRET_KEY` set. With this change the helper resolves it.
- [ ] After merge, redeploy staging from rebuilt image, confirm Django boots cleanly when only `SCITEX_CLOUD_*` is set (with `DeprecationWarning`).
- [ ] Confirm boot fails loud when neither canonical nor legacy is set (test by unsetting both in a throwaway env).
- [ ] Same checks for prod when operator OKs a prod cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)