### PR TITLE
fix: scitex 2.26→2.30.1 + console PTY chdir to HOME (operator dogfooding refresh + bug fold)

### DIFF
--- a/apps/workspace/console_app/services/terminal_broker/session.py
+++ b/apps/workspace/console_app/services/terminal_broker/session.py
@@ -143,7 +143,14 @@ class BasePTY:
         env["LOGNAME"] = self.username
         env["TERM"] = "xterm-256color"
         env["SHELL"] = "/bin/bash"
-        os.chdir("/tmp")
+        # chdir to HOME so the host-side bash prompt (PS1 \w) shows the
+        # user's home rather than "tmp". For broker shells, apptainer's
+        # --pwd flag overrides this inside the container. Fall back to
+        # /tmp if HOME does not exist on the host (broker container).
+        try:
+            os.chdir(env["HOME"])
+        except OSError:
+            os.chdir("/tmp")
         return env
 
     def start_reader(self, output_callback):

--- a/deployment/docker/docker_prod/Dockerfile.prod
+++ b/deployment/docker/docker_prod/Dockerfile.prod
@@ -173,7 +173,8 @@ RUN uv pip install --system --no-cache "scitex[all]==2.26.0"
 # PyTorch etc. are already satisfied from Layer 0. uv skips them and
 # only downloads/installs the scitex package itself. (~30s)
 # No --no-cache here: we want uv to recognize existing packages.
-RUN uv pip install --system "scitex[all]==2.26.0"
+# 2026-06-07: bumped 2.26.0 → 2.30.1 (operator dogfooding refresh).
+RUN uv pip install --system "scitex[all]==2.30.1"
 
 # Playwright browsers (cached separately via BuildKit cache mount)
 RUN --mount=type=cache,target=/root/.cache/ms-playwright \


### PR DESCRIPTION
## Summary

Folded operator-requested dogfooding refresh + an unrelated-but-trivial console-cwd bug operator flagged in the same session. One image swap, same blast radius (django + celery_worker + celery_beat share the image).

| Commit | Scope |
|---|---|
| 1. `build(prod): bump scitex[all] 2.26.0 → 2.30.1 (Layer A)` | Dockerfile.prod line 176 pin bump. Layer 0 (heavy-deps anchor) stays at 2.26.0 per its "NEVER change this version" comment. |
| 2. `fix(console): PTY chdir to HOME, not hardcoded /tmp` | session.py:146 — operator reported "tmp $" prompt; chdir to env["HOME"] with /tmp safety fallback. |

## Why each commit

### Commit 1 (scitex refresh, operator's dogfooding directive)

PyPI gap analysis: only the umbrella `scitex` package was behind (installed 2.29.3, latest 2.30.1); all 38 individual scitex-* deps were already current. Bumping Layer A's pin invalidates its BuildKit cache hash so the rebuild actually pulls 2.30.1 (the prior `docker compose build` cache-hit and shipped the stale version silently).

### Commit 2 (chdir fix, operator screenshot)

Operator saw "tmp $" prompt on scitex.ai console. Root cause: `BasePTY._prepare_child_env()` did `os.chdir("/tmp")` unconditionally before fork; the PTY child inherited cwd. Two lines above, `env["HOME"] = f"/home/{username}"` was already set correctly — the chdir overrode that. Fix uses HOME with /tmp fallback.

Workspace-aware chdir (e.g. `/home/{user}/proj/{slug}`) would need 4-file plumbing from TerminalSession/Shell subclasses down through BasePTY.__init__ — and the in-container CWD is already correctly handled by apptainer's `--pwd` flag for the broker path. HOME is the right minimal fix for the host-side prompt.

## Deploy plan (post-merge, recorded for transparency)

1. NAS `git pull` develop
2. `cd docker_prod && docker compose --env-file ../envs/.env.prod build django` (Layer A re-resolves because pin hash changed)
3. **VERIFY before recreate:** `docker run --rm scitex-hub-prod-django:latest pip show scitex | grep Version` → must report 2.30.1. STOP if not.
4. Recreate the 3 image-sharing services: `... up -d --force-recreate django celery_worker celery_beat`
5. Integrity gate: scitex.ai/landing/ 200 + auth_user=82 + nhk2202 + real page render + cloudflared tunnel up
6. Console-cwd manual verify: open terminal on scitex.ai, prompt should now show `username@host:~$` (HOME) instead of `tmp $`
7. Rollback image `scitex-hub-prod-django:pre-2.30.1` already tagged ✓ — image revert is `docker tag pre-2.30.1 latest && up -d --force-recreate django celery_worker celery_beat`. DB/volumes untouched throughout.

## Test plan

- [ ] CI green (we expect the same 3 pytest-matrix failures as PR #240/#244 — pre-existing test infra issue, not regression. Will merge via --admin override as before.)
- [ ] Post-merge: pip-show-2.30.1 verification gate
- [ ] Integrity gate green
- [ ] Console manual verify (cwd ≠ /tmp)

## Followup work (separate issues to be filed)

1. **Pin-vs-reality drift**: Dockerfile pinned 2.26.0 but image shipped 2.29.3. Some prior out-of-band install bypassed the pin. The pin should be source of truth; investigate how it drifted (rebuild without cache invalidation? entrypoint upgrade?).
2. **Dogfooding-current mechanism**: a hard `==2.30.1` pin goes stale again next release. For operator's "always latest" goal, need a process (build-arg + periodic bump, or scheduled rebuild that pulls latest scitex). Design issue, not a quick fix.
3. **scitex_config missing in Apptainer sandbox** (separate from this PR's scope, surfaced by the chdir investigation): `apps/.../scitex_hub/_config/_loader.py:46` imports `scitex_config` which is not shipped in the prod Apptainer container. Affects any `scitex-hub` CLI invocation inside the container. Fix paths: rebuild container with `scitex_config` package OR make the import optional with stub fallback.

## Refs

- Operator dogfooding directive (via lead 5bbd1cc7): "更新する価値はあります、ドッグフーディングでひたすら改善していくため"
- Operator screenshot — "tmp $" prompt at console open
- 38-package version-gap analysis (in lead conversation 7fab1a63 reply)
- Investigation findings (in subagent report)
