### PR TITLE
feat(workspace): mount agentic_journal_app at /apps/agentic-journal/ + runbook section

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -101,6 +101,15 @@ urlpatterns = [
     ),
     path("apps/llm/", include(("apps.infra.llm_app.urls", "llm_app"))),
     path("apps/clew/", include(("apps.workspace.clew_app.urls", "clew_app"))),
+    path(
+        "apps/agentic-journal/",
+        include(
+            (
+                "apps.workspace.agentic_journal_app.urls",
+                "agentic_journal_app",
+            )
+        ),
+    ),
     path("apps/store/", include(("apps.workspace.apps_app.urls", "apps_app"))),
     path("apps/comms/", include(("apps.workspace.comms_app.urls", "comms_app"))),
     # --- Dev-installed app modules (/apps/dev__<owner>__<repo>/) ---

--- a/docs/runbooks/local-staging-orochi-cloud.md
+++ b/docs/runbooks/local-staging-orochi-cloud.md
@@ -142,6 +142,79 @@ ssh -L 31294:localhost:31294 your-workstation-host
 container healthcheck — that's a good first URL to hit to confirm the
 stack reached the ready state.
 
+## Mounting upstream plugin apps
+
+The hub mounts standalone upstream packages as thin-wrapper plugin
+apps (the `_django` pattern). The first wrapper landed is:
+
+| Hub mount | Wrapper package | Upstream Python package |
+|-----------|-----------------|-------------------------|
+| `/apps/agentic-journal/` | `apps.workspace.agentic_journal_app` | `scitex-agentic-journal` |
+
+A follow-up PR adds the `live_paper_app` wrapper (mount
+`/apps/live-paper/`, upstream `scitex-live-paper`); the registration
+mechanism documented below applies to it as well.
+
+### Wrapper registration mechanism (recap)
+
+Three pieces, all required:
+
+1. **AppConfig** in `apps/workspace/<x>_app/apps.py` (`name =
+   "apps.workspace.<x>_app"`). Auto-discovered into `INSTALLED_APPS`
+   by `discover_local_apps()` in `config/settings/settings_shared.py`.
+2. **URL include** in `config/urls.py` — explicit
+   `path("apps/<mount>/", include((..., "<x>_app")))` entry. **NOT
+   auto-discovered.**
+3. **Manifest** at `apps/workspace/<x>_app/manifest.json`
+   (`scitex-app-manifest` schema v2.0.0).
+
+The upstream package must provide, under `<pkg>/_django/`: `apps.py`,
+`urls.py`, `manifest.json`, plus any handlers/views/templates the
+dashboard renders. The wrapper's `urls.py` then `include()`s the
+upstream URL conf, preserving namespace so reverses
+(`reverse("<x>_app:submission-detail", args=[id])`) match across
+deployments.
+
+### Bring-up — agentic-journal
+
+> **STOP** before each numbered step. The lead must approve a `pip
+> install` into the staging image; running it without confirmation
+> mutates the image's site-packages.
+
+1. **Install `scitex-agentic-journal` into the staging Django image.**
+   Two paths (`scitex-agentic-journal` is pre-alpha, not on PyPI yet):
+
+   - **Editable bind-mount** — extend
+     `deployment/docker/docker-compose.staging.yml` `django.volumes`
+     with a read-only mount of
+     `~/proj/scitex-agentic-journal/src/scitex_agentic_journal` into
+     the container's site-packages.
+   - **`pip install -e`** inside a rebuilt image (`make ENV=staging
+     build`).
+
+2. **Confirm boot.** Either path missing its upstream will log a
+   warning at boot (the wrapper's `apps.ready()` warns instead of
+   raises) and 500 the dashboard URL on first request:
+
+   ```bash
+   make ENV=staging logs-web | grep agentic_journal_app
+   curl -sS http://localhost:31294/apps/agentic-journal/
+   ```
+
+3. **Hub app-store.** `/apps/store/` reads the wrapper's
+   `manifest.json` and lists the app as `default_enabled: false`
+   (alpha). Toggle to enable per project once the operator wants it
+   surfaced in the workspace nav.
+
+### What this section does NOT do
+
+- It does **not** stand the upstream package up against the **NAS**
+  staging instance — that path lives in a separate runbook owned by
+  proj-scitex-orochi.
+- It does **not** add the upstream package as a **hard** dependency
+  of scitex-hub. It's an optional `[staging]` extra; hub deploys
+  that don't host the journal surface simply skip the install.
+
 ## Verifying functionality
 
 Once the page loads, the smoke checks in priority order:


### PR DESCRIPTION
## Summary
Unblocks the agentic-journal dashboard route. PR #257 landed the `apps/workspace/agentic_journal_app/` thin wrapper but no entry was added to `config/urls.py`, so `/apps/agentic-journal/` resolves to 404 today — operator literally cannot reach the journal surface, even though the wrapper, auto-discovery, and manifest are already on develop.

This PR:

- Adds `path("apps/agentic-journal/", include(("apps.workspace.agentic_journal_app.urls", "agentic_journal_app")))` to `config/urls.py`.
- Extends `docs/runbooks/local-staging-orochi-cloud.md` with a **Mounting upstream plugin apps** section: documents the 3-piece registration mechanism (AppConfig auto-discover + URL include + manifest) and the agentic-journal bring-up sequence with STOP markers before any operator-gated install step.

## Scope
- 2 files modified, no new files.
- No infra mutated, no `make start` / compose-up.
- Pre-flight + bring-up + recovery checklist for agentic-journal only; live-paper has its own follow-up PR (`live_paper_app/` wrapper + URL include + live-paper-specific runbook content).

## Follow-up PR
Adds the `live_paper_app/` wrapper (`apps.py` + `urls.py` + `manifest.json` + README + skipif-on-missing-upstream test), the URL include for `/apps/live-paper/`, and the live-paper-specific runbook content. Targets the public `BundleContext` / `BundleSource` / `PaperState` / `RendererOptions` from live-paper develop (PR #23, merged earlier) plus `?embed=1` / `data-embed-mode="1"` for iframe mounting (PR #24, merged). Will land within minutes of this PR.

## Test plan
- [ ] CI green (markdown + config change).
- [ ] Manual: `GET /apps/agentic-journal/` returns the wrapper's placeholder JSON instead of 404.

Closes board card: `hub-plugin-apps-live-paper-and-agentic-journal` (partial — agentic-journal half).