### PR TITLE
chore(rename): strip stale SciTeX-Cloud refs in live pages + comments

### DIFF
--- a/apps/infra/public_app/models.py
+++ b/apps/infra/public_app/models.py
@@ -11,7 +11,7 @@ from apps.infra.auth_app.models import EmailVerification  # noqa
 # EmailVerification model definition moved to apps.infra.auth_app.models
 # Import statement above provides backwards compatibility
 
-# Models for SciTeX-Cloud services
+# Models for SciTeX Hub services
 
 
 class SubscriptionPlan(models.Model):

--- a/apps/infra/public_app/templates/public_app/landing_partials/landing_demos.html
+++ b/apps/infra/public_app/templates/public_app/landing_partials/landing_demos.html
@@ -208,9 +208,9 @@ scitex mcp install  # Add to Claude Code</code></pre>
                             </div>
                         </div>
                     </div>
-                    <!-- Cloud Demo -->
+                    <!-- Hub Demo -->
                     <div class="demos-carousel-slide">
-                        {% include 'public_app/landing_partials/components/module_demo.html' with module_name='Cloud' icon_path='shared/images/icons_svg/scitex-hub-icon.svg' video_path='public_app/videos/landing/hub-demo.mp4' docs_url='public_app:about' github_url='https://github.com/ywatanabe1989/SciTeX-Cloud' video_position='1.5fr 1fr' video_first=True margin='0 auto' features_partial='public_app/landing_partials/features/hub_features.html' %}
+                        {% include 'public_app/landing_partials/components/module_demo.html' with module_name='Hub' icon_path='shared/images/icons_svg/scitex-hub-icon.svg' video_path='public_app/videos/landing/hub-demo.mp4' docs_url='public_app:about' github_url='https://github.com/ywatanabe1989/scitex-hub' video_position='1.5fr 1fr' video_first=True margin='0 auto' features_partial='public_app/landing_partials/features/hub_features.html' %}
                     </div>
                 </div>
             </div>

--- a/apps/infra/public_app/templates/public_app/landing_partials/landing_ecosystem.html
+++ b/apps/infra/public_app/templates/public_app/landing_partials/landing_ecosystem.html
@@ -63,7 +63,7 @@
                             <strong>scitex-hub</strong>
                         </td>
                         <td>
-                            <code>scitex.cloud</code>
+                            <code>scitex.hub</code>
                         </td>
                         <td class="package-version">
                             <code>{{ SCITEX_HUB_VERSION|default:"—" }}</code>

--- a/apps/infra/public_app/templates/public_app/pages/_concept.html
+++ b/apps/infra/public_app/templates/public_app/pages/_concept.html
@@ -88,7 +88,7 @@
             <div class="ecosystem-diagram">
                 <div class="mermaid">
                     graph TD D[SciTeX-Engine] --- F[SciTeX-Search] F --- B[SciTeX-Code] B
-                    --- C[SciTeX-Doc] C --- E[SciTeX-Viz] E --- A[SciTeX-Cloud] B --- G[Data
+                    --- C[SciTeX-Doc] C --- E[SciTeX-Viz] E --- A[SciTeX-Hub] B --- G[Data
                     Analysis] B --- H[AI Integration] C --- I[LaTeX Compilation] C ---
                     J[Paper Templates] D --- K[Automated Research] D --- L[Emacs
                     Integration] E --- M[Publication Figures] E --- N[Data Visualization] F
@@ -149,7 +149,7 @@
                 <div class="col-md-4">
                     <div class="component-card">
                         <div class="component-icon">🌐</div>
-                        <h3>SciTeX-Cloud</h3>
+                        <h3>SciTeX Hub</h3>
                         <p>Unified web platform that integrates all SciTeX tools</p>
                     </div>
                 </div>

--- a/apps/infra/public_app/templates/public_app/pages/_repositories.html
+++ b/apps/infra/public_app/templates/public_app/pages/_repositories.html
@@ -212,7 +212,7 @@
                     <div class="col-md-6 col-lg-4 mb-4">
                         <div class="repo-card">
                             <span class="repo-language language-python">Python</span>
-                            <h3>SciTeX-Cloud</h3>
+                            <h3>SciTeX Hub</h3>
                             <p>Unified web platform that integrates all SciTeX tools</p>
                             <div class="repo-stats">
                                 <div class="repo-stat">
@@ -314,7 +314,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                <td>SciTeX-Cloud</td>
+                                <td>SciTeX Hub</td>
                                 <td>#12</td>
                                 <td>Improve accessibility of landing page</td>
                                 <td>

--- a/apps/infra/public_app/templates/public_app/pages/_roadmap.html
+++ b/apps/infra/public_app/templates/public_app/pages/_roadmap.html
@@ -150,7 +150,7 @@
             <h2>Development Timeline</h2>
             <div class="mermaid">
                 gantt title SciTeX Development Timeline dateFormat YYYY-MM-DD section
-                SciTeX-Cloud Web Interface :done, cloud1, 2025-01-01, 90d User
+                SciTeX Hub Web Interface :done, cloud1, 2025-01-01, 90d User
                 Authentication :done, cloud2, after cloud1, 60d Collaboration Features
                 :active, cloud3, after cloud2, 90d API Integration : cloud4, after cloud3,
                 120d section SciTeX-Doc LaTeX Compilation :done, doc1, 2025-01-01, 120d
@@ -172,7 +172,7 @@
                     <div class="milestone">
                         <div class="milestone-date">June 2025</div>
                         <div class="milestone-content">
-                            <h3>SciTeX-Cloud Beta Release</h3>
+                            <h3>SciTeX Hub Beta Release</h3>
                             <p>
                                 First public beta of the web interface with basic document
                                 management and LaTeX compilation capabilities.
@@ -427,7 +427,7 @@
                 <div class="form-group mb-3">
                     <label for="featureCategory">Category</label>
                     <select class="form-control" id="featureCategory">
-                        <option>SciTeX-Cloud (Web Interface)</option>
+                        <option>SciTeX Hub (Web Interface)</option>
                         <option>SciTeX-Doc (Document Preparation)</option>
                         <option>SciTeX-Code (Data Analysis)</option>
                         <option>SciTeX-Engine (Research Automation)</option>

--- a/apps/infra/public_app/templates/public_app/pages/_windows.html
+++ b/apps/infra/public_app/templates/public_app/pages/_windows.html
@@ -198,8 +198,8 @@ sudo apt install git python3 python3-pip python3-venv</pre>
                 </h3>
                 <p>Open your WSL terminal and clone the SciTeX Hub repository:</p>
                 <pre class="code-block">
-git clone https://github.com/SciTex-AI/SciTeX-Cloud.git
-cd SciTeX-Cloud</pre>
+git clone https://github.com/ywatanabe1989/scitex-hub.git
+cd scitex-hub</pre>
             </div>
             <div class="step-card">
                 <h3>
@@ -459,7 +459,7 @@ netsh interface portproxy delete v4tov4 listenport=8000 listenaddress=0.0.0.0</p
         <h2>Ready to Develop on Windows?</h2>
         <p class="lead">Start building with SciTeX Hub on your Windows machine today</p>
         <div class="mt-4">
-            <a href="https://github.com/SciTex-AI/SciTeX-Cloud"
+            <a href="https://github.com/ywatanabe1989/scitex-hub"
                class="btn btn-primary btn-lg mx-2"
                target="_blank">
                 <i class="fab fa-github"></i> Clone Repository

--- a/apps/infra/public_app/templates/public_app/pages/api_keys.html
+++ b/apps/infra/public_app/templates/public_app/pages/api_keys.html
@@ -61,7 +61,7 @@
                     padding: 2rem;
                     margin-bottom: 2rem">
             <h2 style="color: var(--color-fg-default); margin-bottom: 1rem">Usage</h2>
-            <pre style=" background: var(--color-canvas-default); padding: 1rem; border-radius: 6px; border: 1px solid var(--color-border-default); overflow-x: auto; "><code style="color: var(--color-fg-default); font-family: monospace;">curl -X POST https://scitex.cloud/scholar/api/bibtex/enrich/ \
+            <pre style=" background: var(--color-canvas-default); padding: 1rem; border-radius: 6px; border: 1px solid var(--color-border-default); overflow-x: auto; "><code style="color: var(--color-fg-default); font-family: monospace;">curl -X POST https://scitex.ai/scholar/api/bibtex/enrich/ \
   -H "Authorization: Bearer YOUR_KEY" \
   -F "bibtex_file=@input.bib" \
   -o enriched.bib</code></pre>

--- a/apps/infra/public_app/templates/public_app/pages/feature_request.html
+++ b/apps/infra/public_app/templates/public_app/pages/feature_request.html
@@ -362,7 +362,7 @@
             <p class="text-center mb-4">Here's what we're working on now and planning for the future</p>
             <div class="mermaid">
                 gantt title SciTeX Development Timeline dateFormat YYYY-MM-DD section
-                SciTeX-Cloud Web Interface :done, cloud1, 2025-01-01, 90d User
+                SciTeX Hub Web Interface :done, cloud1, 2025-01-01, 90d User
                 Authentication :done, cloud2, after cloud1, 60d Collaboration Features
                 :active, cloud3, after cloud2, 90d API Integration : cloud4, after cloud3,
                 120d section SciTeX-Doc LaTeX Compilation :done, doc1, 2025-01-01, 120d

--- a/apps/infra/public_app/templates/public_app/pages/vision.html
+++ b/apps/infra/public_app/templates/public_app/pages/vision.html
@@ -279,7 +279,7 @@
                 <div class="timeline-item">
                     <div class="timeline-date">2026-2027 - Phase 3: Visualization & Platform Integration</div>
                     <div class="timeline-content">
-                        <h4>SciTeX-Viz & SciTeX-Cloud Integration</h4>
+                        <h4>SciTeX-Viz & SciTeX Hub Integration</h4>
                         <p>
                             Development of visualization tools and a unified web platform to
                             integrate all components into a cohesive ecosystem.

--- a/apps/infra/public_app/templates/public_app/products/hub.html
+++ b/apps/infra/public_app/templates/public_app/products/hub.html
@@ -25,7 +25,7 @@
                     </p>
                     <div class="location-info">
                         <strong>Project Location:</strong>
-                        <code>~/proj/SciTeX-Cloud</code> (This repository)
+                        <code>~/proj/scitex-hub</code> (This repository)
                         <br />
                         <strong>Production URL:</strong> <code>https://scitex.ai</code>
                     </div>

--- a/apps/workspace/scholar_app/views/bibtex/enrichment.py
+++ b/apps/workspace/scholar_app/views/bibtex/enrichment.py
@@ -12,7 +12,8 @@ import asyncio
 import logging
 import tempfile
 from pathlib import Path
-from django.http import JsonResponse, FileResponse
+
+from django.http import FileResponse, JsonResponse
 from django.views.decorators.http import require_http_methods
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ def bibtex_enrich_sync(request):
     Requires API key authentication.
 
     Usage:
-        curl https://scitex.cloud/scholar/api/bibtex/enrich/ \
+        curl https://scitex.ai/scholar/api/bibtex/enrich/ \
           -H "Authorization: Bearer YOUR_API_KEY" \
           -F "bibtex_file=@original.bib" \
           -o enriched.bib

--- a/config/logger.py
+++ b/config/logger.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Timestamp: "2025-05-22 05:15:38 (ywatanabe)"
-# File: /home/ywatanabe/proj/SciTeX-Cloud/config/logger.py
+# File: /home/ywatanabe/proj/scitex-hub/config/logger.py
 # ----------------------------------------
 """
 Logger utilities for SciTeX Hub project.
@@ -14,9 +14,9 @@ patterns like function calls, exceptions, and API requests.
 """
 
 import logging
-from functools import wraps
-import traceback
 import time
+import traceback
+from functools import wraps
 
 # Get logger for our application
 logger = logging.getLogger("scitex")


### PR DESCRIPTION
## Summary
Cleans the residual `SciTeX-Cloud` brand references from live UX surfaces and a handful of code/header comments that survived the v0.18.0 rename. 13 files, +24/-23 net.

### Touched (live, user-facing)
- **`apps/infra/public_app/templates/public_app/`** — products/hub.html, pages/_concept.html, _repositories.html, _roadmap.html, _windows.html, vision.html, feature_request.html, api_keys.html, landing_partials/landing_demos.html, landing_partials/landing_ecosystem.html.
- **`apps/infra/public_app/models.py`** — file-header comment.
- **`apps/workspace/scholar_app/views/bibtex/enrichment.py`** — docstring curl URL `scitex.cloud` → `scitex.ai`.
- **`config/logger.py`** — stale `/proj/SciTeX-Cloud/` filename comment.

### Intentionally preserved
- ADRs (`docs/adr/0001-rename-scitex-cloud-to-scitex-hub.md`) + CHANGELOG / release notes — historical.
- `config/_env.py` rename-rationale messages — describe the rename event itself.
- `apps/infra/public_app/config/api_docs.py` legacy `scitex-cloud-campaign-*` token alias — back-compat for tokens issued pre-rename.
- `src/scitex_cloud/*` — deprecation shim for the old PyPI distribution.
- `SciTex-AI/SciTeX-Cloud` org-mirror URLs in `_windows.html` / `_repositories.html` table cell — kept until the org-mirror itself is renamed (tracked as board card `rename-followups-org-mirror`).
- `apps/workspace/console_app/views/terminal/dotfiles.py` `@scitex.cloud` git author email — changing this would be a production behaviour change whose tests live in a pre-existing 62-error legacy file (mock/AAA violations); needs its own refactor PR.

## Follow-up board cards (added via `scitex-todo add`)
- `rename-followups-rtd` (operator) — ReadTheDocs project rename, RTD dashboard.
- `rename-followups-org-mirror` (operator) — `SciTeX-AI/scitex-cloud` → `scitex-hub` (needs org admin).
- `rename-followups-nas-migration` (lead) — `scripts/migrate/rename_to_scitex_hub.sh` on the NAS (operator-gated; do not run unattended).

## Test plan
- [ ] CI green (pytest matrix + audit + sphinx + e2e + RTD).
- [ ] Visual: landing page demos slide / windows / repositories / roadmap render with "SciTeX Hub" (not "SciTeX-Cloud").

Closes board card: `rename-followups`.