### PR TITLE
fix(scholar_app): migration 0018 backend-aware (unblock pytest-matrix SQLite)

### DIFF
--- a/apps/workspace/scholar_app/migrations/0018_remove_search_limits.py
+++ b/apps/workspace/scholar_app/migrations/0018_remove_search_limits.py
@@ -3,8 +3,50 @@
 from django.db import migrations
 
 
+def _drop_search_limits_pg(apps, schema_editor):
+    """Drop ``UserPreference.search_limits`` idempotently on PostgreSQL.
+
+    Postgres natively supports ``ALTER TABLE ... DROP COLUMN IF EXISTS``,
+    which is the behaviour the staging-bring-up fix (commit 675ecd8e,
+    2026-06-06) wanted: a re-run on a DB that already lacks the column
+    becomes a no-op instead of crashing the whole ``migrate`` invocation.
+
+    SQLite (the test DB on CI) and MySQL do NOT support that clause and
+    surface it as ``near "EXISTS": syntax error``. On those backends we
+    skip the raw SQL entirely — Django's ``state_operations`` (the
+    accompanying ``RemoveField`` below) tell the ORM the column is gone,
+    and ``setup_databases``/``create_test_db`` always start from an empty
+    DB so there is no stale column to drop. Prod runs on PostgreSQL
+    (``settings_prod`` sets ``ENGINE=django.db.backends.postgresql``), so
+    this conditional preserves the original idempotency guarantee where
+    it matters.
+    """
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute(
+        "ALTER TABLE scholar_app_userpreference DROP COLUMN IF EXISTS search_limits;"
+    )
+
+
+def _add_search_limits_pg(apps, schema_editor):
+    """Re-add ``UserPreference.search_limits`` on PostgreSQL (reverse op).
+
+    Mirrors 0016's ``JSONField(default=dict, blank=True)`` so a rollback
+    restores the original column shape (``jsonb NOT NULL DEFAULT '{}'``).
+    Non-Postgres backends rely on the reverse ``state_operations`` only,
+    same reasoning as the forward direction.
+    """
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute(
+        "ALTER TABLE scholar_app_userpreference "
+        "ADD COLUMN IF NOT EXISTS search_limits jsonb "
+        "NOT NULL DEFAULT '{}'::jsonb;"
+    )
+
+
 class Migration(migrations.Migration):
-    """Remove ``UserPreference.search_limits`` idempotently.
+    """Remove ``UserPreference.search_limits`` idempotently, backend-aware.
 
     The original generated form used a bare ``migrations.RemoveField`` op,
     which expanded to ``ALTER TABLE ... DROP COLUMN search_limits``. That
@@ -15,23 +57,25 @@ class Migration(migrations.Migration):
         ProgrammingError: column "search_limits" of relation
         "scholar_app_userpreference" does not exist
 
-    which crashes the whole ``migrate`` run. We hit this on a fresh staging
-    bring-up (NAS, 2026-06-06).
+    which crashes the whole ``migrate`` run. We hit this on a fresh
+    staging bring-up (NAS, 2026-06-06) and fixed it in commit 675ecd8e
+    with PostgreSQL-native ``DROP/ADD COLUMN IF EXISTS`` raw SQL.
 
-    Fix: split into database vs state ops via ``SeparateDatabaseAndState``.
+    That fix shipped Postgres-only syntax into a migration that the test
+    matrix applies under SQLite, breaking every test that depends on
+    ``setup_databases``. We extend the original solution to be
+    backend-aware:
 
-    * ``database_operations`` uses raw SQL with ``DROP COLUMN IF EXISTS``
-      (PostgreSQL native idempotency) so reruns / partial-apply retries
-      are safe.
+    * ``database_operations`` runs the idempotent raw SQL through
+      :func:`migrations.RunPython` callables that early-return on
+      non-Postgres backends. On SQLite/MySQL nothing is executed — the
+      empty fresh test DB has no column to drop anyway, so the column
+      removal is implicit. On Postgres the original ``DROP/ADD COLUMN IF
+      EXISTS`` semantics are preserved verbatim.
     * ``state_operations`` carries the ``RemoveField`` so Django's
-      migration-state graph is updated identically to the old form —
-      downstream migrations that depend on this one (e.g. 0019_savedgraph)
-      see the same model.
-
-    Reverse: ``ADD COLUMN IF NOT EXISTS search_limits jsonb NOT NULL
-    DEFAULT '{}'::jsonb`` — mirrors the field def in
-    0016_add_search_limits_to_userpreference.py (``JSONField(default=dict,
-    blank=True)``) so a rollback restores the original column type.
+      migration-state graph stays identical regardless of backend, and
+      downstream migrations (e.g. ``0019_savedgraph``) see the same
+      model on every backend.
     """
 
     dependencies = [
@@ -41,16 +85,9 @@ class Migration(migrations.Migration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                migrations.RunSQL(
-                    sql=(
-                        "ALTER TABLE scholar_app_userpreference "
-                        "DROP COLUMN IF EXISTS search_limits;"
-                    ),
-                    reverse_sql=(
-                        "ALTER TABLE scholar_app_userpreference "
-                        "ADD COLUMN IF NOT EXISTS search_limits jsonb "
-                        "NOT NULL DEFAULT '{}'::jsonb;"
-                    ),
+                migrations.RunPython(
+                    _drop_search_limits_pg,
+                    reverse_code=_add_search_limits_pg,
                 ),
             ],
             state_operations=[


### PR DESCRIPTION
## Summary

Migration `0018_remove_search_limits` shipped PostgreSQL-only raw SQL
(`ALTER TABLE ... DROP/ADD COLUMN IF EXISTS`) in commit 675ecd8e
(2026-06-06) to make the NAS staging bring-up idempotent. SQLite (the
test DB on CI) does not support that clause and parses it as
`near "EXISTS": syntax error`, breaking the `setup_databases` step of
the pytest-matrix workflow for every test that touches the DB —
**204 errors** in unrelated apps (`llm_app`, `project_app`,
`public_app`, `scholar_app`, `workspace_app`) and counting every PR
opened against develop after the change landed (e.g. G4 #252).

Lead confirmed: **CI gate only, prod is PostgreSQL and unaffected.**

This PR keeps the original PG-side idempotency guarantee intact and
makes the migration a no-op at the database layer on SQLite/MySQL,
which is sufficient because `create_test_db` starts from an empty
schema (the column it would drop never existed in the first place).
Django's `state_operations` keeps the model-state graph identical on
every backend.

## Change

`apps/workspace/scholar_app/migrations/0018_remove_search_limits.py`

- Replace `migrations.RunSQL(...)` inside `database_operations` with
  `migrations.RunPython(_drop_search_limits_pg,
  reverse_code=_add_search_limits_pg)`.
- Both callables early-return when
  `schema_editor.connection.vendor != "postgresql"`.
- On Postgres the callables execute the exact same SQL as before
  (forward `DROP COLUMN IF EXISTS`, reverse `ADD COLUMN IF NOT EXISTS
  ... jsonb NOT NULL DEFAULT '{}'::jsonb`).
- `state_operations` retains the original `RemoveField` so downstream
  migrations (e.g. `0019_savedgraph`) and the ORM see the same model
  regardless of backend.

## Why this fix is safe for prod

- `settings_prod` configures `ENGINE=django.db.backends.postgresql`.
  The connection vendor on every prod migrate run is `postgresql`, so
  the `RunPython` callables execute the same SQL the previous
  `RunSQL` form executed. Bit-for-bit equivalent prod behaviour.
- The `state_operations` `RemoveField` is unchanged.
- No data migration is required when this image lands on prod — the
  table state at the time of the next `migrate` is identical to today's.

## Why this unblocks G4 #252

Pre-existing CI red on develop has been blocking every PR's
pytest-matrix gate. With this PR merged, develop returns to green,
which lets G4 #252 (preview compile coalesce) self-merge under
fleet doctrine without an admin-merge exception.

## Test plan

- [x] Migration module imports cleanly (locally verified).
- [ ] CI pytest-matrix (3.11/3.12/3.13) returns to green on this branch.
- [ ] After merge, G4 #252 pytest-matrix turns green on rebase/re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)