### PR TITLE
fix(test): skipif on missing scitex-agentic-journal in thin-wrapper urls test

### DIFF
--- a/tests/apps/agentic_journal_app/test_thin_wrapper.py
+++ b/tests/apps/agentic_journal_app/test_thin_wrapper.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
+
+import pytest
 
 _MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
@@ -12,6 +15,9 @@ _MANIFEST_PATH = (
     / "agentic_journal_app"
     / "manifest.json"
 )
+
+
+_UPSTREAM_AVAILABLE = importlib.util.find_spec("scitex_agentic_journal") is not None
 
 
 def test_manifest_file_exists() -> None:
@@ -61,6 +67,14 @@ def test_wrapper_apps_module_imports() -> None:
     assert wrapper_apps.AgenticJournalAppConfig.label == "agentic_journal_app"
 
 
+@pytest.mark.skipif(
+    not _UPSTREAM_AVAILABLE,
+    reason=(
+        "scitex-agentic-journal is not installed in this environment; "
+        "wrapper urls.py eagerly include()s its URL conf and would "
+        "ImportError. Skip — covered by upstream's own _django URL tests."
+    ),
+)
 def test_wrapper_urls_module_imports() -> None:
     # Arrange
     # Act


### PR DESCRIPTION
## Why this exists
**develop is currently RED** on pytest matrix (py3.11 / 3.12 / 3.13) because of:

```
tests/apps/agentic_journal_app/test_thin_wrapper.py::test_wrapper_urls_module_imports
FAILED — ModuleNotFoundError: No module named 'scitex_agentic_journal'
```

The wrapper's `urls.py` uses `django.urls.include("scitex_agentic_journal._django.urls")`, which **eagerly** imports the upstream URL module at test-collection time. `scitex-agentic-journal` is pre-alpha and not yet a hard dep of scitex-hub, so its absence in the CI matrix is the expected state — but the test treats absence as a failure.

## The fix
One-line `@pytest.mark.skipif(not _UPSTREAM_AVAILABLE, ...)` on `test_wrapper_urls_module_imports`. When the upstream IS installed (the runtime path that matters), the test still runs and asserts `len(urlpatterns) >= 1`. When it isn't, the test skips with a clear reason rather than failing — the upstream package has its own `_django` URL tests, so this skip doesn't reduce real coverage.

This is the same change I had pushed to `feat/aj-cloud-thin-wrap` as commit `edfdf346f` shortly after PR #257 was merged — cherry-picked here so it lands on develop directly.

## How #257 merged while red — close the gap
This is the learning question lead asked. Looking at the timeline:
- PR #257 was merged at 16:18:54Z (merge commit `a253c1ae`).
- The merge parent on the head side is `5877d453a` (apps.ready() warns fix, my second commit).
- My third commit `edfdf346f` (test fix) was pushed AFTER the merge.
- The pytest matrix on `5877d453a` was still failing on the same wrapper-urls test at the time of merge — CI conclusion was FAILURE on py3.11/3.12/3.13 (visible in the run-id checks rollup).

So the merge bypassed the failing pytest gate. Two non-mutually-exclusive ways that can happen:
1. **`--admin` merge** (or admin override in the GitHub UI).
2. **Branch-protection rules not requiring pytest-matrix as a required check** — only "import-smoke", "audit", "sphinx", etc.

Closing this gap is repo-config, not code: either add `pytest-matrix-on-ubuntu-py3.{11,12,13}` to the branch-protection required-checks list for `develop`, or stop allowing admin-merge-while-red. Both are operator/lead actions (need repo admin), so I'm flagging here rather than touching `.github` (that's out of my lane tonight and would need a separate decision).

## Test plan
- [x] Locally: `pytest tests/apps/agentic_journal_app/test_thin_wrapper.py` — 4 pass, 1 skipped on missing upstream.
- [ ] CI: pytest matrix green on all three Python versions.

## Scope
Pure test-only change. No production behaviour change. Targets the broken-develop unblock and nothing else.