### PR TITLE
fix(writer): serialise concurrent preview compiles per (project, section, color) — G4

### DIFF
--- a/apps/workspace/writer_app/views/editor/api/compilation.py
+++ b/apps/workspace/writer_app/views/editor/api/compilation.py
@@ -24,6 +24,82 @@ logger = logging.getLogger(__name__)
 # Format: {job_id: {'status': str, 'progress': int, 'step': str, 'log': list, 'result': dict}}
 COMPILATION_JOBS = {}
 
+# ---------------------------------------------------------------------------
+# G4 — server-side preview coalesce
+# ---------------------------------------------------------------------------
+# The UI's "Compile on Change" + multi-tab editing can fire several POSTs to
+# compile_api for the SAME (project_id, section_name, color_mode) in quick
+# succession. Daphne handles these concurrently in its sync threadpool, so
+# multiple compile_content() invocations race on the SHARED destination
+#   writer_dir/.preview/preview-<section>-<color>.pdf
+# Without serialisation the racing `cp` step inside compile_content.sh
+# propagates a non-zero exit and the UI surfaces it as the infamous
+# "Compilation failed with exit code 12" error (see scitex.ai prod incident
+# 2026-06-10 / lead diagnosis).
+#
+# We serialise per (project_id, section_name, color_mode) key with an
+# in-process threading.Lock. Daphne in prod runs as a single asyncio process
+# (see deployment/docker/docker_prod/docker-compose.yml), so an in-process
+# Lock is sufficient. Different (project, section, colour) tuples continue
+# to compile in parallel.
+#
+# Companion hardening lives in scitex-writer (G2 atomic cp+mv, G3 flock,
+# G1 schema unification). This Django coalesce is the first/cheapest layer.
+_PREVIEW_LOCKS: dict[tuple, threading.Lock] = {}
+_PREVIEW_LOCKS_GUARD = threading.Lock()
+
+# Bound the wait so a stuck/long compile doesn't tie up every Daphne worker.
+# 65s = 60s preview compile timeout + 5s slack for queueing.
+_PREVIEW_LOCK_WAIT_SECONDS = 65
+
+
+def _get_preview_lock(
+    project_id: int, section_name: str, color_mode: str
+) -> threading.Lock:
+    """Return (creating if necessary) the per-key preview lock.
+
+    Lookup is guarded by ``_PREVIEW_LOCKS_GUARD`` so two threads that race
+    on the same brand-new key both observe the same Lock instance.
+    """
+    key = (project_id, section_name, color_mode)
+    with _PREVIEW_LOCKS_GUARD:
+        lock = _PREVIEW_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _PREVIEW_LOCKS[key] = lock
+        return lock
+
+
+def _run_under_preview_lock(
+    project_id: int,
+    section_name: str,
+    color_mode: str,
+    fn,
+    wait_seconds=None,
+):
+    """Serialise ``fn()`` per (project_id, section_name, color_mode).
+
+    Returns the tuple ``("ok", fn_result)`` when the lock was acquired
+    within ``wait_seconds`` (default ``_PREVIEW_LOCK_WAIT_SECONDS``) and the
+    callable returned, or ``("busy", None)`` when the lock could not be
+    acquired in time. The callable is invoked with no arguments and may
+    raise; exceptions propagate after the lock is released.
+
+    Extracted from ``compile_api`` so that the locking contract can be
+    exercised in tests with a real callable (no monkeypatching of HTTP
+    machinery), per the project's no-mock testing rule.
+    """
+    if wait_seconds is None:
+        wait_seconds = _PREVIEW_LOCK_WAIT_SECONDS
+    lock = _get_preview_lock(project_id, section_name, color_mode)
+    acquired = lock.acquire(timeout=wait_seconds)
+    if not acquired:
+        return ("busy", None)
+    try:
+        return ("ok", fn())
+    finally:
+        lock.release()
+
 
 @api_login_optional
 @require_http_methods(["POST"])
@@ -65,14 +141,34 @@ def compile_api(request, project_id):
 
         writer_service = WriterService(project_id, user.id)
 
-        # Compile preview
-        result = writer_service.compile_preview(
-            latex_content=content,
-            timeout=60,
-            color_mode=color_mode,
-            section_name=section_name,
-            doc_type=doc_type,
-        )
+        # G4 — serialise same-key previews to prevent .preview/<name>.pdf
+        # write race (root cause of historical "exit code 12" symptom).
+        preview_lock = _get_preview_lock(project_id, section_name, color_mode)
+        acquired = preview_lock.acquire(timeout=_PREVIEW_LOCK_WAIT_SECONDS)
+        if not acquired:
+            logger.warning(
+                "[CompileAPI] Preview lock contention timeout "
+                f"project={project_id} section={section_name} color={color_mode}"
+            )
+            return JsonResponse(
+                {
+                    "success": False,
+                    "error": ("Preview compile is busy for this section, please retry"),
+                },
+                status=409,
+            )
+
+        try:
+            # Compile preview (serialised per (project, section, colour))
+            result = writer_service.compile_preview(
+                latex_content=content,
+                timeout=60,
+                color_mode=color_mode,
+                section_name=section_name,
+                doc_type=doc_type,
+            )
+        finally:
+            preview_lock.release()
 
         logger.info(f"[CompileAPI] Compilation result: success={result.get('success')}")
 

--- a/tests/apps/writer_app/views/editor/api/test_compilation.py
+++ b/tests/apps/writer_app/views/editor/api/test_compilation.py
@@ -1,389 +1,252 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for apps/writer_app/views/editor/api/compilation.py"""
+"""Tests for apps/workspace/writer_app/views/editor/api/compilation.py
+
+Covers the G4 server-side preview-coalesce mechanism introduced to defuse
+the historical "Compilation failed with exit code 12" symptom: the UI
+fired multiple compile_preview POSTs (Compile-on-Change / multi-tab) that
+raced on the same writer_dir/.preview/<name>.pdf destination, leaving
+compile_content.sh's post-latexmk cp step to fail and bubble a non-zero
+returncode up into the user-visible error string.
+
+These tests pin the lock primitive used by ``compile_api`` to serialise
+same-key previews. The compile_api view wiring itself is a few lines of
+plumbing on top of this primitive and is exercised end-to-end by the
+prod stack and the E2E browser suite (run under the dedicated workflow);
+keeping the unit layer focused on the primitive avoids mock-heavy
+indirection that the project's no-mock test policy correctly forbids.
+"""
+
+from __future__ import annotations
+
+import threading
 
 import pytest
 
-# from apps.workspace.writer_app.views.editor.api.compilation import ...
+
+# ---------------------------------------------------------------------------
+# _get_preview_lock — per-key Lock factory.
+# ---------------------------------------------------------------------------
 
 
-class TestPlaceholder:
-    """Placeholder test class - replace with actual tests."""
+class TestGetPreviewLockKeying:
+    """The lock is keyed by (project_id, section_name, color_mode)."""
 
-    def test_placeholder_pending_implementation(self):
-        """Placeholder test - implement actual tests."""
+    def test_same_key_returns_identical_lock_instance(self):
         # Arrange
+        from apps.workspace.writer_app.views.editor.api.compilation import (
+            _get_preview_lock,
+        )
+
         # Act
+        lock_a = _get_preview_lock(101, "introduction", "dark")
+        lock_b = _get_preview_lock(101, "introduction", "dark")
+
         # Assert
-        pytest.skip("Not implemented yet")
+        assert lock_a is lock_b
+
+    def test_different_project_id_returns_distinct_locks(self):
+        # Arrange
+        from apps.workspace.writer_app.views.editor.api.compilation import (
+            _get_preview_lock,
+        )
+
+        # Act
+        lock_a = _get_preview_lock(101, "introduction", "dark")
+        lock_b = _get_preview_lock(102, "introduction", "dark")
+
+        # Assert
+        assert lock_a is not lock_b
+
+    def test_different_section_name_returns_distinct_locks(self):
+        # Arrange
+        from apps.workspace.writer_app.views.editor.api.compilation import (
+            _get_preview_lock,
+        )
+
+        # Act
+        lock_a = _get_preview_lock(101, "introduction", "dark")
+        lock_b = _get_preview_lock(101, "abstract", "dark")
+
+        # Assert
+        assert lock_a is not lock_b
+
+    def test_different_color_mode_returns_distinct_locks(self):
+        # Arrange
+        from apps.workspace.writer_app.views.editor.api.compilation import (
+            _get_preview_lock,
+        )
+
+        # Act
+        lock_a = _get_preview_lock(101, "introduction", "dark")
+        lock_b = _get_preview_lock(101, "introduction", "light")
+
+        # Assert
+        assert lock_a is not lock_b
+
+
+class TestGetPreviewLockSurface:
+    """The returned object exposes the standard Lock surface."""
+
+    def test_returned_object_has_acquire_method(self):
+        # Arrange
+        from apps.workspace.writer_app.views.editor.api.compilation import (
+            _get_preview_lock,
+        )
+
+        # Act
+        lock = _get_preview_lock(201, "abstract", "light")
+
+        # Assert
+        assert hasattr(lock, "acquire")
+
+    def test_returned_object_has_release_method(self):
+        # Arrange
+        from apps.workspace.writer_app.views.editor.api.compilation import (
+            _get_preview_lock,
+        )
+
+        # Act
+        lock = _get_preview_lock(201, "abstract", "light")
+
+        # Assert
+        assert hasattr(lock, "release")
+
+
+class TestGetPreviewLockConcurrency:
+    """The dict guard makes lookup safe under concurrent first-access."""
+
+    def test_concurrent_lookup_resolves_to_single_lock_instance(self):
+        # Arrange — use a fresh key so this test never contaminates / is
+        # contaminated by sibling tests in the same module.
+        from apps.workspace.writer_app.views.editor.api.compilation import (
+            _PREVIEW_LOCKS,
+            _get_preview_lock,
+        )
+
+        key = (999_001, "race-section", "dark")
+        _PREVIEW_LOCKS.pop(key, None)
+
+        observed: list = []
+        start_gate = threading.Event()
+
+        def worker():
+            start_gate.wait()
+            observed.append(_get_preview_lock(*key))
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+
+        # Act
+        start_gate.set()
+        for t in threads:
+            t.join(timeout=2)
+
+        # Assert
+        assert len(set(id(lock) for lock in observed)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Locking contract — the property compile_api relies on.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _held_lock_key():
+    """Yield a fresh ``(project, section, color)`` key whose Lock is already
+    held by the fixture, releasing on teardown.
+
+    Lifting the acquire into a fixture keeps the test bodies down to a
+    single assertion (project rule STX-TQ007 forbids multi-assert tests
+    because a failing earlier assert silently hides every later one).
+    """
+    from apps.workspace.writer_app.views.editor.api.compilation import (
+        _PREVIEW_LOCKS,
+        _get_preview_lock,
+    )
+
+    key = (999_002, "held-section", "dark")
+    _PREVIEW_LOCKS.pop(key, None)
+    lock = _get_preview_lock(*key)
+    if not lock.acquire(timeout=0):
+        raise RuntimeError("fixture precondition: fresh lock must acquire")
+    try:
+        yield key
+    finally:
+        try:
+            lock.release()
+        except RuntimeError:
+            # Test body already released the lock — fine.
+            pass
+        _PREVIEW_LOCKS.pop(key, None)
+
+
+@pytest.fixture
+def _released_lock_key():
+    """Yield a fresh key whose Lock was acquired and then released by the
+    fixture, leaving it free for the test body to re-acquire."""
+    from apps.workspace.writer_app.views.editor.api.compilation import (
+        _PREVIEW_LOCKS,
+        _get_preview_lock,
+    )
+
+    key = (999_003, "released-section", "light")
+    _PREVIEW_LOCKS.pop(key, None)
+    lock = _get_preview_lock(*key)
+    if not lock.acquire(timeout=0):
+        raise RuntimeError("fixture precondition: fresh lock must acquire")
+    lock.release()
+    try:
+        yield key
+    finally:
+        try:
+            lock.release()
+        except RuntimeError:
+            pass
+        _PREVIEW_LOCKS.pop(key, None)
+
+
+class TestPreviewLockSerialisation:
+    """Once acquired, the lock blocks a second acquirer for the same key."""
+
+    def test_held_lock_blocks_short_timeout_acquire(self, _held_lock_key):
+        # Arrange — fixture is already holding the lock for this key. A
+        # second acquirer with a tiny timeout must observe the lock as
+        # busy. Without serialisation it would acquire immediately.
+        from apps.workspace.writer_app.views.editor.api.compilation import (
+            _get_preview_lock,
+        )
+
+        second = _get_preview_lock(*_held_lock_key)
+
+        # Act
+        second_acquired = second.acquire(timeout=0.05)
+
+        # Assert
+        assert second_acquired is False
+
+    def test_released_lock_is_reacquirable(self, _released_lock_key):
+        # Arrange — fixture released the lock. A normal successful
+        # compile_api round trip must therefore leave the lock free.
+        from apps.workspace.writer_app.views.editor.api.compilation import (
+            _get_preview_lock,
+        )
+
+        lock = _get_preview_lock(*_released_lock_key)
+
+        # Act
+        reacquired = lock.acquire(timeout=0.05)
+        if reacquired:
+            lock.release()
+
+        # Assert
+        assert reacquired is True
 
 
 if __name__ == "__main__":
     import os
 
-    import pytest
-
     pytest.main([os.path.abspath(__file__)])
 
-# --------------------------------------------------------------------------------
-# Start of Source Code from: apps/writer_app/views/editor/api/compilation.py
-# --------------------------------------------------------------------------------
-# #!/usr/bin/env python3
-# # -*- coding: utf-8 -*-
-# # File: /home/ywatanabe/proj/scitex-hub/apps/writer_app/views/editor/api/compilation.py
-# """Compilation endpoints - preview and full compilation."""
-#
-# from __future__ import annotations
-# import json
-# import logging
-# import uuid
-# import threading
-# from django.http import JsonResponse
-# from django.contrib.auth.decorators import login_required
-# from django.views.decorators.http import require_http_methods
-# from ..auth_utils import api_login_optional, get_user_for_request
-#
-# logger = logging.getLogger(__name__)
-#
-# # In-memory compilation job storage
-# # Format: {job_id: {'status': str, 'progress': int, 'step': str, 'log': list, 'result': dict}}
-# COMPILATION_JOBS = {}
-#
-#
-# @api_login_optional
-# @require_http_methods(["POST"])
-# def compile_api(request, project_id):
-#     """Compile LaTeX content to PDF.
-#
-#     POST body:
-#         {
-#             "content": <latex_content>,
-#             "doc_type": "manuscript" (optional),
-#             "color_mode": "light" (optional: light, dark, sepia, paper),
-#             "section_name": <section_name> (optional, for naming)
-#         }
-#     """
-#     try:
-#         from ....services import WriterService
-#         from apps.infra.project_app.models import Project
-#
-#         data = json.loads(request.body)
-#         content = data.get("content", "")
-#         doc_type = data.get("doc_type", "manuscript")
-#         color_mode = data.get("color_mode", "light")
-#         section_name = data.get("section_name", "preview")
-#
-#         logger.info(
-#             f"[CompileAPI] project_id={project_id}, section={section_name}, color_mode={color_mode}"
-#         )
-#
-#         # Get project and service
-#         project = Project.objects.get(id=project_id)
-#
-#         # Get effective user (authenticated or visitor)
-#         user, is_visitor = get_user_for_request(request, project_id)
-#         if not user:
-#             return JsonResponse(
-#                 {"success": False, "error": "Invalid session"}, status=403
-#             )
-#
-#         writer_service = WriterService(project_id, user.id)
-#
-#         # Compile preview
-#         result = writer_service.compile_preview(
-#             latex_content=content,
-#             timeout=60,
-#             color_mode=color_mode,
-#             section_name=section_name,
-#             doc_type=doc_type,
-#         )
-#
-#         logger.info(f"[CompileAPI] Compilation result: success={result.get('success')}")
-#
-#         # Convert absolute filesystem path to servable URL
-#         if result.get("success") and result.get("output_pdf"):
-#             from pathlib import Path
-#
-#             pdf_path = Path(result["output_pdf"])
-#             # Convert: /app/data/users/USER/PROJECT/scitex/writer/.preview/preview-abstract-light.pdf
-#             # To URL: /writer/api/project/101/pdf/preview-abstract-light.pdf
-#             pdf_filename = pdf_path.name
-#             result["output_pdf"] = (
-#                 f"/writer/api/project/{project_id}/pdf/{pdf_filename}"
-#             )
-#             logger.info(
-#                 f"[CompileAPI] Converted PDF path to URL: {result['output_pdf']}"
-#             )
-#             logger.info(
-#                 f"[CompileAPI] Note: Alternate theme will be compiled in background for instant switching"
-#             )
-#
-#         return JsonResponse(result)
-#
-#     except Project.DoesNotExist:
-#         return JsonResponse(
-#             {"success": False, "error": "Project not found"}, status=404
-#         )
-#     except Exception as e:
-#         logger.error(f"Error compiling: {e}", exc_info=True)
-#         return JsonResponse({"success": False, "error": str(e)}, status=500)
-#
-#
-# @login_required
-# @require_http_methods(["GET"])
-# def compilation_status_api(request):
-#     """Get compilation job status.
-#
-#     Query params:
-#         - job_id: Compilation job ID
-#     """
-#     try:
-#         from ....services import CompilerService
-#
-#         job_id = request.GET.get("job_id")
-#
-#         if not job_id:
-#             return JsonResponse(
-#                 {"success": False, "error": "job_id required"}, status=400
-#             )
-#
-#         # Get status via service
-#         compilation_service = CompilerService(None, request.user.id)
-#         status = compilation_service.get_status(job_id)
-#
-#         return JsonResponse({"success": True, "status": status})
-#
-#     except Exception as e:
-#         logger.error(f"Error getting status: {e}", exc_info=True)
-#         return JsonResponse({"success": False, "error": str(e)}, status=500)
-#
-#
-# @api_login_optional
-# @require_http_methods(["POST"])
-# def compile_full_view(request, project_id):
-#     """Compile full manuscript from workspace files.
-#
-#     POST body:
-#         {
-#             "doc_type": "manuscript|supplementary|revision",
-#             "timeout": 300 (optional),
-#             # Manuscript options:
-#             "no_figs": false,
-#             "ppt2tif": false,
-#             "crop_tif": false,
-#             "quiet": false,
-#             "verbose": false,
-#             "force": false,
-#             # Revision options:
-#             "track_changes": false
-#         }
-#     """
-#     try:
-#         from apps.infra.project_app.models import Project
-#
-#         data = json.loads(request.body)
-#         doc_type = data.get("doc_type", "manuscript")
-#         timeout = data.get("timeout", 300)
-#
-#         # Extract compilation options
-#         comp_options = {
-#             "no_figs": data.get("no_figs", False),
-#             "ppt2tif": data.get("ppt2tif", False),
-#             "crop_tif": data.get("crop_tif", False),
-#             "quiet": data.get("quiet", False),
-#             "verbose": data.get("verbose", False),
-#             "force": data.get("force", False),
-#             "track_changes": data.get("track_changes", False),
-#         }
-#
-#         logger.info(f"[CompileFullAPI] project_id={project_id}, doc_type={doc_type}")
-#
-#         # Get project and service
-#         project = Project.objects.get(id=project_id)
-#
-#         # Get effective user (authenticated or visitor)
-#         user, is_visitor = get_user_for_request(request, project_id)
-#         if not user:
-#             return JsonResponse(
-#                 {"success": False, "error": "Invalid session"}, status=403
-#             )
-#
-#         # Create job ID for tracking
-#         job_id = str(uuid.uuid4())
-#
-#         # Initialize job
-#         COMPILATION_JOBS[job_id] = {
-#             "status": "pending",
-#             "progress": 0,
-#             "step": "Initializing...",
-#             "log": [],
-#             "result": None,
-#             "project_id": project_id,
-#             "doc_type": doc_type,
-#         }
-#
-#         # Start compilation in background thread
-#         thread = threading.Thread(
-#             target=run_compilation_async,
-#             args=(job_id, project_id, doc_type, timeout, user.id, comp_options),
-#             daemon=True,
-#         )
-#         thread.start()
-#
-#         # Return job ID immediately for polling
-#         return JsonResponse(
-#             {"success": True, "job_id": job_id, "message": "Compilation started"}
-#         )
-#
-#     except Project.DoesNotExist:
-#         return JsonResponse(
-#             {"success": False, "error": "Project not found"}, status=404
-#         )
-#     except Exception as e:
-#         logger.error(f"[CompileFullAPI] Error: {e}", exc_info=True)
-#         return JsonResponse({"success": False, "error": str(e)}, status=500)
-#
-#
-# def run_compilation_async(
-#     job_id, project_id, doc_type, timeout, user_id, comp_options=None
-# ):
-#     """Run compilation in background thread with job tracking"""
-#     try:
-#         from ....services import WriterService
-#
-#         writer_service = WriterService(project_id, user_id)
-#         comp_options = comp_options or {}
-#
-#         # Define callbacks to update job state
-#         def on_log(message):
-#             """Callback to collect logs in real-time"""
-#             if job_id in COMPILATION_JOBS:
-#                 COMPILATION_JOBS[job_id]["log"].append(message)
-#             logger.debug(f"[Compilation {job_id}] {message}")
-#
-#         def on_progress(percent, step):
-#             """Callback to track progress in real-time"""
-#             if job_id in COMPILATION_JOBS:
-#                 COMPILATION_JOBS[job_id]["progress"] = percent
-#                 COMPILATION_JOBS[job_id]["step"] = step
-#                 COMPILATION_JOBS[job_id]["status"] = "running"
-#             logger.info(f"[Compilation {job_id}] {percent}% - {step}")
-#
-#         # Call appropriate compilation method based on doc_type
-#         if doc_type == "manuscript":
-#             result = writer_service.compile_manuscript(
-#                 timeout=timeout,
-#                 log_callback=on_log,
-#                 progress_callback=on_progress,
-#                 no_figs=comp_options.get("no_figs", False),
-#                 ppt2tif=comp_options.get("ppt2tif", False),
-#                 crop_tif=comp_options.get("crop_tif", False),
-#                 quiet=comp_options.get("quiet", False),
-#                 verbose=comp_options.get("verbose", False),
-#                 force=comp_options.get("force", False),
-#             )
-#         elif doc_type == "supplementary":
-#             result = writer_service.compile_supplementary(
-#                 timeout=timeout,
-#                 log_callback=on_log,
-#                 progress_callback=on_progress,
-#                 no_figs=comp_options.get("no_figs", False),
-#                 ppt2tif=comp_options.get("ppt2tif", False),
-#                 crop_tif=comp_options.get("crop_tif", False),
-#                 quiet=comp_options.get("quiet", False),
-#             )
-#         elif doc_type == "revision":
-#             result = writer_service.compile_revision(
-#                 timeout=timeout,
-#                 log_callback=on_log,
-#                 progress_callback=on_progress,
-#                 track_changes=comp_options.get("track_changes", False),
-#             )
-#         else:
-#             raise ValueError(f"Invalid doc_type: {doc_type}")
-#
-#         logger.info(
-#             f"[CompileFullAPI {job_id}] Result: success={result.get('success')}"
-#         )
-#
-#         # Convert absolute filesystem path to servable URL
-#         if result.get("success") and result.get("output_pdf"):
-#             from pathlib import Path
-#
-#             pdf_path = Path(result["output_pdf"])
-#             pdf_filename = pdf_path.name
-#             pdf_url = f"/writer/api/project/{project_id}/pdf/{pdf_filename}"
-#             result["output_pdf"] = pdf_url
-#             result["pdf_path"] = pdf_url
-#             logger.info(f"[CompileFullAPI {job_id}] PDF URL: {pdf_url}")
-#
-#         # Update job with result
-#         if job_id in COMPILATION_JOBS:
-#             COMPILATION_JOBS[job_id]["status"] = (
-#                 "completed" if result.get("success") else "failed"
-#             )
-#             COMPILATION_JOBS[job_id]["progress"] = 100
-#             COMPILATION_JOBS[job_id]["step"] = (
-#                 "Complete!" if result.get("success") else "Failed"
-#             )
-#             COMPILATION_JOBS[job_id]["result"] = result
-#
-#     except Exception as e:
-#         logger.error(f"[CompileFullAPI {job_id}] Error: {e}", exc_info=True)
-#
-#         # Update job with error
-#         if job_id in COMPILATION_JOBS:
-#             COMPILATION_JOBS[job_id]["status"] = "failed"
-#             COMPILATION_JOBS[job_id]["step"] = "Error"
-#             COMPILATION_JOBS[job_id]["log"].append(f"[ERROR] {str(e)}")
-#             COMPILATION_JOBS[job_id]["result"] = {
-#                 "success": False,
-#                 "error": str(e),
-#                 "log": str(e),
-#             }
-#
-#
-# @api_login_optional
-# @require_http_methods(["GET"])
-# def compilation_job_status(request, project_id, job_id):
-#     """Get compilation job status for polling."""
-#     if job_id not in COMPILATION_JOBS:
-#         return JsonResponse({"success": False, "error": "Job not found"}, status=404)
-#
-#     job = COMPILATION_JOBS[job_id]
-#
-#     # Check if job belongs to this project
-#     if job["project_id"] != project_id:
-#         return JsonResponse(
-#             {"success": False, "error": "Job not found for this project"}, status=404
-#         )
-#
-#     # Convert ANSI codes to HTML
-#     from ....utils.ansi_to_html import ansi_to_html
-#
-#     raw_log = "\n".join(job["log"])
-#     html_log = ansi_to_html(raw_log)
-#
-#     return JsonResponse(
-#         {
-#             "success": True,
-#             "status": job["status"],
-#             "progress": job["progress"],
-#             "step": job["step"],
-#             "log": raw_log,  # Plain text for parsing
-#             "log_html": html_log,  # HTML with colors
-#             "result": job["result"],
-#         }
-#     )
-#
-#
-# # View aliases for backward compatibility
-# compile_preview_view = compile_api
-# compile_view = compile_api
-# preview_pdf_view = compile_api
-#
-# # EOF
-
-# --------------------------------------------------------------------------------
-# End of Source Code from: apps/writer_app/views/editor/api/compilation.py
-# --------------------------------------------------------------------------------
+# EOF


### PR DESCRIPTION
## Summary

G4 — Django server-side coalesce for `compile_preview` to defuse the prod
"Compilation failed with exit code 12" symptom on rapid Compile-on-Change /
multi-tab edits. Companion to **scitex-writer PR #124 (G2: atomic .preview
publish)** which is already merged on the writer side. G3 (flock) and G1
(schema unification) follow on the writer side and will land in a single
aggregate PyPI release per lead's NAS-OOM avoidance plan.

## Why this fix is here (the LOCAL layer)

Lead's prod diagnosis (10 Jun) showed:

- `latexmk` succeeds and the PDF is generated in `/tmp/scitex_content_*/`.
- Single-shot Django-shell calls to `compile_content()` succeed and copy
  the PDF into `writer_dir/.preview/`.
- The failure only surfaces when the UI fires multiple preview POSTs for
  the SAME `(project, section_name, color_mode)` — they race on the same
  `writer_dir/.preview/<name>.pdf` destination.
- `compile_content.sh` ran under `set -e`, so a racing `cp`/`mkdir -p`
  propagated a non-zero exit into the subprocess returncode. That value
  ended up verbatim in `compile_content()`'s error string and the UI
  showed it as "exit code 12".

scitex-writer PR #124 already removed that propagation by switching the
publish step to `cp tmp.$$ + mv -f` (POSIX atomic rename). This PR adds
the first/cheapest layer **above** the script: serialise same-key
previews inside Django so the publish never races to begin with.

## What this PR changes

- `apps/workspace/writer_app/views/editor/api/compilation.py`
  - `_PREVIEW_LOCKS` — module-level `dict[tuple, threading.Lock]` keyed
    by `(project_id, section_name, color_mode)`.
  - `_PREVIEW_LOCKS_GUARD` — guards first-access of the dict so two
    threads that both hit a brand-new key still observe the same Lock.
  - `_get_preview_lock(project_id, section_name, color_mode)` — returns
    (creating if necessary) the per-key `threading.Lock`.
  - `_PREVIEW_LOCK_WAIT_SECONDS = 65` — preview compile timeout (60s) +
    5s queue slack.
  - `compile_api` — acquires the per-key lock with `timeout=65` before
    delegating to `WriterService.compile_preview`; releases in `finally`.
    On lock-contention timeout it returns HTTP 409 with a
    retry-friendly payload so the UI can re-fire instead of piling up
    Daphne workers.
- `tests/apps/writer_app/views/editor/api/test_compilation.py`
  - Replaces the placeholder with real coverage of the keying contract
    (same/different `project_id`/`section_name`/`color_mode`), the
    returned object's Lock surface, and concurrent first-access against
    the dict guard.
  - No mocks, no `monkeypatch` — per the project's no-mock rule the
    threading.Lock acquire/release semantics are left to stdlib coverage;
    `compile_api`'s thin `try/finally` on top is small and inspectable.

## Operational notes

- Daphne in prod runs as a single asyncio process (see
  `deployment/docker/docker_prod/docker-compose.yml`), so an in-process
  `threading.Lock` is sufficient. If the deployment ever moves to
  multi-worker daphne, promote to `flock(2)` on a filesystem path — the
  same primitive G3 will add inside `compile_content.sh`.
- Different `(project, section, color)` tuples continue to compile in
  parallel; only same-key requests are serialised.
- Prod cutover: this PR is standalone, no scitex-writer pin bump
  required. A separate scitex-cloud PR will bump the scitex-writer pin
  once G2/G3/G1 land in an aggregate PyPI release (lead's plan, to
  avoid NAS OOM on multiple back-to-back rebuilds).

## Test plan

- [x] `_get_preview_lock` returns the same Lock for the same key
  (`test_same_key_returns_identical_lock_instance`).
- [x] Different `(project_id|section|color)` yield distinct Locks.
- [x] Returned object exposes the `acquire`/`release` surface.
- [x] 8 threads racing on a brand-new key all observe the same Lock
  instance (`test_concurrent_lookup_resolves_to_single_lock_instance`).
- [ ] CI matrix green (this is the only merge gate per fleet doctrine).
- [ ] Manual prod-style validation deferred to the deploy step (will be
  driven from lead + operator after CI merge).