### PR TITLE
docs(wrapper): correct apps.ready() docstring on missing-upstream path

### DIFF
--- a/apps/workspace/agentic_journal_app/apps.py
+++ b/apps/workspace/agentic_journal_app/apps.py
@@ -33,10 +33,13 @@ class AgenticJournalAppConfig(AppConfig):
         on PyPI). Raising there crashes every Django startup including
         the unrelated pytest matrix.
 
-        The "fail loud" doctrine still holds — the **request path**
-        raises clearly (see ``urls.py`` lazy include + ``manifest`` view)
-        if a user hits the dashboard with no upstream installed. Boot
-        is permissive; runtime is strict.
+        The "fail loud" doctrine still holds — the **request path** dies
+        loudly when a user hits the dashboard with no upstream installed:
+        ``urls.py`` calls ``django.urls.include("scitex_agentic_journal.
+        _django.urls")``, which Django resolves lazily on the first URL
+        match. With the upstream absent that resolve raises
+        ``ImportError`` and Django renders a 500 — not a silent stub
+        page. Boot is permissive; runtime is strict.
         """
         try:
             from scitex_agentic_journal._django import load_manifest


### PR DESCRIPTION
## Summary
Surgical docstring fix in `apps/workspace/agentic_journal_app/apps.py`.

The original `ready()` docstring claimed the request path failed via "`urls.py` lazy include + `manifest` view" — but there is no `manifest` view in this thin wrapper, and `load_manifest()` is called from `ready()` itself (boot path), not from a view. The actual missing-upstream behaviour is simpler and worth saying directly:

> `django.urls.include("scitex_agentic_journal._django.urls")` is resolved lazily on the first URL match. With the upstream absent, that resolve raises `ImportError` and Django renders a 500 — not a silent stub page.

## Scope
- Pure docstring change. **No behaviour change.**
- The fix-loud-at-runtime contract is identical; the docstring now describes the real mechanism instead of an imagined one.
- 1 file modified (`apps.py`), 7 lines changed.

## Test plan
- [ ] CI matrix green (it's a string-literal-only change; expect full pass set as on #260).