### PR TITLE
feat(workspace): live_paper_app cloud-side thin wrapper + URL mount

### DIFF
--- a/apps/workspace/live_paper_app/README.md
+++ b/apps/workspace/live_paper_app/README.md
@@ -1,0 +1,67 @@
+# Live Paper — cloud-side thin wrapper
+
+This Django sub-app is a **thin shim** over the standalone
+[`scitex-live-paper`](https://github.com/ywatanabe1989/scitex-live-paper).
+
+## What this package owns
+
+- Registration into the SciTeX Hub workspace (`apps.py` AppConfig).
+- URL include of the upstream embedded patterns (`urls.py`).
+- Hub-side manifest for the app-store loader (`manifest.json`).
+
+## What it does NOT own
+
+- **Logic** — owned by `scitex_live_paper._django` upstream.
+- **Templates / static / handlers** — owned upstream.
+- **The plugin-mount contract** (`mount(resolver=...)`) — owned
+  upstream; this wrapper currently uses the single-tenant env-pinned
+  path. A follow-up PR will flip the wrapper to use
+  `mount(resolver=...)` once the upstream `BundleContext` dataclass
+  is publicly importable.
+
+## Configuration
+
+The single-tenant path is driven by an env var consumed inside the
+container Django process:
+
+```
+SCITEX_LIVE_PAPER_BUNDLE=/path/inside/container/to/bundle
+```
+
+See `docs/runbooks/local-staging-orochi-cloud.md` for the bring-up
+sequence on a local staging workstation. The bundle path is read by
+the upstream `_django/urls.py`; the wrapper does not touch it.
+
+## Embedding the viewer in another hub view
+
+The upstream SPA shell honours an **embed-mode** flag that strips its
+own chrome so the hub-side host (e.g. a project_app panel rendering
+the viewer inside an iframe) can avoid double-chrome:
+
+```html
+<iframe src="/apps/live-paper/?embed=1" data-embed-mode="1"></iframe>
+```
+
+Both knobs are part of the upstream SPA contract (scitex-live-paper
+PR #24, merged):
+
+- `?embed=1` — query-string flag the SPA reads to skip its own
+  chrome (nav, headers, footers).
+- `data-embed-mode="1"` — attribute the SPA places on the root div;
+  hub-side JS that wraps the iframe can read it to suppress hub
+  chrome too.
+
+If you mount the viewer **without** the iframe (e.g. as a stand-alone
+hub page), drop both flags so the SPA renders its full chrome.
+
+## Adding behaviour
+
+If you find yourself adding business logic here, **stop**. Push the
+logic upstream into `scitex-live-paper` and have the wrapper only
+re-export.
+
+## See also
+
+- Upstream package: https://github.com/ywatanabe1989/scitex-live-paper
+- Sibling wrapper: `apps/workspace/agentic_journal_app/` (same shape).
+- Local-staging runbook: `docs/runbooks/local-staging-orochi-cloud.md`.

--- a/apps/workspace/live_paper_app/__init__.py
+++ b/apps/workspace/live_paper_app/__init__.py
@@ -1,0 +1,19 @@
+"""SciTeX Live Paper — cloud-side thin wrapper.
+
+This Django sub-app is a **thin shim** over the standalone
+``scitex-live-paper`` package. The standalone owns:
+
+- The viewer + handlers + services (``_django/``).
+- The plugin-mount contract (``mount(resolver=...)``) — its multi-
+  tenant entry point. The hub wrapper currently uses the single-
+  tenant env-pinned path (``SCITEX_LIVE_PAPER_BUNDLE``) and will
+  flip to ``mount(resolver=...)`` in a follow-up once live-paper's
+  ``BundleContext`` dataclass lands publicly.
+
+The wrapper owns nothing except the registration into the
+``apps/workspace`` discovery list and the URL include. If the
+wrapper grows beyond ``apps.py`` + ``urls.py`` + ``manifest.json``,
+that's a smell — push the logic back upstream.
+"""
+
+default_app_config = "apps.workspace.live_paper_app.apps.LivePaperAppConfig"

--- a/apps/workspace/live_paper_app/apps.py
+++ b/apps/workspace/live_paper_app/apps.py
@@ -1,0 +1,49 @@
+"""Django AppConfig — cloud-side thin wrapper for scitex-live-paper.
+
+Boot is permissive; runtime is strict. If ``scitex-live-paper`` is not
+installed (not yet a hard dep — pre-alpha, not on PyPI), Django still
+boots and the wrapper logs a warning. The dashboard URL `apps/
+live-paper/` then surfaces a typed 500 on first request via the lazy
+``include("scitex_live_paper._django.urls")`` in ``urls.py``.
+
+This mirrors the agentic_journal_app wrapper's docstring on the same
+contract; both apps share the wrapper pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.apps import AppConfig
+
+_logger = logging.getLogger(__name__)
+
+
+class LivePaperAppConfig(AppConfig):
+    """Cloud-side wrapper for ``scitex_live_paper._django``."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.workspace.live_paper_app"
+    label = "live_paper_app"
+    verbose_name = "Live Paper"
+
+    def ready(self) -> None:
+        """Probe the upstream package and warn (not raise) if missing.
+
+        The fail-loud doctrine still holds — the **request path** dies
+        loudly when a user hits ``/apps/live-paper/`` with no upstream
+        installed: ``urls.py`` calls ``django.urls.include(
+        "scitex_live_paper._django.urls")``, which Django resolves
+        lazily on the first URL match. With the upstream absent that
+        resolve raises ``ImportError`` and Django renders a 500.
+        """
+        try:
+            import scitex_live_paper._django  # noqa: F401
+        except ImportError:
+            _logger.warning(
+                "live_paper_app: `scitex-live-paper` is not installed. "
+                "Dashboard URLs (/apps/live-paper/) will return 500 with "
+                "a typed error until you `pip install scitex-live-paper` "
+                "or remove this app from INSTALLED_APPS."
+            )
+            return

--- a/apps/workspace/live_paper_app/manifest.json
+++ b/apps/workspace/live_paper_app/manifest.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "scitex-app-manifest",
+  "$schema_version": "2.0.0",
+  "name": "live-paper",
+  "label": "Live Paper",
+  "app_name": "live_paper_app",
+  "icon": "",
+  "icon_svg": true,
+  "description": "Interactive scientific paper viewer: claim verification, provenance graph, reproducible figures. Plugin-mounted into SciTeX Hub via the standalone scitex-live-paper package.",
+  "version": "0.1.0-alpha",
+  "license": "AGPL-3.0",
+  "keyboard_shortcut": "L",
+  "order": 65,
+  "default_enabled": false,
+  "accent_color": "live-paper",
+  "body_class": "live-paper-page",
+  "partial_template": "live_paper_app/index_partial.html",
+  "context_builder": "",
+  "docs_slug": "live-paper",
+  "ai_hint": "View an interactive scientific paper with claim verification + provenance graph + reproducible figures.",
+  "allowed_extensions": [],
+  "hidden_patterns": ["__pycache__", "node_modules", ".git", ".venv"],
+  "privileges": [
+    {"type": "filesystem", "scope": "project", "reason": "Read bundled live-paper artifacts (manuscript + claims + DAG + assets)"},
+    {"type": "network", "scope": "outbound", "reason": "Persistent-ID resolver (DOI / sandbox) lookups"}
+  ],
+  "builtin": false,
+  "dependencies": {
+    "python": ["scitex-live-paper>=0.1.0a0"],
+    "system": [],
+    "node": [],
+    "r": [],
+    "other": []
+  },
+  "container": null
+}

--- a/apps/workspace/live_paper_app/urls.py
+++ b/apps/workspace/live_paper_app/urls.py
@@ -1,0 +1,23 @@
+"""URL config — forward to the upstream embedded app.
+
+The hub wrapper currently uses the **single-tenant env-pinned** path:
+the upstream ``_django/urls.py`` reads ``SCITEX_LIVE_PAPER_BUNDLE``
+to find the bundle for the live-paper viewer. Multi-tenant routing
+via ``scitex_live_paper.mount(resolver=...)`` is a follow-up once
+the upstream's ``BundleContext`` dataclass is publicly importable.
+
+A future hub-side change (e.g. switching to ``mount(resolver=...)``
+or adding hub-auth middleware) lives here. Today the wrapper just
+``include()``s the upstream patterns under the workspace's mount
+point. The upstream URL conf declares ``app_name = "live_paper"`` so
+reverses (``reverse("live_paper:viewer_page")``) stay stable across
+deployments without an explicit ``namespace=`` argument.
+"""
+
+from __future__ import annotations
+
+from django.urls import include, path
+
+urlpatterns = [
+    path("", include("scitex_live_paper._django.urls")),
+]

--- a/config/urls.py
+++ b/config/urls.py
@@ -101,6 +101,10 @@ urlpatterns = [
     ),
     path("apps/llm/", include(("apps.infra.llm_app.urls", "llm_app"))),
     path("apps/clew/", include(("apps.workspace.clew_app.urls", "clew_app"))),
+    path(
+        "apps/live-paper/",
+        include("apps.workspace.live_paper_app.urls"),
+    ),
     path("apps/store/", include(("apps.workspace.apps_app.urls", "apps_app"))),
     path("apps/comms/", include(("apps.workspace.comms_app.urls", "comms_app"))),
     # --- Dev-installed app modules (/apps/dev__<owner>__<repo>/) ---

--- a/tests/apps/live_paper_app/test_thin_wrapper.py
+++ b/tests/apps/live_paper_app/test_thin_wrapper.py
@@ -1,0 +1,92 @@
+"""Smoke tests for the live-paper cloud-side thin wrapper.
+
+Mirrors ``tests/apps/agentic_journal_app/test_thin_wrapper.py`` — the
+wrapper pattern is identical (apps.py + urls.py + manifest.json), only
+the upstream package name changes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "apps"
+    / "workspace"
+    / "live_paper_app"
+    / "manifest.json"
+)
+
+
+_UPSTREAM_AVAILABLE = importlib.util.find_spec("scitex_live_paper") is not None
+
+
+def test_manifest_file_exists() -> None:
+    # Arrange
+    path = _MANIFEST_PATH
+    # Act
+    exists = path.is_file()
+    # Assert
+    assert exists is True
+
+
+def test_manifest_app_name_matches_wrapper_package() -> None:
+    # Arrange
+    body = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    # Act
+    app_name = body["app_name"]
+    # Assert
+    assert app_name == "live_paper_app"
+
+
+def test_manifest_declares_scitex_live_paper_python_dep() -> None:
+    # Arrange
+    body = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    # Act
+    python_deps = body["dependencies"]["python"]
+    declares = any(dep.startswith("scitex-live-paper") for dep in python_deps)
+    # Assert
+    assert declares is True
+
+
+def test_manifest_default_enabled_is_false_until_alpha_stabilises() -> None:
+    # Arrange
+    body = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    # Act
+    default_enabled = body["default_enabled"]
+    # Assert
+    assert default_enabled is False
+
+
+def test_wrapper_apps_module_imports() -> None:
+    # Arrange
+    expected_label = "live_paper_app"
+    # Act
+    from apps.workspace.live_paper_app import apps as wrapper_apps
+
+    actual_label = wrapper_apps.LivePaperAppConfig.label
+    # Assert
+    assert actual_label == expected_label
+
+
+@pytest.mark.skipif(
+    not _UPSTREAM_AVAILABLE,
+    reason=(
+        "scitex-live-paper is not installed in this environment; "
+        "wrapper urls.py eagerly include()s its URL conf and would "
+        "ImportError. Skip — covered by upstream's own _django URL tests."
+    ),
+)
+def test_wrapper_urls_module_imports() -> None:
+    # Arrange
+    min_patterns = 1
+    # Act
+    from apps.workspace.live_paper_app import urls as wrapper_urls
+
+    actual = len(wrapper_urls.urlpatterns)
+    # Assert
+    assert actual >= min_patterns


### PR DESCRIPTION
## Summary
Adds the `apps/workspace/live_paper_app/` thin wrapper that mounts the standalone `scitex-live-paper` package's `_django` app at `/apps/live-paper/`. Mirrors the `agentic_journal_app` pattern (PR #257 + #264).

## How it works
- Wrapper `urls.py` does `include("scitex_live_paper._django.urls")`. Upstream URL conf declares `app_name = "live_paper"` so reverses (`reverse("live_paper:viewer_page")`) work without an explicit `namespace=` argument.
- AppConfig `ready()` is **boot-permissive, runtime-strict**: warns if `scitex-live-paper` isn't installed; the first request matching `/apps/live-paper/` then surfaces a typed `ImportError` 500.
- Wrapper runs against the **single-tenant env-pinned path** (`SCITEX_LIVE_PAPER_BUNDLE`). A follow-up will flip to `scitex_live_paper.mount(resolver=...)` once that helper lands in scitex-live-paper PR #2; I'll co-design the resolver signature with proj-scitex-live-paper.

## Files
- `apps/workspace/live_paper_app/__init__.py` — `default_app_config` hook
- `apps/workspace/live_paper_app/apps.py` — `LivePaperAppConfig`, same warning-vs-raising pattern as `agentic_journal_app`
- `apps/workspace/live_paper_app/urls.py` — `include(scitex_live_paper._django.urls)`
- `apps/workspace/live_paper_app/manifest.json` — hub app-store record (`scitex-app-manifest` v2.0.0), `default_enabled=false`, declares `scitex-live-paper>=0.1.0a0` as optional python dep
- `apps/workspace/live_paper_app/README.md` — thin-wrapper contract + iframe embed-mode docs (`?embed=1` + `data-embed-mode="1"` per scitex-live-paper PR #24, merged)
- `tests/apps/live_paper_app/test_thin_wrapper.py` — 6 no-mock unit tests mirroring `agentic_journal_app`; the urls-module-import test is `skipif`'d when `scitex-live-paper` is missing
- `config/urls.py` — `path("apps/live-paper/", include("apps.workspace.live_paper_app.urls"))`

## Coordination
- Live-paper public types (`BundleContext` / `BundleSource` / `PaperState` / `RendererOptions`) are stable on their develop (PR #23 merged).
- Embed-mode contract (`?embed=1` + `data-embed-mode="1"`) is stable (PR #24 merged) and documented in the wrapper README.
- `mount(resolver=...)` is intentionally NOT used yet — pending PR #2 from scitex-live-paper.

## Scope
Parallel sibling to PR #264 (`agentic_journal_app` URL include + runbook section). Different files → no conflict; lead approved opening in parallel.

## Test plan
- [ ] CI green; pytest matrix runs the new test file with skipif on missing upstream.
- [ ] Manual: `GET /apps/live-paper/` returns the upstream viewer's M1 placeholder once `scitex-live-paper` is bind-mounted into the staging image (operator-gated; documented in the e6 runbook).

Closes board card: `hub-plugin-apps-live-paper-and-agentic-journal` (remaining half — agentic-journal half = PR #264).