### PR TITLE
chore(prod): pin scitex-writer 2.10.1 → 2.17.5 + Django consumer asdict()

### DIFF
--- a/apps/workspace/writer_app/services/writer/compilation.py
+++ b/apps/workspace/writer_app/services/writer/compilation.py
@@ -5,7 +5,9 @@ Thin wrapper delegating to scitex.writer.compile for all compilation.
 Django imports from scitex_writer._compile for compilation functions.
 """
 
-from typing import TYPE_CHECKING, Callable, Optional
+import dataclasses
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from scitex import logging
 
@@ -27,6 +29,39 @@ def _get_sw_compile():
     return _sw_compile
 
 
+def _coerce_compile_result_to_dict(result: Any) -> dict:
+    """Normalise a ``scitex.writer.compile.content()`` return value to a dict.
+
+    scitex-writer >= 2.17.5 (G1, schema unification) returns a
+    ``CompilationResult`` dataclass. Older releases returned a raw ``dict``.
+    The downstream Django view (``compile_api``) and the UI's TypeScript
+    ``CompilationResult`` interface both consume the response as JSON, so we
+    flatten the dataclass with ``dataclasses.asdict`` and coerce any
+    ``Path`` fields (``output_pdf`` / ``diff_pdf`` / ``log_file`` /
+    ``temp_dir``) to strings so ``django.http.JsonResponse`` can serialise
+    the result without a custom encoder.
+
+    Passing through a plain dict (pre-2.17.5 shape) is a no-op so this
+    helper is safe to call unconditionally.
+    """
+    if dataclasses.is_dataclass(result) and not isinstance(result, type):
+        raw = dataclasses.asdict(result)
+    elif isinstance(result, dict):
+        raw = dict(result)
+    else:  # pragma: no cover — defensive: scitex.writer.compile.content
+        # always returns one of the two shapes above.
+        return {
+            "success": False,
+            "error": f"unexpected result shape: {type(result).__name__}",
+        }
+
+    for key in ("output_pdf", "diff_pdf", "log_file", "temp_dir"):
+        value = raw.get(key)
+        if isinstance(value, Path):
+            raw[key] = str(value)
+    return raw
+
+
 class CompilationMixin:
     """Mixin for compilation-related operations.
 
@@ -43,7 +78,10 @@ class CompilationMixin:
     ) -> dict:
         """Compile a quick preview of provided LaTeX content.
 
-        Delegates to scitex.writer.compile.content().
+        Delegates to scitex.writer.compile.content(). The upstream return
+        type changed from a raw dict to a ``CompilationResult`` dataclass
+        in scitex-writer 2.17.5 (G1); we normalise both back to a dict so
+        ``compile_api`` and the UI keep their existing JSON contract.
         """
         try:
             # Sanitize section_name: strip .tex extension if present
@@ -60,7 +98,7 @@ class CompilationMixin:
                 timeout=timeout,
                 keep_aux=False,
             )
-            return result
+            return _coerce_compile_result_to_dict(result)
         except Exception as e:
             logger.error(f"Preview compilation error: {e}", exc_info=True)
             return {

--- a/deployment/docker/docker_prod/Dockerfile.prod
+++ b/deployment/docker/docker_prod/Dockerfile.prod
@@ -376,12 +376,19 @@ RUN uv pip install --system --no-cache ".[all]"
 # --- Layer C0: Anchor — cache ecosystem packages (bump rarely) ---
 # Pinned versions to cache the dependency tree. Only update when
 # you want to reset the cache baseline.
+#
+# 2026-06-10: scitex-writer 2.10.1 → 2.17.5 (aggregate release of
+#   G2 atomic .preview write (#124), G3 flock per-name serialisation
+#   (#125), G1 CompilationResult schema unification (#126)). The
+#   release-level fixes for the prod preview-compile race that this
+#   image needs to ship live here; Django consumer updated below to
+#   convert the new dataclass response to a JSON-serialisable dict.
 RUN uv pip install --system --no-cache \
     "figrecipe==0.27.0" \
     "scitex-io==0.2.3" \
     "scitex-stats==0.2.6" \
     "scitex-plt==0.24.0" \
-    "scitex-writer==2.10.1" \
+    "scitex-writer==2.17.5" \
     "scitex-linter==0.3.1" \
     "scitex-ui==0.4.2" \
     "openalex-local==0.6.0" \

--- a/tests/apps/writer_app/services/writer/test_compilation.py
+++ b/tests/apps/writer_app/services/writer/test_compilation.py
@@ -1,447 +1,199 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for apps/writer_app/services/writer/compilation.py"""
+"""Tests for apps/workspace/writer_app/services/writer/compilation.py
+
+Focused on ``_coerce_compile_result_to_dict``, the helper introduced by
+the scitex-writer 2.17.5 pin-bump to translate the upstream return type
+change (raw ``dict`` -> ``CompilationResult`` dataclass, G1) back into a
+JSON-serialisable ``dict`` for the Django view + UI contract.
+
+The wider ``CompilationMixin.compile_preview`` itself drives latex
+subprocesses against a real project directory; that path is exercised
+by the E2E browser suite. Here we pin the small, deterministic helper
+that sits between scitex-writer and the JsonResponse boundary.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
 
 import pytest
 
-# from apps.workspace.writer_app.services.writer.compilation import ...
+# ---------------------------------------------------------------------------
+# Fixtures — real dataclasses + plain dicts; no mocks per repo no-mock policy.
+# ---------------------------------------------------------------------------
 
 
-class TestPlaceholder:
-    """Placeholder test class - replace with actual tests."""
+@dataclasses.dataclass
+class _FakeCompilationResult:
+    """Minimal stand-in for scitex_writer 2.17.5 ``CompilationResult``.
 
-    def test_placeholder_pending_implementation(self):
-        """Placeholder test - implement actual tests."""
+    Hand-rolled (rather than imported from scitex-writer) so the test
+    survives independent of the installed scitex-writer version.
+    """
+
+    success: bool
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    output_pdf: Path | None = None
+    diff_pdf: Path | None = None
+    log_file: Path | None = None
+    duration: float = 0.0
+
+
+@pytest.fixture
+def dataclass_result():
+    return _FakeCompilationResult(
+        success=True,
+        exit_code=0,
+        stdout="latexmk OK",
+        stderr="",
+        output_pdf=Path("/tmp/preview/abstract-light.pdf"),
+        log_file=Path("/tmp/preview/abstract-light.log"),
+        duration=1.25,
+    )
+
+
+@pytest.fixture
+def legacy_dict_result():
+    return {
+        "success": True,
+        "output_pdf": "/tmp/preview/abstract-light.pdf",
+        "temp_dir": "/tmp/preview",
+        "color_mode": "light",
+        "log": "ok",
+        "message": "Content compiled successfully",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Behaviour tests — one assertion per test (STX-TQ007).
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceCompileResultDataclass:
+    """When the upstream returns a CompilationResult dataclass."""
+
+    def test_dataclass_input_returns_dict(self, dataclass_result):
         # Arrange
+        from apps.workspace.writer_app.services.writer.compilation import (
+            _coerce_compile_result_to_dict,
+        )
+
         # Act
+        result = _coerce_compile_result_to_dict(dataclass_result)
+
         # Assert
-        pytest.skip("Not implemented yet")
+        assert isinstance(result, dict)
+
+    def test_dataclass_success_field_preserved(self, dataclass_result):
+        # Arrange
+        from apps.workspace.writer_app.services.writer.compilation import (
+            _coerce_compile_result_to_dict,
+        )
+
+        # Act
+        result = _coerce_compile_result_to_dict(dataclass_result)
+
+        # Assert
+        assert result["success"] is True
+
+    def test_dataclass_exit_code_field_preserved(self, dataclass_result):
+        # Arrange
+        from apps.workspace.writer_app.services.writer.compilation import (
+            _coerce_compile_result_to_dict,
+        )
+
+        # Act
+        result = _coerce_compile_result_to_dict(dataclass_result)
+
+        # Assert
+        assert result["exit_code"] == 0
+
+    def test_dataclass_output_pdf_coerced_to_str(self, dataclass_result):
+        # Arrange
+        from apps.workspace.writer_app.services.writer.compilation import (
+            _coerce_compile_result_to_dict,
+        )
+
+        # Act
+        result = _coerce_compile_result_to_dict(dataclass_result)
+
+        # Assert
+        assert result["output_pdf"] == "/tmp/preview/abstract-light.pdf"
+
+    def test_dataclass_log_file_coerced_to_str(self, dataclass_result):
+        # Arrange
+        from apps.workspace.writer_app.services.writer.compilation import (
+            _coerce_compile_result_to_dict,
+        )
+
+        # Act
+        result = _coerce_compile_result_to_dict(dataclass_result)
+
+        # Assert
+        assert result["log_file"] == "/tmp/preview/abstract-light.log"
+
+    def test_dataclass_unset_optional_path_stays_none(self, dataclass_result):
+        # Arrange — ``diff_pdf`` defaults to None in the fixture; the helper
+        # must not turn None into the string "None".
+        from apps.workspace.writer_app.services.writer.compilation import (
+            _coerce_compile_result_to_dict,
+        )
+
+        # Act
+        result = _coerce_compile_result_to_dict(dataclass_result)
+
+        # Assert
+        assert result["diff_pdf"] is None
+
+
+class TestCoerceCompileResultDict:
+    """When the upstream returns a raw dict (pre-2.17.5 shape)."""
+
+    def test_dict_input_returns_dict(self, legacy_dict_result):
+        # Arrange
+        from apps.workspace.writer_app.services.writer.compilation import (
+            _coerce_compile_result_to_dict,
+        )
+
+        # Act
+        result = _coerce_compile_result_to_dict(legacy_dict_result)
+
+        # Assert
+        assert isinstance(result, dict)
+
+    def test_dict_input_preserves_existing_fields(self, legacy_dict_result):
+        # Arrange
+        from apps.workspace.writer_app.services.writer.compilation import (
+            _coerce_compile_result_to_dict,
+        )
+
+        # Act
+        result = _coerce_compile_result_to_dict(legacy_dict_result)
+
+        # Assert
+        assert result["success"] is True
+
+    def test_dict_input_is_a_copy_not_the_same_instance(self, legacy_dict_result):
+        # Arrange — mutating ``result`` inside compile_api (e.g. rewriting
+        # output_pdf to a served URL) must not mutate caller-side state.
+        from apps.workspace.writer_app.services.writer.compilation import (
+            _coerce_compile_result_to_dict,
+        )
+
+        # Act
+        result = _coerce_compile_result_to_dict(legacy_dict_result)
+
+        # Assert
+        assert result is not legacy_dict_result
 
 
 if __name__ == "__main__":
     import os
 
-    import pytest
-
     pytest.main([os.path.abspath(__file__)])
 
-# --------------------------------------------------------------------------------
-# Start of Source Code from: apps/writer_app/services/writer/compilation.py
-# --------------------------------------------------------------------------------
-# """
-# LaTeX compilation operations for Writer.
-#
-# Handles preview compilation, manuscript/supplementary/revision compilation.
-# """
-#
-# from pathlib import Path
-# from typing import Optional, Callable
-# from scitex import logging
-#
-# logger = logging.getLogger(__name__)
-#
-#
-# class CompilationMixin:
-#     """Mixin for compilation-related operations."""
-#
-#     def _apply_color_mode_to_latex(self, latex_content: str, color_mode: str) -> str:
-#         """Apply color mode to LaTeX content by injecting color commands.
-#
-#         Args:
-#             latex_content: Original LaTeX content
-#             color_mode: 'light', 'dark', 'sepia', or 'paper'
-#
-#         Returns:
-#             Modified LaTeX content with color commands
-#         """
-#         # Skip color injection for light mode (default LaTeX colors)
-#         if color_mode == "light":
-#             return latex_content
-#
-#         # Define dark mode colors - Eye-friendly warm dark background with soft text
-#         # Following modern dark mode best practices (Material Design, GitHub, VS Code)
-#         # Background: #1c2128 (rgb 0.11, 0.129, 0.157) - darker warm gray with slight blue tint
-#         # Text: #c9d1d9 (rgb 0.788, 0.82, 0.851) - soft off-white with warm tone
-#         # These colors reduce eye strain and prevent "halation" effect of pure white on pure black
-#         # The darker background is more comfortable while avoiding pure black
-#         # Must be after \documentclass but before \begin{document}
-#         color_commands = """\\usepackage{xcolor}
-# \\pagecolor[rgb]{0.11,0.129,0.157}
-# \\color[rgb]{0.788,0.82,0.851}
-# """
-#
-#         # Find the position to inject
-#         if "\\begin{document}" in latex_content:
-#             # Insert right before \begin{document}
-#             latex_content = latex_content.replace(
-#                 "\\begin{document}", f"{color_commands}\\begin{{document}}", 1
-#             )
-#         else:
-#             # Just prepend if no \begin{document} found
-#             latex_content = color_commands + latex_content
-#
-#         return latex_content
-#
-#     def compile_preview(
-#         self,
-#         latex_content: str,
-#         timeout: int = 60,
-#         color_mode: str = "light",
-#         section_name: str = "preview",
-#         doc_type: str = "manuscript",
-#     ) -> dict:
-#         """Compile a quick preview of provided LaTeX content (not from workspace).
-#
-#         This is used for live preview of the current section being edited.
-#
-#         Args:
-#             latex_content: Complete LaTeX document content to compile
-#             timeout: Compilation timeout in seconds (default: 60 for quick preview)
-#             color_mode: PDF color mode - 'light', 'dark', 'sepia', or 'paper'
-#             section_name: Section name for output filename (e.g., 'introduction')
-#             doc_type: Document type - 'manuscript', 'supplementary', or 'revision'
-#
-#         Returns:
-#             Compilation result dict with keys:
-#                 - success: bool
-#                 - output_pdf: str (path if successful)
-#                 - log: str (compilation log)
-#                 - error: str (error message if failed)
-#         """
-#         # Import at method start to avoid UnboundLocalError in except clauses
-#         import subprocess
-#         import shutil
-#
-#         try:
-#             # Apply color mode to LaTeX content
-#             latex_content = self._apply_color_mode_to_latex(latex_content, color_mode)
-#
-#             # Create .preview directory in scitex/writer for compiled previews
-#             # This directory stores temporary compiled PDFs for quick preview
-#             # Structure: scitex/writer/.preview/
-#             preview_dir = self.writer_dir / ".preview"
-#             preview_dir.mkdir(parents=True, exist_ok=True)
-#
-#             # Ensure bibliography is accessible for citations
-#             # Link bibliography from 00_shared/bib_files to preview directory
-#             bib_source = (
-#                 self.writer_dir / "00_shared" / "bib_files" / "bibliography.bib"
-#             )
-#             bib_link = preview_dir / "bibliography.bib"
-#             if bib_source.exists() and not bib_link.exists():
-#                 try:
-#                     bib_link.symlink_to(bib_source)
-#                     logger.info(
-#                         f"[CompilePreview] Created bibliography symlink for citations"
-#                     )
-#                 except Exception as e:
-#                     logger.warning(
-#                         f"[CompilePreview] Could not create bibliography symlink: {e}"
-#                     )
-#
-#             # Write content to temporary .tex file in .preview directory
-#             # Include theme in temp filename to avoid conflicts with parallel compilations
-#             temp_tex = preview_dir / f"preview-{section_name}-{color_mode}-temp.tex"
-#             logger.info(
-#                 f"[CompilePreview] Creating preview file: {temp_tex} for section: {section_name}, theme: {color_mode}"
-#             )
-#             temp_tex.write_text(latex_content, encoding="utf-8")
-#
-#             logger.info(
-#                 f"[CompilePreview] Compiling {color_mode} preview with latexmk ({len(latex_content)} chars) timeout={timeout}s"
-#             )
-#
-#             # Use latexmk for intelligent multi-pass compilation (handles citations automatically)
-#             # This matches the behavior of full manuscript compilation
-#             result = subprocess.run(
-#                 [
-#                     "latexmk",
-#                     "-pdf",  # Generate PDF output
-#                     "-interaction=nonstopmode",  # Don't stop on errors
-#                     f"-output-directory={preview_dir}",  # Output to preview directory
-#                     "-silent",  # Reduce verbosity
-#                     str(temp_tex),
-#                 ],
-#                 capture_output=True,
-#                 text=True,
-#                 timeout=timeout,
-#                 cwd=str(preview_dir),  # Run from preview directory for relative paths
-#             )
-#
-#             log_content = result.stdout + result.stderr
-#
-#             # Expected PDF output: .preview/preview-{section_name}-{color_mode}-temp.pdf
-#             temp_pdf = preview_dir / f"preview-{section_name}-{color_mode}-temp.pdf"
-#             # Final PDF name: .preview/preview-{section_name}-{color_mode}.pdf
-#             output_pdf = preview_dir / f"preview-{section_name}-{color_mode}.pdf"
-#
-#             # latexmk creates preview-{section_name}-{color_mode}-temp.pdf from preview-{section_name}-{color_mode}-temp.tex
-#             logger.info(f"[CompilePreview] Looking for compiled PDF: {temp_pdf}")
-#
-#             # Check if compilation succeeded by looking for the PDF file
-#             # Note: latexmk return code may be non-zero even on successful compilation
-#             # with -interaction=nonstopmode, so we check for the PDF file instead
-#             if temp_pdf.exists():
-#                 logger.info(
-#                     f"[CompilePreview] {color_mode} PDF compiled successfully with citations at {temp_pdf}"
-#                 )
-#
-#                 # Clean up auxiliary files to keep preview directory tidy
-#                 # Keep: .pdf, .tex, bibliography.bib (symlink)
-#                 # Remove: .aux, .log, .fls, .fdb_latexmk, .bbl, .blg, .out, .toc
-#                 aux_extensions = [
-#                     ".aux",
-#                     ".log",
-#                     ".fls",
-#                     ".fdb_latexmk",
-#                     ".bbl",
-#                     ".blg",
-#                     ".out",
-#                     ".toc",
-#                     ".nav",
-#                     ".snm",
-#                 ]
-#                 base_name = temp_tex.stem
-#                 for ext in aux_extensions:
-#                     aux_file = preview_dir / f"{base_name}{ext}"
-#                     if aux_file.exists():
-#                         try:
-#                             aux_file.unlink()
-#                         except Exception as e:
-#                             logger.debug(
-#                                 f"[CompilePreview] Could not remove auxiliary file {aux_file.name}: {e}"
-#                             )
-#
-#                 # Rename from temp filename to final filename
-#                 if temp_pdf != output_pdf:
-#                     shutil.move(str(temp_pdf), str(output_pdf))
-#
-#                 logger.info(
-#                     f"WriterService: Preview compilation succeeded for {section_name} ({color_mode}): {output_pdf}"
-#                 )
-#
-#                 return {
-#                     "success": True,
-#                     "output_pdf": str(output_pdf),
-#                     "log": log_content,
-#                     "error": None,
-#                 }
-#             else:
-#                 logger.error(
-#                     f"WriterService: Preview compilation failed - PDF not found at {temp_pdf}"
-#                 )
-#                 logger.error(f"latexmk return console: {result.returncode}")
-#                 logger.error(f"latexmk output:\n{log_content}")
-#                 return {
-#                     "success": False,
-#                     "output_pdf": None,
-#                     "log": log_content,
-#                     "error": f"PDF compilation failed - no output PDF generated",
-#                 }
-#
-#         except subprocess.TimeoutExpired:
-#             logger.error(f"WriterService: Preview compilation timeout after {timeout}s")
-#             return {
-#                 "success": False,
-#                 "output_pdf": None,
-#                 "log": f"Compilation timeout after {timeout} seconds",
-#                 "error": f"Compilation timeout",
-#             }
-#         except Exception as e:
-#             logger.error(
-#                 f"WriterService: Preview compilation error: {e}", exc_info=True
-#             )
-#             return {
-#                 "success": False,
-#                 "output_pdf": None,
-#                 "log": str(e),
-#                 "error": str(e),
-#             }
-#
-#     def compile_manuscript(
-#         self,
-#         timeout: int = 300,
-#         log_callback: Optional[Callable] = None,
-#         progress_callback: Optional[Callable] = None,
-#         no_figs: bool = False,
-#         ppt2tif: bool = False,
-#         crop_tif: bool = False,
-#         quiet: bool = False,
-#         verbose: bool = False,
-#         force: bool = False,
-#         **kwargs,  # Catch any unexpected arguments
-#     ) -> dict:
-#         """Compile manuscript with optional callbacks for live updates.
-#
-#         Args:
-#             timeout: Compilation timeout in seconds
-#             log_callback: Optional callback for real-time log streaming
-#             progress_callback: Optional callback for progress updates
-#             no_figs: Exclude figures for quick compilation
-#             ppt2tif: Convert PowerPoint to TIF on WSL
-#             crop_tif: Crop TIF images to remove excess whitespace
-#             quiet: Suppress detailed logs for LaTeX compilation
-#             verbose: Show detailed logs for LaTeX compilation
-#             force: Force full recompilation, ignore cache
-#
-#         Returns:
-#             Compilation result dict with keys:
-#                 - success: bool
-#                 - output_pdf: str (path if successful)
-#                 - log: str (compilation log)
-#                 - error: str (error message if failed)
-#         """
-#         try:
-#             # Use standalone compile function from scitex.writer._compile
-#             from scitex.writer._compile import compile_manuscript
-#
-#             result = compile_manuscript(
-#                 project_dir=self.writer_dir,
-#                 timeout=timeout,
-#                 no_figs=no_figs,
-#                 ppt2tif=ppt2tif,
-#                 crop_tif=crop_tif,
-#                 quiet=quiet,
-#                 verbose=verbose,
-#                 force=force,
-#                 log_callback=log_callback,
-#                 progress_callback=progress_callback,
-#             )
-#             # Build log from stdout/stderr
-#             log_content = ""
-#             if hasattr(result, "stdout") and result.stdout:
-#                 log_content += result.stdout
-#             if hasattr(result, "stderr") and result.stderr:
-#                 if log_content:
-#                     log_content += "\n"
-#                 log_content += result.stderr
-#
-#             return {
-#                 "success": result.success,
-#                 "output_pdf": str(result.output_pdf) if result.output_pdf else None,
-#                 "log": log_content,
-#                 "error": None,  # No error if compilation completed
-#             }
-#         except Exception as e:
-#             logger.error(f"Compilation error: {e}", exc_info=True)
-#             return {
-#                 "success": False,
-#                 "output_pdf": None,
-#                 "log": str(e),
-#                 "error": str(e),
-#             }
-#
-#     def compile_supplementary(
-#         self,
-#         timeout: int = 300,
-#         log_callback: Optional[Callable] = None,
-#         progress_callback: Optional[Callable] = None,
-#         no_figs: bool = False,
-#         ppt2tif: bool = False,
-#         crop_tif: bool = False,
-#         quiet: bool = False,
-#         **kwargs,  # Catch any unexpected arguments
-#     ) -> dict:
-#         """Compile supplementary material.
-#
-#         Args:
-#             timeout: Compilation timeout in seconds
-#             log_callback: Optional callback for real-time log streaming
-#             progress_callback: Optional callback for progress updates
-#             no_figs: Exclude figures (default includes figures)
-#             ppt2tif: Convert PowerPoint to TIF on WSL
-#             crop_tif: Crop TIF images to remove excess whitespace
-#             quiet: Suppress detailed logs for LaTeX compilation
-#         """
-#         try:
-#             # Use standalone compile function from scitex.writer._compile
-#             from scitex.writer._compile import compile_supplementary
-#
-#             result = compile_supplementary(
-#                 project_dir=self.writer_dir,
-#                 timeout=timeout,
-#                 no_figs=no_figs,
-#                 ppt2tif=ppt2tif,
-#                 crop_tif=crop_tif,
-#                 quiet=quiet,
-#                 log_callback=log_callback,
-#                 progress_callback=progress_callback,
-#             )
-#             # Build log from stdout/stderr
-#             log_content = ""
-#             if hasattr(result, "stdout") and result.stdout:
-#                 log_content += result.stdout
-#             if hasattr(result, "stderr") and result.stderr:
-#                 if log_content:
-#                     log_content += "\n"
-#                 log_content += result.stderr
-#
-#             return {
-#                 "success": result.success,
-#                 "output_pdf": str(result.output_pdf) if result.output_pdf else None,
-#                 "log": log_content,
-#                 "error": None,  # No error if compilation completed
-#             }
-#         except Exception as e:
-#             logger.error(f"Supplementary compilation error: {e}", exc_info=True)
-#             return {
-#                 "success": False,
-#                 "output_pdf": None,
-#                 "log": str(e),
-#                 "error": str(e),
-#             }
-#
-#     def compile_revision(
-#         self,
-#         timeout: int = 300,
-#         log_callback: Optional[Callable] = None,
-#         progress_callback: Optional[Callable] = None,
-#         track_changes: bool = False,
-#         **kwargs,  # Catch any unexpected arguments
-#     ) -> dict:
-#         """Compile revision response document.
-#
-#         Args:
-#             timeout: Compilation timeout in seconds
-#             log_callback: Optional callback for real-time log streaming
-#             progress_callback: Optional callback for progress updates
-#             track_changes: Whether to enable change tracking (diff highlighting)
-#         """
-#         try:
-#             # Use standalone compile function from scitex.writer._compile
-#             from scitex.writer._compile import compile_revision
-#
-#             result = compile_revision(
-#                 project_dir=self.writer_dir,
-#                 timeout=timeout,
-#                 track_changes=track_changes,
-#                 log_callback=log_callback,
-#                 progress_callback=progress_callback,
-#             )
-#             # Build log from stdout/stderr
-#             log_content = ""
-#             if hasattr(result, "stdout") and result.stdout:
-#                 log_content += result.stdout
-#             if hasattr(result, "stderr") and result.stderr:
-#                 if log_content:
-#                     log_content += "\n"
-#                 log_content += result.stderr
-#
-#             return {
-#                 "success": result.success,
-#                 "output_pdf": str(result.output_pdf) if result.output_pdf else None,
-#                 "log": log_content,
-#                 "error": None,  # No error if compilation completed
-#             }
-#         except Exception as e:
-#             logger.error(f"Revision compilation error: {e}", exc_info=True)
-#             return {
-#                 "success": False,
-#                 "output_pdf": None,
-#                 "log": str(e),
-#                 "error": str(e),
-#             }
-
-# --------------------------------------------------------------------------------
-# End of Source Code from: apps/writer_app/services/writer/compilation.py
-# --------------------------------------------------------------------------------
+# EOF


### PR DESCRIPTION
## Summary

Pin-bump the prod image to **scitex-writer 2.17.5**, the aggregate
release of the three preview-compile-race hardening PRs landed against
scitex-writer this turn, and migrate the Django consumer to the new
``CompilationResult`` schema introduced in that release.

scitex-writer 2.17.5 payload (already on PyPI):

- **G2 (#124)** — `compile_content.sh` post-latexmk publish is now
  atomic (`cp tmp.$$ + mv -f`). A racing same-key cp can no longer
  propagate a non-zero shell exit into `compile_content()` and surface
  as the user-visible "exit code 12" error.
- **G3 (#125)** — per-(project, section, color_mode) `flock` around
  the script body via `$PREVIEW_DIR/.lock.$JOB_NAME` with `-w
  $TIMEOUT`. Two simultaneous invocations on the same key now
  serialise inside the script even if the Django caller doesn't.
- **G1 (#126)** — `compile_content()` returns a typed
  `CompilationResult` dataclass instead of the historical ad-hoc dict,
  matching the UI's TypeScript `CompilationResult` interface
  (`success`/`exit_code`/`stdout`/`stderr`/`output_pdf`/`log_file`/...).

## Changes

### `deployment/docker/docker_prod/Dockerfile.prod`

- Layer C0 anchor: `scitex-writer==2.10.1` → `scitex-writer==2.17.5`.
  Layer C1 already does `--upgrade scitex-writer`, so it resolves to
  2.17.5 today regardless; bumping the anchor resets the
  dependency-tree cache baseline for future deploys.
- Inline comment captures the G2+G3+G1 rationale for future readers.

### `apps/workspace/writer_app/services/writer/compilation.py`

- New `_coerce_compile_result_to_dict()` helper:
  - Flattens a `CompilationResult` dataclass to a plain dict via
    `dataclasses.asdict()`.
  - Coerces `Path`-typed fields (`output_pdf`, `diff_pdf`, `log_file`,
    `temp_dir`) to `str` so `django.http.JsonResponse` can serialise
    the result without a custom encoder.
  - Pre-2.17.5 dict shapes pass straight through unchanged.
- `CompilationMixin.compile_preview()` passes the upstream return
  value through this helper before returning. No other call-site
  changes are needed:
  - `compile_api` (views/editor/api/compilation.py) keeps its
    `result.get("success")` / `result["output_pdf"]` mutate pattern.
- `compile_manuscript` / `compile_supplementary` / `compile_revision`
  already accessed `CompilationResult` via `hasattr` + attribute
  syntax and remain bit-for-bit unchanged.

### `tests/apps/writer_app/services/writer/test_compilation.py`

- Replace the placeholder skip with real coverage of
  `_coerce_compile_result_to_dict` against:
  - a hand-rolled stand-in dataclass (pinning the 2.17.5 shape and
    decoupling the test from the installed scitex-writer version), and
  - a legacy dict input (pre-2.17.5 shape) to verify back-compat.
- Tests are no-mock, no-monkeypatch, one assertion per test (STX-TQ007
  / STX-NM00x).

## Prod safety

- Wire shape to the UI is preserved (`success`/`output_pdf`/`exit_code`/
  `log`/...). The TypeScript interface already named these fields;
  only the `Path` → `str` coercion is new and is invisible to the
  client.
- `compile_api`'s `result["output_pdf"]` URL rewrite continues to work
  because the helper returns a dict.
- No data migration. No schema change. Image rebuild only.

## Coordination

- **Depends-on (CI)**: PR #253 (migration 0018 SQLite compat) unblocks
  the pytest-matrix gate on develop; this PR's CI will go green once
  #253 merges.
- **Lead release gate**: prod rebuild is deferred until lead verifies
  the new `CompilationResult` round-trip on a staging build, then
  operator + lead pick a NAS-friendly deploy window.
- **Companion PR (scitex-cloud-internal)**: #252 (G4 server-side
  coalesce) merges independently.

## Test plan

- [ ] Develop-side pytest-matrix returns to green via PR #253 merge.
- [ ] After rebase / re-run, this PR's pytest-matrix is green.
- [ ] Staging verify by lead before prod rebuild.
- [ ] Operator + lead schedule prod rebuild + cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)