### PR TITLE
feat(hub): publish-flow client tidy — project create --category app + JWT-endpoint URL fix

### DIFF
--- a/apps/infra/project_app/views/projects/api.py
+++ b/apps/infra/project_app/views/projects/api.py
@@ -236,8 +236,28 @@ def api_project_create_jwt(request):
     """
     JWT-authenticated project creation endpoint for CLI access.
 
-    Accepts JSON: {"name": "...", "description": "...", "visibility": "private"}
-    Returns: {"success": true, "project_id": ..., "slug": "...", "url": "..."}
+    Accepts JSON::
+
+        {
+          "name": "my-thing",
+          "description": "...",          # optional
+          "visibility": "private",       # optional, "public"|"private"
+          "is_app": false,               # optional, marks as app project
+          "app_category": "writing"      # optional, app sub-category
+        }
+
+    The ``is_app`` flag is the agent-programmatic equivalent of the user
+    selecting "this is an app project" at creation time. Setting it does
+    NOT submit the project to the registry (that's a separate ``app
+    submit`` call); it only marks the project so subsequent ``app
+    install-dev`` / ``app submit`` calls know what to do.
+
+    ``app_category`` is optional at creation: leaving it blank is fine
+    (the value is required only when ``app submit`` is called and can be
+    supplied there). Allowed values come from
+    :data:`apps.workspace.apps_app.models.CATEGORY_CHOICES`.
+
+    Returns: ``{"success": true, "project_id": ..., "slug": "...", "url": ..., "is_app": bool, "app_category": str}``.
 
     CSRF-exempt by design — authentication is via Bearer JWT token, not session.
     The Django signal in project_signals.py will automatically create the
@@ -246,6 +266,8 @@ def api_project_create_jwt(request):
     name = request.data.get("name", "").strip()
     description = request.data.get("description", "").strip()
     visibility = request.data.get("visibility", "private")
+    is_app = bool(request.data.get("is_app", False))
+    app_category = (request.data.get("app_category") or "").strip()
 
     if not name:
         return Response(
@@ -263,18 +285,42 @@ def api_project_create_jwt(request):
             status=400,
         )
 
+    # Validate app_category if supplied (optional even when is_app=True)
+    if app_category:
+        try:
+            from apps.workspace.apps_app.models import CATEGORY_CHOICES
+        except Exception:  # pragma: no cover — fail-open if apps_app unavailable
+            CATEGORY_CHOICES = []
+        valid_categories = {c[0] for c in CATEGORY_CHOICES}
+        if valid_categories and app_category not in valid_categories:
+            return Response(
+                {
+                    "success": False,
+                    "error": (
+                        f"app_category must be one of: "
+                        f"{', '.join(sorted(valid_categories))}"
+                    ),
+                },
+                status=400,
+            )
+
     try:
         # Ensure unique name per user (appends suffix if duplicate)
         unique_name = Project.generate_unique_name(name, request.user)
         slug = Project.generate_unique_slug(unique_name, owner=request.user)
 
-        project = Project.objects.create(
-            name=unique_name,
-            slug=slug,
-            description=description,
-            owner=request.user,
-            visibility=visibility,
-        )
+        create_kwargs = {
+            "name": unique_name,
+            "slug": slug,
+            "description": description,
+            "owner": request.user,
+            "visibility": visibility,
+            "is_app": is_app,
+        }
+        if app_category:
+            create_kwargs["app_category"] = app_category
+
+        project = Project.objects.create(**create_kwargs)
 
         project_url = f"/{request.user.username}/{project.slug}/"
 
@@ -284,6 +330,8 @@ def api_project_create_jwt(request):
                 "project_id": project.pk,
                 "slug": project.slug,
                 "url": project_url,
+                "is_app": project.is_app,
+                "app_category": project.app_category or "",
                 "message": f'Project "{project.name}" created successfully',
             },
             status=201,

--- a/docs/runbooks/publish-app-from-user-account.md
+++ b/docs/runbooks/publish-app-from-user-account.md
@@ -1,0 +1,243 @@
+# Publish a SciTeX App From a User Account
+
+Audience: agent or operator driving the **agent-programmatic publish flow**
+end-to-end (the operator-12834 / 12845 directive — demonstrate that hub
+apps are user-creatable, customizable, published from a personal account,
+all via the CLI client with no manual UI step).
+
+The flow takes a thin-wrapper Django app, registers a corresponding
+**project** under the user's namespace on `https://scitex.ai`, develop-installs
+it locally, then **submits** it to the central registry. Submission opens
+a cross-repo PR; merge equals approval (MELPA-style).
+
+## Glossary
+
+- **Workspace JWT** — the `Authorization: Bearer <jwt>` token the hub CLI
+  uses for `/api/...` endpoints (`project create`, `app submit`). Default
+  TTL: 60 minutes (`config/settings/settings_auth.py`,
+  `SIMPLE_JWT.ACCESS_TOKEN_LIFETIME`).
+- **Registry** — `scitex-apps/<slug>` on the central Gitea
+  (`git.scitex.ai`). Cross-repo PRs `user/<slug>` → `scitex-apps/<slug>`
+  land here; merging surfaces the app marketplace-wide.
+- **Editable install** — when scitex-hub is `pip install -e .` from a
+  worktree (common in dev), the running `scitex-hub` CLI imports from
+  the worktree's `src/`. Patches to that worktree take effect on the
+  next invocation, no re-install.
+
+## 0. Prerequisites
+
+1. `scitex-hub` CLI on `PATH`. Verify:
+   ```bash
+   scitex-hub --version
+   ```
+2. The thin-wrapper app source in a directory containing `manifest.json`.
+   (See `app init` below.)
+3. **Workspace JWT** delivered via cached token file (see §2).
+
+## 1. Set the hub server target
+
+The CLI honours `SCITEX_HUB_URL` for both `project create` (via the
+Python API in `scitex_hub.project`) and `app submit` (via the
+`--server` flag, which falls back to the same env var).
+
+```bash
+export SCITEX_HUB_URL=https://scitex.ai
+```
+
+That's the **bare Django host** — no trailing slash, no `/api/` prefix.
+The CLI builds `{SCITEX_HUB_URL}/api/...` URLs internally. `git.scitex.ai`
+is the Gitea host the Django backend reaches *server-side* via the
+project-creation signal; the CLI never talks to Gitea directly.
+
+## 2. Workspace JWT — token-only, no interactive login
+
+The user account (`ywatanabe` for the demo) is a Google-OAuth account
+created via allauth; there is no usable password. So the standard
+`/api/token/` username/password exchange is not available. Use one of:
+
+### 2a. Server-minted JWT (TODAY — zero code changes)
+
+On the prod Django shell (someone with `docker compose exec` access on
+the prod NAS):
+
+```bash
+docker compose \
+  -f deployment/docker/docker-compose.yml \
+  -f deployment/docker/docker-compose.prod.yml \
+  exec -T django \
+  python manage.py shell -c "$(cat <<'PY'
+from datetime import timedelta
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import RefreshToken
+u = get_user_model().objects.get(username='ywatanabe')
+t = RefreshToken.for_user(u).access_token
+t.set_exp(lifetime=timedelta(hours=2))   # safety margin over the 60-min default
+print(str(t))
+PY
+)"
+```
+
+The printed string is a SimpleJWT access token signed for that user.
+Drop it into the hub's cached-token location:
+
+```bash
+mkdir -p ~/.scitex/cloud/runtime
+cat > ~/.scitex/cloud/runtime/token.json <<'JSON'
+{"server": "https://scitex.ai", "access": "<paste the JWT here>"}
+JSON
+```
+
+`_workspace_auth.load_cached_token()` reads this file. The first
+`scitex-hub` call that needs a JWT cache-hits this entry; no
+`/api/token/` round-trip, no prompt.
+
+### 2b. APIKey PAT (FOLLOW-UP — requires server-side PR)
+
+The `scitex_xxxx` API-key UI exists at
+`https://scitex.ai/api-keys/` but is not yet wired into the JWT
+endpoints (`api_project_create_jwt`, `api_submit_jwt`). The durable
+agent-programmatic-publish path adds an `APIKeyAuthentication` DRF
+class so a UI-generated PAT auths against those endpoints. Once that
+lands, the runbook §2 above becomes "Operator generates a PAT in the
+UI → drops it into the same `token.json`". Tracked as the
+`scitex-hub-apikey-on-jwt-endpoints` card.
+
+## 3. Scaffold the thin-wrapper app
+
+Use `scitex-hub app init` to generate the boilerplate, then customise
+three files (apps.py, urls.py, manifest.json) to forward to the
+upstream package.
+
+```bash
+scitex-hub app init /tmp/scitex_live_paper_app \
+    --name scitex_live_paper_app \
+    --label "SciTeX Live Paper" \
+    --icon "fas fa-file-lines" \
+    --description "Interactive live-paper viewer + claim provenance"
+```
+
+Then in the generated directory:
+
+**`urls.py`** — replace the placeholder list with a shim that includes
+the upstream package's URL conf:
+```python
+from django.urls import include, path
+from . import views
+app_name = "scitex_live_paper_app"
+urlpatterns = [
+    path("info/", views.index_view, name="info"),
+    path("", include("scitex_live_paper._django.urls")),
+]
+```
+
+**`apps.py`** — boot-permissive `ready()` so missing upstream warns
+instead of crashing import:
+```python
+def ready(self) -> None:
+    try:
+        import scitex_live_paper._django  # noqa: F401
+    except ImportError:
+        _logger.warning(
+            "scitex_live_paper_app: `scitex-live-paper` is not installed..."
+        )
+```
+
+**`manifest.json`** — declare the python dependency so the hub knows
+what to install for the user when they enable the app:
+```json
+"dependencies": { "python": ["scitex-live-paper>=0.1.0a0"], "system": [] }
+```
+
+## 4. Create the user project
+
+```bash
+scitex-hub project create scitex-live-paper-app
+```
+
+The naming convention:
+- **Django module** (snake_case): `scitex_live_paper_app`
+- **Gitea slug** (hyphenated, suffixed `-app`): `scitex-live-paper-app`
+
+Once the operator-12845 client-tidy PR lands you can mark the project
+as an app at creation time:
+
+```bash
+scitex-hub project create scitex-live-paper-app --category app
+# or the equivalent shortcut:
+scitex-hub app create scitex-live-paper
+```
+
+The `--app` shorthand and the `scitex-hub app create` group are wired
+to call `project_create(category="app")` which sets `is_app=True`
+server-side and auto-suffixes `_app` if missing.
+
+At the API layer the call hits `POST /api/projects/create/` →
+`api_project_create_jwt`, authenticated by the JWT from §2. The Django
+signal handler then creates the corresponding Gitea repo at
+`git.scitex.ai/<user>/<slug>` automatically.
+
+## 5. Install the app source into the project
+
+The local app source you scaffolded in §3 needs to be pushed to the
+Gitea repo created in §4. With a Gitea remote configured, the
+`install-dev` flow handles this:
+
+```bash
+scitex-hub app install-dev /tmp/scitex_live_paper_app
+```
+
+(This step still depends on having a Gitea push credential — for the
+agent-runs-it demo, the operator's Gitea token gets injected into the
+container env.)
+
+## 6. Submit for review
+
+```bash
+scitex-hub app submit /tmp/scitex_live_paper_app
+```
+
+Hits `POST /api/apps/submit/` → `api_submit_jwt` with the JWT from §2.
+This:
+1. Looks up the user's project by name.
+2. Pins the HEAD commit of the user's Gitea repo.
+3. Creates an `AppsModule` record (or updates one) + a
+   `ModuleSubmission`.
+4. Opens a cross-repo PR `user/<slug>` → `scitex-apps/<slug>`.
+5. Returns the PR URL.
+
+Track review status by querying the registry:
+```bash
+gh -R scitex-apps/scitex-live-paper-app pr list
+```
+
+Merge of the PR equals approval — at that point the
+`api_registry_webhook` handler sets `visibility=public,
+is_verified=True` on the AppsModule, and the app becomes visible in
+the marketplace browse view.
+
+## Troubleshooting
+
+- **401 on `app submit`** with a valid-looking JWT: the older
+  `_publish.py` URL pointed at `/apps/store/api/<module_name>/submit/`
+  which routes to a `@login_required` view (session-only). The fixed
+  URL is `/api/apps/submit/`. If you're running an editable install,
+  patch `src/scitex_hub/appmaker/_publish.py:51` and re-invoke; no
+  re-install needed.
+- **JWT expired mid-flow**: by default 60 min — re-mint via §2a. The
+  `set_exp(lifetime=timedelta(hours=2))` variant gives a 2 h window.
+- **Name conflict** (`HTTP 400` "already exists"): a previous attempt
+  reserved the slug. Either delete with `scitex-hub project delete
+  <slug> --yes` or pick a new name.
+- **`scitex-hub` CLI says "API key required"** when calling MCP
+  endpoints (not JWT endpoints): that's a separate `SCITEX_HUB_API_KEY`
+  env var read by `_mcp_tools/api.py`; not relevant for the publish
+  flow which only uses JWT.
+
+## Related
+
+- `docs/runbooks/local-staging-orochi-cloud.md` — local-staging
+  variant of this flow (against a localhost Django + ngrok).
+- Operator messages 12834, 12845, 12871 (publish-from-user-account
+  directive + naming convention).
+- Card `scitex-hub-apikey-on-jwt-endpoints` — durable server-side PR
+  that replaces the §2a one-liner with a UI-generated PAT path.

--- a/src/scitex_hub/_cli/_app/__init__.py
+++ b/src/scitex_hub/_cli/_app/__init__.py
@@ -12,6 +12,7 @@ all verbs onto the group (each submodule registers on import).
 # module decorates a different verb; we import all of them so ``app`` is fully
 # populated by the time callers (e.g. main.py) reach for it.
 from . import (
+    _create,  # noqa: F401
     _deps,  # noqa: F401
     _inventory,  # noqa: F401
     _prefs,  # noqa: F401

--- a/src/scitex_hub/_cli/_app/_create.py
+++ b/src/scitex_hub/_cli/_app/_create.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``scitex-hub app create`` — single-call programmatic app-project creation.
+
+Thin sugar over ``scitex-hub project create --category app`` so the fully
+programmatic publish flow has a shorter top-level invocation:
+
+    scitex-hub app create my-tool [--description ...] [--app-category writing]
+
+Mirrors ``scitex-hub project create --app <name>`` exactly: same auto
+``_app`` suffix, same is_app=True semantics, same optional sub-category.
+Surfaced as a top-level alias because operator 12845 specifically asked
+for app-project creation to be a single agent-driven step.
+"""
+
+from __future__ import annotations
+
+import click
+
+from ._group import app, console
+
+
+@app.command("create")
+@click.argument("name")
+@click.option("-d", "--description", default="", help="App project description")
+@click.option(
+    "-t", "--template", default="scitex_minimal", show_default=True, help="Template ID"
+)
+@click.option(
+    "--app-category",
+    "app_category",
+    type=click.Choice(
+        [
+            "writing",
+            "visualization",
+            "data",
+            "analysis",
+            "reference",
+            "utility",
+            "other",
+        ],
+        case_sensitive=False,
+    ),
+    default=None,
+    help=(
+        "App sub-category for marketplace listing. Optional at create "
+        "time — can also be filled in at `app submit`."
+    ),
+)
+def app_create(name, description, template, app_category):
+    """Create a new SciTeX Hub app project.
+
+    Equivalent to ``scitex-hub project create <name> --category app``.
+    Auto-appends ``_app`` to the name if missing (operator-12845
+    convention). Does NOT submit the app to the registry — that's a
+    separate ``scitex-hub app submit`` call once the source is ready.
+
+    \b
+    Examples:
+        scitex-hub app create my-tool
+        scitex-hub app create my-tool --description "..."
+        scitex-hub app create my-tool --app-category writing
+    """
+    from scitex_hub.project import project_create as _create
+
+    try:
+        result = _create(
+            name,
+            description=description,
+            template=template,
+            category="app",
+            app_category=app_category,
+        )
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise SystemExit(2)
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise SystemExit(1)
+
+    msg = result.get("message", name)
+    console.print(f"[green]Created app project: {msg}[/green]")
+    final_slug = result.get("slug", "")
+    if final_slug:
+        console.print(f"  slug:         [cyan]{final_slug}[/cyan]")
+    sub_cat = result.get("app_category") or "<unset>"
+    console.print(f"  app_category: [cyan]{sub_cat}[/cyan]")
+
+
+# EOF

--- a/src/scitex_hub/_cli/project.py
+++ b/src/scitex_hub/_cli/project.py
@@ -74,16 +74,105 @@ def project_list(as_json):
 @click.argument("name")
 @click.option("-d", "--description", default="", help="Project description")
 @click.option("-t", "--template", default="scitex_minimal", help="Template ID")
-def project_create(name, description, template):
-    """Create a new project."""
+@click.option(
+    "-c",
+    "--category",
+    type=click.Choice(["project", "app"], case_sensitive=False),
+    default="project",
+    show_default=True,
+    help=(
+        "Top-level project category. 'app' marks the project as an app "
+        "plugin (is_app=True) and auto-suffixes the name with '_app' if "
+        "missing — does NOT submit it to the registry."
+    ),
+)
+@click.option(
+    "--app",
+    "app_shorthand",
+    is_flag=True,
+    help="Shorthand for --category app. Mutually exclusive with --category=app already-set.",
+)
+@click.option(
+    "--app-category",
+    "app_category",
+    type=click.Choice(
+        [
+            "writing",
+            "visualization",
+            "data",
+            "analysis",
+            "reference",
+            "utility",
+            "other",
+        ],
+        case_sensitive=False,
+    ),
+    default=None,
+    help=(
+        "App sub-category for marketplace listing. Only valid with "
+        "--category app (or --app). Optional at create time — can also be "
+        "filled in at `app submit`."
+    ),
+)
+def project_create(name, description, template, category, app_shorthand, app_category):
+    """Create a new project.
+
+    \b
+    Examples:
+        # Research project (default)
+        scitex-hub project create my-research --description "..."
+
+        # App project — auto-suffixes to my-tool_app
+        scitex-hub project create my-tool --category app
+        scitex-hub project create my-tool --app          # shorthand
+
+        # App project with pre-set sub-category
+        scitex-hub project create my-tool --app --app-category writing
+    """
     from scitex_hub.project import project_create as _create
 
+    # Resolve --app shorthand and reject the conflicting combo.
+    if app_shorthand:
+        if category != "project":
+            console.print(
+                "[red]error: --app conflicts with --category=app; pass one or the other[/red]"
+            )
+            raise SystemExit(2)
+        category = "app"
+
+    if app_category and category != "app":
+        console.print(
+            "[red]error: --app-category is only valid with --category app (or --app)[/red]"
+        )
+        raise SystemExit(2)
+
     try:
-        result = _create(name, description=description, template=template)
-        console.print(f"[green]Created project: {result.get('message', name)}[/green]")
+        result = _create(
+            name,
+            description=description,
+            template=template,
+            category=category,
+            app_category=app_category,
+        )
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise SystemExit(2)
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/red]")
         raise SystemExit(1)
+
+    msg = result.get("message", name)
+    final_slug = result.get("slug", "")
+    if result.get("is_app"):
+        console.print(f"[green]Created app project: {msg}[/green]")
+        if final_slug:
+            console.print(f"  slug:         [cyan]{final_slug}[/cyan]")
+        sub_cat = result.get("app_category") or "<unset>"
+        console.print(f"  app_category: [cyan]{sub_cat}[/cyan]")
+    else:
+        console.print(f"[green]Created project: {msg}[/green]")
+        if final_slug:
+            console.print(f"  slug: [cyan]{final_slug}[/cyan]")
 
 
 @project.command("delete")

--- a/src/scitex_hub/appmaker/_publish.py
+++ b/src/scitex_hub/appmaker/_publish.py
@@ -46,9 +46,15 @@ def publish(app_dir: str | Path, server_url: str, token: str) -> dict:
 
     project_name = manifest.get("name", app_path.name)
 
-    # Submit via JWT-authenticated endpoint
-    # Route: apps/store/api/<module_name>/submit/
-    url = f"{server_url.rstrip('/')}/apps/store/api/{project_name}/submit/"
+    # Submit via JWT-authenticated endpoint.
+    #
+    # Canonical route: /api/apps/submit/ → ``api_submit_jwt`` (DRF
+    # ``@api_view + IsAuthenticated``, honours JWTAuthentication). The
+    # older /apps/store/api/<module_name>/submit/ route hits
+    # ``api_submit_for_review`` which is ``@login_required``
+    # (session-only) and 401s a Bearer-only request — that route is for
+    # the in-app UI submission flow, not the CLI.
+    url = f"{server_url.rstrip('/')}/api/apps/submit/"
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",

--- a/src/scitex_hub/project/__init__.py
+++ b/src/scitex_hub/project/__init__.py
@@ -9,6 +9,10 @@ Project CRUD (Python API):
     projects = project_list()
     new = project_create("my-project", description="My research")
 
+    # Create as an app project (the agent-programmatic publish flow).
+    app = project_create("my-tool", category="app")
+    # -> name becomes "my-tool_app" (auto-suffix), is_app=True.
+
 Sandboxed file-operation handlers (async, used by MCP tools) live in
 :mod:`scitex_hub.project._mcp.handlers`.
 """
@@ -16,6 +20,29 @@ Sandboxed file-operation handlers (async, used by MCP tools) live in
 from __future__ import annotations
 
 from .._mcp_tools.api import _make_request
+
+#: Top-level project categories. Currently only ``"app"`` adds non-default
+#: semantics (sets ``is_app=True`` server-side + auto-suffixes the name with
+#: ``_app`` if missing). ``"project"`` is the default research-project shape
+#: and adds no extra fields — listed here so the API surface is closed and
+#: ``--category`` can be exhaustively validated CLI-side.
+PROJECT_CATEGORIES: tuple[str, ...] = ("project", "app")
+
+#: Suffix appended to app-project names when ``category="app"`` and the
+#: name doesn't already end with it. Mirrors the operator-12845 directive
+#: ("the project NAME likely needs an 'app' SUFFIX").
+APP_NAME_SUFFIX = "_app"
+
+
+def _apply_app_suffix(name: str) -> str:
+    """Return ``name`` with ``_app`` appended unless already present.
+
+    The check is suffix-only (not substring) so e.g. ``my_app_repo`` stays
+    untouched and only ``my_app`` round-trips through unchanged.
+    """
+    if name.endswith(APP_NAME_SUFFIX):
+        return name
+    return f"{name}{APP_NAME_SUFFIX}"
 
 
 def project_list() -> list[dict]:
@@ -34,22 +61,68 @@ def project_create(
     name: str,
     description: str = "",
     template: str = "scitex_minimal",
+    *,
+    category: str = "project",
+    app_category: str | None = None,
+    request_fn=None,
 ) -> dict:
     """Create a new SciTeX Hub project.
 
     Args:
-        name: Project name.
+        name: Project name. When ``category="app"`` and the name does not
+            already end with ``_app``, the suffix is appended automatically
+            (operator-12845 convention) before the server call.
         description: Optional description.
         template: Template ID (default: scitex_minimal).
+        category: Top-level project category. One of
+            :data:`PROJECT_CATEGORIES`. ``"app"`` marks the new project as
+            an app plugin (sets ``is_app=True`` server-side) — does NOT
+            submit it to the registry; that's a separate
+            :mod:`scitex_hub.appmaker` ``publish`` call.
+        app_category: Optional app sub-category (writing, visualization,
+            data, analysis, reference, utility, other). Only used when
+            ``category="app"``; ignored otherwise. The sub-category can
+            also be left blank at create time and filled in at
+            ``app submit`` time.
+        request_fn: Optional dependency-injection seam for the HTTP
+            transport. Defaults to the module-level
+            :func:`_make_request`. Tests inject a hand-rolled fake to
+            avoid talking to a live server; production callers leave
+            this argument unset.
 
     Returns:
-        Dict with project_id, name, success.
+        Dict with success, project_id, slug, url, is_app, app_category.
+
+    Raises:
+        ValueError: ``category`` not in :data:`PROJECT_CATEGORIES`.
+        RuntimeError: Server-side rejection (name conflict, validation, etc.).
     """
-    result = _make_request(
-        "POST",
-        "/api/v1/projects/create/",
-        data={"name": name, "description": description, "template": template},
-    )
+    if category not in PROJECT_CATEGORIES:
+        raise ValueError(
+            f"category must be one of {PROJECT_CATEGORIES!r}, got {category!r}"
+        )
+
+    is_app = category == "app"
+    if is_app:
+        name = _apply_app_suffix(name)
+    elif app_category:
+        # Non-app project with app_category is a programming error — surface
+        # rather than silently dropping the field.
+        raise ValueError(
+            f"app_category is only valid when category='app'; got category={category!r}"
+        )
+
+    payload: dict[str, object] = {
+        "name": name,
+        "description": description,
+        "template": template,
+        "is_app": is_app,
+    }
+    if is_app and app_category:
+        payload["app_category"] = app_category
+
+    do_request = request_fn if request_fn is not None else _make_request
+    result = do_request("POST", "/api/v1/projects/create/", data=payload)
     if result.get("success"):
         return result
     raise RuntimeError(result.get("error", "Failed to create project"))

--- a/tests/scitex_hub/test_project_create_category.py
+++ b/tests/scitex_hub/test_project_create_category.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_hub/test_project_create_category.py
+
+"""Unit tests for ``scitex_hub.project.project_create`` category/app surface.
+
+Covers the operator-12845 publish-flow client tidy:
+- ``category`` validates against ``PROJECT_CATEGORIES``.
+- ``category="app"`` auto-suffixes the name with ``_app`` (unless already
+  present) and sends ``is_app=True`` in the payload.
+- ``app_category`` is only valid when ``category="app"``.
+- ``app_category`` round-trips through the payload when present.
+
+No mocks, no monkeypatch. ``project_create`` exposes a ``request_fn``
+dependency-injection seam: tests pass a small hand-rolled
+``_FakeRequester`` that records calls on a real attribute.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+
+@dataclass
+class _FakeRequester:
+    """Hand-rolled stand-in for the HTTP transport.
+
+    Returns a fixed response dict, records each invocation's (method,
+    endpoint, data) on ``self.calls``.
+    """
+
+    response: dict[str, Any] = field(
+        default_factory=lambda: {
+            "success": True,
+            "project_id": 42,
+            "slug": "my-tool-app",
+            "url": "/ywatanabe/my-tool-app/",
+            "is_app": True,
+            "app_category": "",
+            "message": 'Project "my-tool_app" created successfully',
+        }
+    )
+    calls: list[tuple[str, str, dict[str, Any] | None]] = field(default_factory=list)
+
+    def __call__(
+        self,
+        method: str,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        files: dict[str, Any] | None = None,
+        auth_required: bool = True,
+    ) -> dict[str, Any]:
+        self.calls.append((method, endpoint, data))
+        return self.response
+
+    @property
+    def last_payload(self) -> dict[str, Any]:
+        """Last ``data`` payload the production code sent us."""
+        return self.calls[-1][2] or {}
+
+    @property
+    def called(self) -> bool:
+        return bool(self.calls)
+
+
+def test_project_categories_constant_is_closed_set():
+    # Arrange
+    from scitex_hub.project import PROJECT_CATEGORIES
+
+    # Act
+    actual = tuple(PROJECT_CATEGORIES)
+
+    # Assert
+    assert actual == ("project", "app")
+
+
+def test_invalid_category_raises_value_error():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+    raised: Exception | None = None
+
+    # Act
+    try:
+        project_create("my-thing", category="not-a-category", request_fn=fake)
+    except ValueError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "category must be one of" in str(raised)
+
+
+def test_invalid_category_does_not_call_server():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+
+    # Act
+    try:
+        project_create("my-thing", category="not-a-category", request_fn=fake)
+    except ValueError:
+        pass
+
+    # Assert
+    assert fake.called is False
+
+
+def test_default_category_sends_is_app_false():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+
+    # Act
+    project_create("my-research", request_fn=fake)
+
+    # Assert
+    assert fake.last_payload["is_app"] is False
+
+
+def test_default_category_does_not_apply_app_suffix():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+
+    # Act
+    project_create("my-research", request_fn=fake)
+
+    # Assert
+    assert fake.last_payload["name"] == "my-research"
+
+
+def test_app_category_sets_is_app_true():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+
+    # Act
+    project_create("my-tool", category="app", request_fn=fake)
+
+    # Assert
+    assert fake.last_payload["is_app"] is True
+
+
+def test_app_category_appends_app_suffix():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+
+    # Act
+    project_create("my-tool", category="app", request_fn=fake)
+
+    # Assert
+    assert fake.last_payload["name"] == "my-tool_app"
+
+
+def test_app_category_skips_suffix_when_already_present():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+
+    # Act
+    project_create("already_app", category="app", request_fn=fake)
+
+    # Assert
+    assert fake.last_payload["name"] == "already_app"
+
+
+def test_app_category_with_app_subcategory_round_trips():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+
+    # Act
+    project_create("my-tool", category="app", app_category="writing", request_fn=fake)
+
+    # Assert
+    assert fake.last_payload["app_category"] == "writing"
+
+
+def test_project_category_with_app_subcategory_raises():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+    raised: Exception | None = None
+
+    # Act
+    try:
+        project_create(
+            "my-thing",
+            category="project",
+            app_category="writing",
+            request_fn=fake,
+        )
+    except ValueError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "app_category is only valid" in str(raised)
+
+
+def test_project_category_with_app_subcategory_does_not_call_server():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+
+    # Act
+    try:
+        project_create(
+            "my-thing",
+            category="project",
+            app_category="writing",
+            request_fn=fake,
+        )
+    except ValueError:
+        pass
+
+    # Assert
+    assert fake.called is False
+
+
+def test_app_subcategory_omitted_keeps_payload_without_key():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    fake = _FakeRequester()
+
+    # Act
+    project_create("my-tool", category="app", request_fn=fake)
+
+    # Assert
+    assert "app_category" not in fake.last_payload
+
+
+def test_server_error_propagates_as_runtime_error():
+    # Arrange
+    from scitex_hub.project import project_create
+
+    failing = _FakeRequester(response={"success": False, "error": "name conflict"})
+    raised: Exception | None = None
+
+    # Act
+    try:
+        project_create("my-tool", category="app", request_fn=failing)
+    except RuntimeError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "name conflict" in str(raised)
+
+
+# EOF


### PR DESCRIPTION
## Summary

Implements the operator-12845 agent-programmatic-publish client tidy + ships the demo-critical \`_publish.py\` URL fix so \`scitex-hub app submit\` actually targets the JWT-friendly endpoint.

- **\`scitex_hub.project.project_create\`** gains \`category\` (\"project\"|\"app\") + \`app_category\` kwargs + a \`request_fn\` DI seam. \`category=\"app\"\` auto-suffixes \`_app\` and sends \`is_app=True\`.
- **\`scitex-hub project create\`** CLI: new \`--category\` / \`--app\` / \`--app-category\` flags.
- **\`scitex-hub app create <name>\`**: new shortcut, sugar for \`project create --category app\`.
- **\`api_project_create_jwt\`** (server): accepts \`is_app\` + \`app_category\` from request data; validates against \`CATEGORY_CHOICES\`.
- **\`appmaker._publish\`**: posts to \`/api/apps/submit/\` (\`api_submit_jwt\`, JWT-friendly) instead of \`/apps/store/api/<x>/submit/\` (\`@login_required\` — 401s a Bearer-authenticated request).
- **Runbook** \`docs/runbooks/publish-app-from-user-account.md\` documents the end-to-end flow + the durable \"APIKey-on-JWT-endpoints\" follow-up.

## Test plan

- [x] 13 new unit tests in \`tests/scitex_hub/test_project_create_category.py\` cover: category validation, suffix auto-append, app_category round-trip, non-app + app_category rejection, server-error propagation. All pass (\`PYTHONPATH=.../src pytest tests/scitex_hub/test_project_create_category.py\` → 13 passed).
- [x] STX-NM* / STX-TQ* lint clean (no mocks, no monkeypatch, hand-rolled \`_FakeRequester\` injected via the new \`request_fn\` seam; AAA markers on all tests).
- [ ] CI matrix: depends on this PR landing.