### PR TITLE
fix(make): add --env-file ../envs/.env.prod to prod COMPOSE_CMD (Option C)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,11 @@ ifdef ENV
     COMPOSE_CMD := docker compose -f docker-compose.yml -f docker-compose.staging.yml
   else ifeq ($(ENV),prod)
     DOCKER_DIR := $(DOCKER_BASE_DIR)/docker_prod
-    COMPOSE_CMD := docker compose
+    # --env-file ../envs/.env.prod feeds SCITEX_HUB_*_PROD vars at compose-time
+    # (cloudflared token, ports). Symmetric with staging COMPOSE_CMD above.
+    # Closes RC-6's compose-time-substitution sibling gap surfaced in the
+    # 2026-06-06 cutover (docs/incidents/2026-06-06-prod-cutover-cloud-to-hub.md).
+    COMPOSE_CMD := docker compose --env-file ../envs/.env.prod
   endif
   # Export SCITEX_ENV for docker-compose to use in env_file selection
   export SCITEX_ENV := $(ENV)
@@ -418,18 +422,22 @@ stop-all:
 		echo -e "$(CYAN)Checking $$env...$(NC)"; \
 		if [ "$$env" = "dev" ]; then \
 			COMPOSE="docker compose"; \
+			COMPOSE_DIR="docker_dev"; \
 		elif [ "$$env" = "staging" ]; then \
 			COMPOSE="docker compose -f docker-compose.yml -f docker-compose.staging.yml"; \
+			COMPOSE_DIR="."; \
 		else \
-			COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.yml"; \
+			COMPOSE="docker compose --env-file ../envs/.env.prod"; \
+			COMPOSE_DIR="docker_prod"; \
 		fi; \
 		export SCITEX_ENV=$$env; \
-		if $$COMPOSE ps -q 2>/dev/null | grep -q .; then \
+		( cd $$COMPOSE_DIR 2>/dev/null && \
+		  if $$COMPOSE ps -q 2>/dev/null | grep -q .; then \
 			echo -e "  $(YELLOW)Stopping $$env containers...$(NC)"; \
 			$$COMPOSE down --remove-orphans 2>/dev/null || true; \
-		else \
+		  else \
 			echo -e "  $(GREEN)✓ $$env already stopped$(NC)"; \
-		fi; \
+		  fi ); \
 	done
 	@echo -e ""
 	@echo -e "$(GREEN)✅ All environments stopped$(NC)"

--- a/scripts/deploy/rebuild.sh
+++ b/scripts/deploy/rebuild.sh
@@ -67,6 +67,13 @@ if [ "$ENV" = "staging" ]; then
     DOCKER_DIR="$PROJECT_ROOT/deployment/docker"
     export SCITEX_ENV=staging
     COMPOSE_CMD="docker compose --env-file ./envs/.env.staging -f docker-compose.yml -f docker-compose.staging.yml"
+elif [ "$ENV" = "prod" ]; then
+    # --env-file ../envs/.env.prod feeds SCITEX_HUB_*_PROD vars at compose-time
+    # (cloudflared token, ports). Symmetric with staging COMPOSE_CMD above.
+    # Closes RC-6's compose-time-substitution sibling gap surfaced in the
+    # 2026-06-06 cutover (docs/incidents/2026-06-06-prod-cutover-cloud-to-hub.md).
+    DOCKER_DIR="$PROJECT_ROOT/deployment/docker/docker_prod"
+    COMPOSE_CMD="docker compose --env-file ../envs/.env.prod"
 else
     DOCKER_DIR="$PROJECT_ROOT/deployment/docker/docker_${ENV}"
     COMPOSE_CMD="docker compose"
@@ -162,7 +169,16 @@ nice -n 10 $COMPOSE_CMD build
 
 # Step 4: Clear vite timestamp (forces TypeScript rebuild)
 echo -e "${CYAN}  4. Clearing vite timestamp (forces TypeScript rebuild)...${NC}"
-docker run --rm -v "scitex-hub-${ENV}_static_volume:/staticfiles" alpine \
+# Prod uses external volumes named scitex-hub-nas_* (per docker_prod/docker-compose.yml
+# `external: true, name: scitex-hub-nas_*` declarations); dev/staging use auto-created
+# project-namespaced scitex-hub-${ENV}_*. Without this branch, the prod path silently
+# no-op'd on a volume that doesn't exist — surfaced 2026-06-06 cutover postmortem.
+if [ "$ENV" = "prod" ]; then
+    STATIC_VOL="scitex-hub-nas_static_volume"
+else
+    STATIC_VOL="scitex-hub-${ENV}_static_volume"
+fi
+docker run --rm -v "${STATIC_VOL}:/staticfiles" alpine \
     rm -f /staticfiles/vite/.build-timestamp 2>/dev/null || true
 
 # Step 5: Start services


### PR DESCRIPTION
## Summary

Closes the three gaps the 2026-06-06 prod cutover surfaced in the `make`/`rebuild.sh` prod path so future `make ENV=prod start` works clean end-to-end:

| Gap | Before | After |
|---|---|---|
| **1. compose-time substitution** | prod COMPOSE_CMD bare `docker compose`, no `--env-file` flag. Compose-time `${SCITEX_HUB_*_PROD}` (e.g. cloudflared token) fell back to `docker_prod/.env` which is the stale `SCITEX_CLOUD_*`-only file → cloudflared got empty token | `docker compose --env-file ../envs/.env.prod` (symmetric with staging) |
| **2. stop-all divergence** | `make stop-all` for prod used a different compose path than `make ENV=prod start` (project namespace mismatch) | stop-all's prod branch matches start (`cd docker_prod && docker compose --env-file ../envs/.env.prod down`); fixed dev branch missing `COMPOSE_DIR` too |
| **3. rebuild.sh step 4 volume drift** | Hardcoded `scitex-hub-${ENV}_static_volume` evaluates to `scitex-hub-prod_static_volume` for prod, but prod compose declares external `scitex-hub-nas_static_volume` → step silently no-op'd | prod branch uses actual external name `scitex-hub-nas_static_volume` |

## Why

The 2026-06-06 SCITEX_CLOUD_* → SCITEX_HUB_* prod cutover surfaced **RC-6**: container runtime env was reading stale `docker_prod/.env` despite `--env-file` flag on the CLI (env_file: directive vs --env-file flag are different inputs). PR #240 fixed the runtime layer (env_file directive → `../envs/.env.prod`). But the compose-time substitution layer (the OTHER input for `${VAR}` references in the compose file) still relied on `docker_prod/.env`. For the cloudflared `--token ${SCITEX_HUB_CLOUDFLARE_TUNNEL_TOKEN_PROD}`, that meant the token resolved to empty if the local `.env` didn't have the var.

The v3 #4 cutover (2026-06-07) worked around this by running `docker compose --env-file ../envs/.env.prod up -d` manually instead of `make ENV=prod start` (Option B in the postmortem). This PR is the Option C follow-up: make the `make` path do it correctly so the operator's habitual `make ENV=prod start` works.

## Scope (does NOT touch)

- Container runtime env (`env_file:` directive) — already fixed by PR #240
- The shared `docker_prod/.env` file on disk (rollback compose still reads it as its `SCITEX_CLOUD_*` source per per-stack separation)
- Any image (purely Makefile + shell-script changes; no rebuild needed)

## Test plan

- [ ] CI green
- [ ] Post-merge, NAS pull, then verify `make ENV=prod start` brings up scitex-hub-prod containers correctly (cloudflared connects, all 11 healthy, scitex.ai still serving). Suggested to verify in a dryrun project name first to avoid disrupting the live stack.
- [ ] After confirmation, this becomes the canonical prod-start path (closes the cutover's "use the operator's make habit" arc).

## Refs

- `docs/incidents/2026-06-06-prod-cutover-cloud-to-hub.md` — the cutover postmortem
- PR #240 — env_file directive fix (sibling: runtime env layer)
- ADR-0001 — SCITEX_CLOUD_* → SCITEX_HUB_* rename
- Issue #243 — canonicalize docker-compose.rollback.yml (related housekeeping)
- Issue #242 — visitor-pool ImportError (latent bug surfaced during #4 warmup)
