### PR TITLE
fix(docker): bump Dockerfile.prod Layer 0 to scitex[all]==2.30.1 + smoke gate (closes #242)

### DIFF
--- a/deployment/docker/docker_prod/Dockerfile.prod
+++ b/deployment/docker/docker_prod/Dockerfile.prod
@@ -167,7 +167,15 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
 # This installs PyTorch, scipy, scikit-learn, etc. as transitive deps.
 # The version is intentionally old and frozen. Only update when scitex
 # changes its major dependency versions (e.g., PyTorch 2.x → 3.x).
-RUN uv pip install --system --no-cache "scitex[all]==2.26.0"
+#
+# 2026-06-07: bumped 2.26.0 → 2.30.1 so the [all] anchor resolves at a
+# scitex version whose [all] extra includes scitex-template + scitex-audit.
+# Previously, Layer 0 at 2.26.0 anchored the [all] extras to a version
+# that pre-dated those submodules; the later `.[all]` install on hub
+# source upgrades scitex itself but uv does NOT re-resolve [all] extras
+# on upgrade, so scitex-template / scitex-audit never landed.
+# See visitor_pool ImportError in v3 #4 cutover postmortem.
+RUN uv pip install --system --no-cache "scitex[all]==2.30.1"
 
 # --- Layer A: Latest scitex (bump freely on every publish) ---
 # PyTorch etc. are already satisfied from Layer 0. uv skips them and
@@ -175,6 +183,13 @@ RUN uv pip install --system --no-cache "scitex[all]==2.26.0"
 # No --no-cache here: we want uv to recognize existing packages.
 # 2026-06-07: bumped 2.26.0 → 2.30.1 (operator dogfooding refresh).
 RUN uv pip install --system "scitex[all]==2.30.1"
+
+# --- Smoke gate: scitex umbrella extras must be importable ---
+# Guards against future regressions where a Layer 0 / Layer A pin drifts
+# to a scitex version whose [all] omits one of these submodules. If
+# either import fails the build fails immediately rather than producing
+# an image that crash-loops on cold-boot.
+RUN python -c "import scitex.template; import scitex.audit; print('scitex extras OK:', scitex.template.__name__, scitex.audit.__name__)"
 
 # Playwright browsers (cached separately via BuildKit cache mount)
 RUN --mount=type=cache,target=/root/.cache/ms-playwright \


### PR DESCRIPTION
## Root cause (lead triage)

- `Dockerfile.prod` Layer 0 (Line 170) was still pinned at `scitex[all]==2.26.0` — that version's `[all]` extra pre-dates the `scitex-template` and `scitex-audit` submodules.
- Layer A (Line 176) was bumped to `2.30.1` in PR #246, but **Layer 0 was left at 2.26.0**.
- Later `uv pip install .[all]` from hub source (Line 374) upgrades `scitex` itself to 2.30.1, **but uv does NOT re-resolve scitex's `[all]` extras on upgrade** — only the direct package + first-order deps.
- Net result: `scitex==2.30.1` is installed, but `scitex-template` / `scitex-audit` are missing.
- Cold-boot `ImportError` surfaces in `create_visitor_pool`, causing django container `restart_count→1` on every fresh image rebuild.

## Fix

1. Bump Layer 0 from `scitex[all]==2.26.0` to `scitex[all]==2.30.1` so both Layer 0 and Layer A agree, and the `[all]` extras are anchored at a scitex version that includes `scitex-template` + `scitex-audit`.
2. Add an immediate smoke gate after Layer A: `RUN python -c "import scitex.template; import scitex.audit; ..."` — fails the build if any future drift omits these submodules, rather than shipping a crash-looping image.

## Deploy gate

This PR is the **repo fix only**. The actual prod rebuild + redeploy on hub-prod is still gated on operator GO routed via lead. No prod action triggered by this merge.

## Test plan

- [x] pre-commit hooks (whitespace / EOF / yaml) pass
- [ ] CI green except known-baseline pytest-matrix failures
- [ ] On next operator-approved hub-prod rebuild: smoke gate runs during build, confirms `scitex.template` + `scitex.audit` importable; running container shows `restart_count=0` on cold-boot

## Refs

- hub issue #242 (visitor-pool ImportError, observed on v3 #4 cutover)
- scitex-dev issue #132 (closed: wrong premise; this is the actual fix)
- `docs/incidents/2026-06-06-prod-cutover-cloud-to-hub.md` (v3 #4 postmortem)
- PR #246 (half-fix — bumped Layer A only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
