### PR TITLE
fix(scholar_app): make 0018_remove_search_limits idempotent

### DIFF
--- a/apps/workspace/scholar_app/migrations/0018_remove_search_limits.py
+++ b/apps/workspace/scholar_app/migrations/0018_remove_search_limits.py
@@ -4,14 +4,60 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
+    """Remove ``UserPreference.search_limits`` idempotently.
+
+    The original generated form used a bare ``migrations.RemoveField`` op,
+    which expanded to ``ALTER TABLE ... DROP COLUMN search_limits``. That
+    SQL is not idempotent: if the column is missing (e.g. a fresh DB where
+    something dropped it earlier, or a partial migration apply that was
+    retried), the rerun raises::
+
+        ProgrammingError: column "search_limits" of relation
+        "scholar_app_userpreference" does not exist
+
+    which crashes the whole ``migrate`` run. We hit this on a fresh staging
+    bring-up (NAS, 2026-06-06).
+
+    Fix: split into database vs state ops via ``SeparateDatabaseAndState``.
+
+    * ``database_operations`` uses raw SQL with ``DROP COLUMN IF EXISTS``
+      (PostgreSQL native idempotency) so reruns / partial-apply retries
+      are safe.
+    * ``state_operations`` carries the ``RemoveField`` so Django's
+      migration-state graph is updated identically to the old form —
+      downstream migrations that depend on this one (e.g. 0019_savedgraph)
+      see the same model.
+
+    Reverse: ``ADD COLUMN IF NOT EXISTS search_limits jsonb NOT NULL
+    DEFAULT '{}'::jsonb`` — mirrors the field def in
+    0016_add_search_limits_to_userpreference.py (``JSONField(default=dict,
+    blank=True)``) so a rollback restores the original column type.
+    """
 
     dependencies = [
         ("scholar_app", "0017_add_user_library_storage_fields"),
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name="userpreference",
-            name="search_limits",
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        "ALTER TABLE scholar_app_userpreference "
+                        "DROP COLUMN IF EXISTS search_limits;"
+                    ),
+                    reverse_sql=(
+                        "ALTER TABLE scholar_app_userpreference "
+                        "ADD COLUMN IF NOT EXISTS search_limits jsonb "
+                        "NOT NULL DEFAULT '{}'::jsonb;"
+                    ),
+                ),
+            ],
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="userpreference",
+                    name="search_limits",
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
## Summary
- `apps/workspace/scholar_app/migrations/0018_remove_search_limits.py` used a bare `migrations.RemoveField(...)` op, expanding to `ALTER TABLE ... DROP COLUMN search_limits`.
- That SQL is **not idempotent**: if the column is already missing (partial migration apply, retry after crash, etc.), the rerun crashes the whole `migrate` invocation with `ProgrammingError: column "search_limits" does not exist`.
- Hit during fresh staging bring-up on NAS (2026-06-06).

## Fix
- Wrap the field removal in `migrations.SeparateDatabaseAndState`:
  - `database_operations`: raw SQL with PostgreSQL's idempotent `DROP COLUMN IF EXISTS` (and `ADD COLUMN IF NOT EXISTS ... DEFAULT '{}'::jsonb` for reverse, mirroring the `JSONField(default=dict, blank=True)` in 0016_add_search_limits_to_userpreference.py).
  - `state_operations`: keeps the original `RemoveField` so Django's migration-state graph stays identical and downstream migrations (e.g. 0019_savedgraph) see the same model.

## Behavior
- No model change.
- No behavior change for a normal forward apply.
- Rerun-safe SQL only matters when the column is missing because an earlier 0018 attempt partially landed or was retried.

## Test plan
- [x] Surfaced naturally during staging bring-up on NAS — a partial migrate caused `ProgrammingError` on rerun.
- [ ] Apply on a fresh DB (no `scholar_app_userpreference.search_limits` at start) — should still succeed (DROP IF EXISTS is a no-op).
- [ ] Apply on a DB where 0016 created the column and 0017 added other fields — should drop the column as before.
- [ ] Reverse migration creates the column with the right type/default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)