### PR TITLE
docs(incidents): extend prod cutover postmortem with RC-6 final + RC-7 + v3 #4 timeline

### DIFF
--- a/docs/incidents/2026-06-06-prod-cutover-cloud-to-hub.md
+++ b/docs/incidents/2026-06-06-prod-cutover-cloud-to-hub.md
@@ -170,24 +170,202 @@ contained 80. The old prod stack continued to work because its image was the
 pre-PR-#237 build that read `SCITEX_CLOUD_DB_NAME` directly — matching the
 stale env.
 
-### Fix
+### Fix — per-stack env separation (NOT a global symlink)
 
-1. Repo: `deployment/docker/docker_prod/docker-compose.yml` — change every
-   `env_file: - .env` to `env_file: - ../envs/.env.prod`. One source of truth,
-   no ambiguous `.env` resolution. Lives in this PR.
-2. NAS-side: `mv docker_prod/.env docker_prod/.env.stale-apr25-pre-rename`
-   then `ln -sf ../envs/.env.prod docker_prod/.env`. Belt-and-suspenders so a
-   compose that still references `.env` resolves correctly. Applied 2026-06-07
-   00:54 JST.
-3. Mandatory dryrun gate before v3 attempt #4: re-run the full single-stack
-   shape (cloudflared + nginx + celery + pgbouncer-as-only-DB-path) against
-   the restored DB with the corrected env_file → must reach http 200 + 82 +
-   nhk2202 + clean entrypoint completion → only then schedule attempt #4.
+The HUB and ROLLBACK stacks need DIFFERENT env files: the hub stack must read
+`SCITEX_HUB_*` (new naming + new DB `scitex_hub_nas`), the rollback stack must
+read `SCITEX_CLOUD_*` (legacy naming + old DB `scitex_cloud_nas`). A global
+symlink `docker_prod/.env → ../envs/.env.prod` would point BOTH stacks at the
+hub env file — which would convert the rollback stack into a landmine on its
+next container recreate (host reboot, `restart: always` respawn, OOM, manual
+restart): rollback django would read `SCITEX_HUB_DB_NAME=scitex_hub_nas`, ask
+pgbouncer for a DB the rollback postgres doesn't have, and enter the same
+restart loop — but this time inside our safety floor. An initial attempt at
+this symlink (2026-06-07 00:54 JST) was reverted ~5 min later (01:01 JST) on
+review.
 
-## Operator-facing follow-ups
+The correct fix is per-stack separation, scoped to each compose file:
 
-* Anthropic API key visible in `.env.staging` (flagged earlier by lead, separate from this incident).
-* `make rebuild`'s Apptainer sandbox post-step still errors on read-only fs (non-blocking but noisy).
-* The new prod compose's volume `external: true` declarations require operators to pre-create any volume they wipe before the next `up` (RC-5). Consider switching to compose-managed volumes (no `external:`) once the cutover is stable, so deletes self-heal.
+1. **HUB compose** (`docker_prod/docker-compose.yml`, in repo, PR #240):
+   change every `env_file: - .env` to `env_file: - ../envs/.env.prod`. Hub
+   stack now reads the canonical `SCITEX_HUB_*` source directly with no
+   `.env` dependency. **Container runtime env layer fixed.**
+2. **ROLLBACK compose** (`docker_prod/docker-compose.rollback.yml`, NAS-local
+   recovery artifact, not in repo until issue #243 lands): keeps
+   `env_file: - .env` as-is. `.env` is the regular file with `SCITEX_CLOUD_*`
+   only — exactly what rollback needs.
+3. The shared `docker_prod/.env` regular file is left UNTOUCHED. After PR
+   #240 merges, the hub stack no longer reads it; only rollback does.
+4. **Compose-time `${VAR}` substitution layer** (the OTHER half of the env
+   path that PR #240's `env_file:` directive change does NOT cover): for the
+   make path the fix is **PR #244** (Option C) — adds `--env-file
+   ../envs/.env.prod` to the prod `COMPOSE_CMD` in Makefile + rebuild.sh,
+   symmetric with the existing staging COMPOSE_CMD. Without this, compose-time
+   `${SCITEX_HUB_CLOUDFLARE_TUNNEL_TOKEN_PROD}` (in the cloudflared service
+   command) would resolve from `docker_prod/.env` (the stale SCITEX_CLOUD_*
+   file) → empty token → tunnel dead even with django serving 200.
+
+## v3 attempt #4 timeline (2026-06-07 02:30–03:10 JST)
+
+Operator gave explicit GO ("今すぐGO" + "fail freely, no need to revert").
+Lead's directives in effect: data floor absolute (sources `:ro`, dump
+preserved); fail-forward (no auto-rollback); abort signature = django
+RestartCount ≥ 2 OR Exited (not slow-warmup).
+
+Phases executed:
+
+1. **PREP** — closed PR #241 as duplicate (PR #240 already on develop, only
+   doc-correction remained); NAS `git pull` to 8794dac4; cloudflared token
+   pre-flight ✓; fresh `pg_dump` of live `scitex_cloud_nas` as `scitex_nas`
+   user → `v4-pre-20260606T165824Z.sql` (146 MB).
+2. **Pre-mirror** (all RO source, wipe-then-cp -a target):
+   * `gitea_data` 12.1 GB → 43m16s (HDD + many small git objects)
+   * `scitex_config_volume` 136 MB → 2.16s
+   * `media_volume` 683 MB → 2.53s
+   * Sources (`scitex-cloud-nas_*`) never mutated. Site serving throughout.
+3. **DOWN (downtime begins)** — manual `docker compose -p scitex-cloud-prod
+   -f docker_prod/docker-compose.rollback.yml down --remove-orphans` (Gap 2:
+   make couldn't reach the legacy `scitex-cloud-prod` project). First attempt
+   failed because rollback compose was at `/tmp/rollback.yml` and compose
+   resolved its `env_file: .env` relative to /tmp/. Retried with rollback
+   compose restored to `docker_prod/` (its proper location, so `.env`
+   resolves to the existing stale-Apr25 file with SCITEX_CLOUD_* keys). 12
+   containers stopped+removed in 40.4s; 7 scitex-cloud-nas_* volumes
+   preserved.
+4. **First UP attempt — FAILED, restart-loop signature** — naive `docker
+   compose up -d` brought up ALL services at once. Django's entrypoint ran
+   `migrate` against a fresh-empty `scitex_hub_nas` and created Django's
+   types/extensions. Then the v4 dump restore ran AFTER → tried to recreate
+   those types → `django.db.utils.IntegrityError: duplicate key value
+   violates unique constraint "pg_type_typname_nsp_index"`. Plus stale
+   `static_volume` (not wiped, had v3 #3 root-owned files) → `EACCES
+   permission denied` during vite build. RestartCount hit 2 → STOP per gate.
+5. **Diagnosis** — sequencing race: dryrun A had run postgres+pgbouncer
+   first, then restored dump, then brought up the rest. The v3 #4 first-try
+   ran everything at once and put migrate BEFORE restore. Plus
+   static_volume residue caused the EACCES (mirrored volumes were
+   ownership-preserved by `cp -a`, but static was kept as-is from v3 #3
+   which had root-owned files).
+6. **Corrected sequence (FIX1+FIX2+FIX3)**:
+   * **FIX1**: `down hub-prod` (keep volumes), wipe
+     `scitex-hub-nas_{postgres_data,static_volume}` (the two residue
+     volumes; do NOT touch the mirrored gitea/media/scitex_config), `up
+     postgres pgbouncer redis` only, wait postgres healthy.
+   * **FIX2**: restore v4 dump into freshly-empty `scitex_hub_nas`. 10.3s,
+     auth_user=82 ✓, nhk2202=155 ✓, NO IntegrityError (clean target).
+   * **FIX3**: `up -d` rest. Django's `migrate` saw populated
+     `django_migrations` → no-op → IntegrityError addressed. Visitor-pool
+     ImportError caused RestartCount=1 (known-benign per dryrun precedent,
+     issue #242), second start reached healthy at ~4 min.
+7. **INTEGRITY GATE GREEN**:
+   * https://scitex.ai/landing/ → HTTP 200 in 156ms, real SciTeX page
+   * `SELECT count(*) FROM auth_user` → 82
+   * `SELECT id, username FROM auth_user WHERE username='nhk2202'` →
+     `155|nhk2202`
+   * cloudflared tunnel: 3 quic connections registered (nrt07/12/16 Tokyo)
+   * All 11 hub-prod containers healthy
+8. **POST-DONE SMOKE GREEN** (per lead's "preserve workspaces" requirement):
+   * scitex_config_volume in django: 137 MB, scitex:scitex-owned, real
+     content (`browser/ logs/ scholar/ templates/ verification.db`)
+   * media_volume: 684 MB, scitex:scitex-owned, real subdirs
+     (`bibtex_enriched/ bibtex_uploads/ videos/`)
+   * gitea_data: 12.1 GB, git:git-owned, 47 repositories enumerated, gitea
+     internal API returns real repo list. No EACCES on the mirrored mounts.
+   * The single EACCES in django logs was the pre-FIX1 static_volume entry,
+     not an ongoing issue.
+
+Real outage window: `down` (02:52) → INTEGRITY GREEN (~03:10) ≈ 18 min.
+
+## RC-7: Sequencing race (up-all-then-restore vs postgres-first-then-restore)
+
+Naive `docker compose up -d` brings up ALL services in dependency order
+(postgres → django via `depends_on: postgres healthy`). Django's entrypoint
+runs `migrate` as part of its boot, against whatever state postgres has at
+that moment. If postgres is freshly-initialized-empty (because the volume was
+wiped pre-up), migrate creates the Django schema from scratch — including all
+the django-managed types/extensions. A subsequent `pg_dump` restore against
+that same DB then tries to CREATE TYPE / CREATE EXTENSION again → catalog
+collision → IntegrityError on `pg_type_typname_nsp_index`.
+
+Dryrun A had implicitly avoided this by bringing up postgres+pgbouncer first,
+restoring the dump before django ever started, then bringing up django.
+Django's migrate then saw the dump's `django_migrations` table as
+fully-populated → no-op → no schema re-creation → no collision.
+
+**Operational rule**: when restoring a `pg_dump` into a freshly-initialized
+prod-like postgres, always restore BEFORE the django container starts
+migrating. The corrected runbook (next section) enforces this.
+
+## Corrected runbook for cutover-with-pg_dump
+
+For future cutover-style operations that combine "fresh DB volume + restore
+dump + bring up django stack":
+
+```
+1. PREP (no downtime):
+   a. NAS git pull develop (must have PR #240 + PR #244 merged)
+   b. Verify envs/.env.prod has SCITEX_HUB_*_PROD vars (esp. cloudflared token)
+   c. Take fresh pg_dump from live source (read-only):
+      pg_dump -U <db-user> -d <source-db> --clean --if-exists \
+        --no-owner --no-privileges > /backups/v<n>-pre-<ts>.sql
+   d. (If migrating file volumes) Pre-mirror RO source → wiped target with
+      cp -a (preserve ownership) or rsync -aH --delete (more robust on
+      ongoing changes); never delete or write to source volumes.
+
+2. DOWNTIME (manual; old stack project name may not match make):
+   docker compose -p <old-project> -f <old-compose>.yml down --remove-orphans
+
+3. WIPE residue volumes (not the mirrored ones):
+   docker volume rm scitex-hub-nas_postgres_data
+   docker volume create scitex-hub-nas_postgres_data
+   docker volume rm scitex-hub-nas_static_volume      # regen on collectstatic
+   docker volume create scitex-hub-nas_static_volume
+
+4. UP DB-TIER ONLY (postgres+pgbouncer+redis):
+   cd deployment/docker/docker_prod
+   docker compose --env-file ../envs/.env.prod up -d postgres pgbouncer redis
+   # wait postgres (healthy)
+
+5. RESTORE dump into the freshly-empty DB (BEFORE django ever starts):
+   cat /backups/v<n>-pre-<ts>.sql | docker exec -i scitex-hub-prod-postgres-1 \
+     psql -U <db-user> -d <target-db>
+   # verify expected row counts before proceeding
+
+6. UP REST of stack:
+   docker compose --env-file ../envs/.env.prod up -d
+   # django's migrate is now a no-op against the restored django_migrations table
+
+7. WARMUP (≥6 min budget) — gate: abort on RestartCount≥2 OR Exited (NOT
+   slow-warmup; start_period is legitimately 4-5 min for collectstatic +
+   workspace pip/npm).
+
+8. INTEGRITY GATE: https://<domain>/<known-path> → 200 + DB row counts +
+   canary user + real page rendering + tunnel up.
+```
+
+After PR #244 merges, step 6 simplifies to `make ENV=prod start` (Option C
+makes the make path symmetric with staging).
+
+## Operator-facing follow-ups (status updated 2026-06-07)
+
+* **PR #244** opened (Option C) — adds `--env-file ../envs/.env.prod` to
+  prod COMPOSE_CMD in Makefile + rebuild.sh; closes Gap 1 (compose-time
+  --env-file), Gap 2 (stop-all project name divergence), Gap 3 (rebuild.sh
+  static_volume name drift). After merge, `make ENV=prod start` works clean
+  for the operator's habitual path.
+* **Issue #242** filed — visitor-pool `ImportError:
+  scitex.template.clone_template` crashes django on every boot, recovers on
+  restart; latent bug to fix with try/except OR pip install.
+* **Issue #243** filed — canonicalize NAS-local `docker-compose.rollback.yml`
+  into the repo (`deployment/docker/docker_prod/`) so the rollback floor
+  definition is version-controlled.
+* Anthropic API key visible in `.env.staging` (flagged earlier by lead,
+  separate from this incident).
+* `make rebuild`'s Apptainer sandbox post-step still errors on read-only fs
+  (non-blocking but noisy).
+* The new prod compose's volume `external: true` declarations require
+  operators to pre-create any volume they wipe before the next `up` (RC-5).
+  Consider switching to compose-managed volumes (no `external:`) once the
+  cutover is stable, so deletes self-heal.
 
 <!-- EOF -->


### PR DESCRIPTION
## Summary

Per the 2026-06-07 cutover wrap-up, extends `docs/incidents/2026-06-06-prod-cutover-cloud-to-hub.md` with:

1. **CORRECTED Fix section** — the original "ln -sf docker_prod/.env → ../envs/.env.prod" symlink approach was applied operationally at 00:54 JST, vetoed by lead on review (would have repointed rollback stack at the hub env file on next container recreate), and reverted at 01:01 JST. Replaced with the per-stack env separation rationale that actually landed (PR #240 for runtime env_file directive + PR #244 for compose-time `--env-file`). The symlink apply/revert timeline is recorded for historical accuracy.

2. **NEW: v3 attempt #4 timeline (02:30–03:10 JST 2026-06-07)** — PREP through POST-DONE SMOKE GREEN, including the FIX1+FIX2+FIX3 iteration needed to close the sequencing race. Real outage window ≈ 18 min.

3. **NEW: RC-7 — Sequencing race** (up-all-then-restore vs postgres-first-then-restore). Naive `docker compose up -d` lets django's entrypoint migrate against a fresh-empty DB BEFORE the dump restore runs → schema collisions on the subsequent restore (`django.db.utils.IntegrityError: duplicate key value violates unique constraint "pg_type_typname_nsp_index"`). Operational rule: always restore BEFORE django starts migrating.

4. **NEW: Corrected runbook section** — step-by-step for any future cutover-with-pg_dump. After PR #244 merges, step 6 simplifies to `make ENV=prod start`.

5. **UPDATED: Operator-facing follow-ups** — links PR #244 (Option C make-ify), issue #242 (visitor-pool ImportError), issue #243 (canonicalize rollback compose).

## Why

The doc was the postmortem written DURING the cutover; it predates v3 #4, the corrected sequence, and the make-path fix. Lead asked for "RC-6 final + the sequencing-race finding + the full #4 timeline + the corrected runbook" as the canonical record. This PR provides that.

## Scope

- Doc-only (single file: `docs/incidents/2026-06-06-prod-cutover-cloud-to-hub.md`)
- +197/-19 lines
- No code or config changes

## Test plan

- [ ] CI green (docs-only PR; should be quick)
- [ ] Visual review of the new sections (timeline accuracy, runbook correctness, all PR/issue refs valid)

## Refs

- PR #239 — the original postmortem PR (this extends that doc)
- PR #240 — env_file directive fix (the runtime env layer of RC-6)
- PR #244 — Option C make-ify (the compose-time env layer of RC-6)
- Issue #242 — visitor-pool ImportError
- Issue #243 — canonicalize rollback compose
- ADR-0001 — SCITEX_CLOUD_* → SCITEX_HUB_* rename
