### PR TITLE
test(shim): cover scitex_cloud deprecation-message + PEP-562 AttributeError

### DIFF
--- a/tests/scitex_hub/test_scitex_cloud_shim.py
+++ b/tests/scitex_hub/test_scitex_cloud_shim.py
@@ -76,3 +76,61 @@ def test_scitex_cloud_submodules_are_identical_to_scitex_hub():
     ok = _run_snippet_ok(snippet)
     # Assert
     assert ok
+
+
+def test_deprecation_message_names_new_module_and_adr():
+    """The operator-facing migration hint must point at the new name AND the ADR.
+
+    Without these two strings the user is told "deprecated" with no way to
+    find the replacement or the rationale — silent migration handoff is
+    the failure mode this test prevents.
+    """
+    # Arrange
+    snippet = """
+        import warnings
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            import scitex_cloud  # noqa: F401
+        dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert dep, "no DeprecationWarning captured"
+        msg = str(dep[0].message)
+        assert "scitex_hub" in msg, f"replacement name missing in {msg!r}"
+        assert "0001" in msg, f"ADR-0001 link missing in {msg!r}"
+        print("OK")
+    """
+    # Act
+    ok = _run_snippet_ok(snippet)
+    # Assert
+    assert ok
+
+
+def test_unknown_attribute_on_shim_raises_attribute_error():
+    """PEP-562 ``__getattr__`` must not silently swallow lookup misses.
+
+    If the fallback silently returns ``None`` (or worse, an unrelated
+    object), downstream code reading the legacy name observes a fake
+    success — exactly the silent-fallback failure mode the rename ADR
+    rejects. Verify the shim raises ``AttributeError`` for a guaranteed-
+    nonexistent name, and that the error message mentions the legacy
+    package so the operator knows where the lookup landed.
+    """
+    # Arrange
+    snippet = """
+        import warnings
+        warnings.simplefilter("ignore")
+        import scitex_cloud
+        bogus = "definitely_not_a_real_symbol_xyz_42"
+        try:
+            getattr(scitex_cloud, bogus)
+        except AttributeError as exc:
+            assert "scitex_cloud" in str(exc), f"missing module name: {exc!r}"
+            print("OK")
+        else:
+            raise AssertionError(
+                "getattr returned silently for an unknown attribute"
+            )
+    """
+    # Act
+    ok = _run_snippet_ok(snippet)
+    # Assert
+    assert ok


### PR DESCRIPTION
## Why this PR
Adds two **no-mock** subprocess-isolated tests filling real gaps in the `scitex_cloud` back-compat shim's operator-facing contract. The existing suite verifies the shim **mechanism** (warning fires, top-level symbols alias, submodules identical) but leaves the **operator-facing surface** uncovered — the warning text content and the PEP-562 fallback's silent-handoff failure mode.

## What's covered
1. **`test_deprecation_message_names_new_module_and_adr`** — the existing tests confirm *a* DeprecationWarning fires, but not what it says. Operators reading the warning need to learn (a) the new module name `scitex_hub` and (b) the rationale link (ADR-0001) or the deprecation is just noise. Asserting both strings are present prevents a future shim edit from quietly stripping the migration handoff.
2. **`test_unknown_attribute_on_shim_raises_attribute_error`** — the PEP-562 `__getattr__` fallback is the load-bearing mechanism behind `scitex_cloud.<anything>` aliasing to `scitex_hub`. If it silently returns `None` (or worse, a default), legacy callers observe **fake success** — exactly the silent-fallback failure mode ADR-0001 rejects. Verifies a guaranteed-nonexistent lookup raises `AttributeError` and that the error message mentions the legacy module so the operator sees where it landed.

## Test plan
- [x] File syntax-checked locally (`ast.parse`).
- [ ] CI pytest matrix runs the new tests in the fresh-subprocess pattern the existing suite uses. Expect both green on py3.{11,12,13}; no daphne/Django imports inside the new tests.

## Scope
- Pure additive test coverage on the shim. **No production behaviour change.**
- Reuses the existing `_run_snippet_ok` helper so the new tests inherit the suite's fresh-interpreter discipline.
- No mocks (subprocess against real `scitex_cloud` + `scitex_hub`).