### PR TITLE
feat(accounts_app): JWTBearerToSessionMiddleware — accept Bearer JWT on plain Django views

### DIFF
--- a/apps/infra/accounts_app/middleware.py
+++ b/apps/infra/accounts_app/middleware.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Middleware for resolving non-session authentication into ``request.user``.
+
+This module hosts the JWT-bearer → request.user shim that lets plain Django
+views (``@require_http_methods`` etc.) accept SimpleJWT access tokens
+without each view having to convert to DRF (``@api_view +
+IsAuthenticated``). The motivating use case is the agent-programmatic
+publish flow (operator-12880): every project-scoped operation lives behind
+endpoints in ``apps/infra/project_app/views/repository/api/`` that check
+``request.user.is_authenticated`` — and ``request.user`` is normally
+populated by Django's ``AuthenticationMiddleware`` from a session cookie.
+A CLI client holding only a Bearer JWT would be silently anonymous on
+those endpoints. This middleware closes that gap.
+
+Trust model: the same one already used by the workspace console's
+``terminal_broker/shell.py:_make_short_lived_jwt`` —
+``RefreshToken.for_user(user).access_token`` mints a JWT that
+authenticates AS the user. SimpleJWT's ``JWTAuthentication`` validates
+that token's signature, expiry, and user_id claim against the database;
+nothing here weakens those checks.
+
+Pattern follows ``apps.infra.project_app.middleware.OnSiteAuthMiddleware``:
+hybrid sync/async, mutates ``request.user`` only when the existing
+authentication slot is empty, sets ``request._dont_enforce_csrf_checks``
+when (and only when) the JWT successfully resolves — Bearer authentication
+is the trust signal, mirroring the existing OnSite carve-out.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction, sync_to_async
+
+logger = logging.getLogger(__name__)
+
+
+class JWTBearerToSessionMiddleware:
+    """Resolve ``Authorization: Bearer <jwt>`` → ``request.user``.
+
+    Runs only when the upstream ``AuthenticationMiddleware`` left
+    ``request.user`` anonymous AND the request carries a ``Bearer`` header.
+    Browser flows (cookie sessions) are unaffected — the middleware
+    short-circuits on the ``is_authenticated`` check before touching the
+    Authorization header.
+
+    Fail-closed semantics: a malformed / expired / forged token leaves the
+    request anonymous (downstream permission checks then return 401/403).
+    Only narrow SimpleJWT / DRF auth exceptions are swallowed; any other
+    exception propagates per the project's crash-loud doctrine.
+    """
+
+    sync_capable = True
+    async_capable = True
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        if iscoroutinefunction(get_response):
+            markcoroutinefunction(self)
+
+    def __call__(self, request):
+        if iscoroutinefunction(self.get_response):
+            return self._acall(request)
+        self._sync_body(request)
+        return self.get_response(request)
+
+    async def _acall(self, request):
+        await sync_to_async(self._sync_body, thread_sensitive=True)(request)
+        return await self.get_response(request)
+
+    def _sync_body(self, request):
+        # Browser session already authenticated this request — leave it
+        # entirely alone (do not even inspect the Bearer header).
+        if request.user.is_authenticated:
+            return
+
+        auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+        if not auth_header.startswith("Bearer "):
+            return
+
+        # Local imports keep this middleware importable even in test setups
+        # that don't have DRF wired (e.g. minimal `manage.py check`).
+        from rest_framework.exceptions import AuthenticationFailed
+        from rest_framework_simplejwt.authentication import JWTAuthentication
+        from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+
+        try:
+            result = JWTAuthentication().authenticate(request)
+        except (InvalidToken, TokenError, AuthenticationFailed) as exc:
+            # Fail closed — leave the request anonymous so the view's own
+            # permission check returns the correct 401/403. Log at INFO
+            # because a bad token is a normal client error, not a server
+            # bug.
+            logger.info("JWTBearerToSessionMiddleware: rejected token (%s)", exc)
+            return
+        # Any other exception (e.g. DB connection error, mis-configured
+        # SECRET_KEY) is a real bug and MUST propagate so the surrounding
+        # request-level error handlers / crash-loud doctrine see it.
+        # Intentionally not caught here.
+
+        if result is None:
+            # No token usable for auth (e.g. header wasn't actually a JWT —
+            # could be a stale scitex_xxxx API key for the MCP path).
+            return
+
+        user, validated_token = result
+        request.user = user
+        request._jwt_auth = validated_token
+        # Bearer auth is the trust signal — mirrors OnSiteAuthMiddleware's
+        # CSRF carve-out. The token's signature already proves the
+        # request's intent.
+        request._dont_enforce_csrf_checks = True
+
+
+# EOF

--- a/config/settings/settings_shared.py
+++ b/config/settings/settings_shared.py
@@ -176,6 +176,12 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # Resolve Authorization: Bearer <jwt> → request.user for plain Django
+    # views. Browser cookie-sessions short-circuit before this runs
+    # (request.user already authenticated), so the middleware is a pure
+    # addition that opens the JWT door to existing endpoints without
+    # touching any view. See apps/infra/accounts_app/middleware.py.
+    "apps.infra.accounts_app.middleware.JWTBearerToSessionMiddleware",
     "apps.infra.project_app.middleware.OnSiteAuthMiddleware",
     "allauth.account.middleware.AccountMiddleware",
     "apps.infra.project_app.middleware.VisitorAutoLoginMiddleware",

--- a/tests/apps/accounts_app/test_jwt_bearer_middleware.py
+++ b/tests/apps/accounts_app/test_jwt_bearer_middleware.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""End-to-end tests for ``JWTBearerToSessionMiddleware``.
+
+The middleware lets plain Django views (``@require_http_methods``) accept a
+SimpleJWT access token in the ``Authorization: Bearer …`` header without
+the views themselves switching to DRF (``@api_view + IsAuthenticated``).
+This file exercises that contract through the **real** middleware stack
+and a **real** project-scoped endpoint
+(``apps.infra.project_app.views.repository.api.git_status.api_git_status``)
+— no mocks, no monkeypatch, no patched internals.
+
+Two contracts, both required by the publish-flow design intent
+(operator-12880 "ユーザは gitea を意識しないつくり") + the
+review-hardening directive (catch only specific JWT errors, fail closed
+on anything malformed):
+
+1. POSITIVE — A valid JWT minted via
+   ``RefreshToken.for_user(user).access_token`` reaches the project-scoped
+   view AS that user; the owner-based read-access check passes and the
+   view returns a non-"Permission denied" response.
+
+2. NEGATIVE — A garbage / forged Bearer leaves the request anonymous,
+   so the same view returns a "Permission denied" JSON body — proof
+   that the middleware cannot be tricked into authenticating an
+   attacker.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.infra.project_app.models import Project
+
+
+def _mint_access_token(user: User) -> str:
+    """Real JWT issuance — the same call path the workspace console uses
+    (``terminal_broker/shell.py:_make_short_lived_jwt``).
+    """
+    return str(RefreshToken.for_user(user).access_token)
+
+
+@pytest.mark.django_db
+def test_valid_bearer_jwt_authenticates_request_as_owner():
+    """POSITIVE — valid JWT resolves to the owner; read-access granted."""
+    # Arrange
+    owner = User.objects.create_user(
+        username="jwt-positive", email="jwt-positive@example.com", password="x"
+    )
+    project = Project.objects.create(
+        name="jwt-positive-proj",
+        slug="jwt-positive-proj",
+        description="middleware positive-path probe",
+        owner=owner,
+        visibility="private",
+    )
+    token = _mint_access_token(owner)
+    client = Client()
+
+    # Act
+    response = client.get(
+        f"/{owner.username}/{project.slug}/api/git/status/",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    # Assert — the owner-as-resolved-by-middleware passes the read-access
+    # check; the view either succeeds or fails for an unrelated reason
+    # (e.g. project dir not on disk in the test setup), but it MUST NOT
+    # come back with the "Permission denied" payload that signals the
+    # middleware never resolved the user.
+    assert b"Permission denied" not in response.content
+
+
+@pytest.mark.django_db
+def test_garbage_bearer_leaves_request_anonymous_and_denies():
+    """NEGATIVE — forged Bearer must NOT trick the middleware. Owner-scoped
+    private project is denied because ``request.user`` stays anonymous."""
+    # Arrange
+    owner = User.objects.create_user(
+        username="jwt-negative", email="jwt-negative@example.com", password="x"
+    )
+    project = Project.objects.create(
+        name="jwt-negative-proj",
+        slug="jwt-negative-proj",
+        description="middleware negative-path probe",
+        owner=owner,
+        visibility="private",
+    )
+    client = Client()
+
+    # Act
+    response = client.get(
+        f"/{owner.username}/{project.slug}/api/git/status/",
+        HTTP_AUTHORIZATION="Bearer this.is.not-a-real-jwt",
+    )
+
+    # Assert — fail-closed: the malformed token produced an anonymous
+    # request, the private owner-only project denied access, and the JSON
+    # body says so verbatim.
+    assert b"Permission denied" in response.content
+
+
+# EOF


### PR DESCRIPTION
## Summary

Opens the JWT door to the platform's existing project-scoped endpoints (\`apps/infra/project_app/views/repository/api/*\`) without each view converting to DRF. Motivated by operator-12880's design directive (user must never touch Gitea — server holds the credential, agent-programmatic actions go through the user's own JWT).

- Adds \`apps/infra/accounts_app/middleware.py::JWTBearerToSessionMiddleware\`
- Wires it after \`AuthenticationMiddleware\` in \`config/settings/settings_shared.py\`

## Blast radius

- Fires **only** when \`request.user\` is anonymous AND the request carries \`Authorization: Bearer …\`. Browser cookie-sessions short-circuit on the \`is_authenticated\` check and never enter the middleware body — existing flows untouched.
- Extends the **same** trust model the workspace console already uses at \`apps/workspace/console_app/services/terminal_broker/shell.py:65\` (\`RefreshToken.for_user(user).access_token\`). Not a new trust surface, just a wider acceptance point for the same signed-by-server token.
- CSRF carve-out (\`request._dont_enforce_csrf_checks = True\`) gated on a successful JWT resolve — mirrors \`OnSiteAuthMiddleware\`'s existing pattern. Malformed Bearer keeps CSRF enforcement intact.

## Fail-closed semantics (review-hardening)

- Catches **only** \`InvalidToken\` / \`TokenError\` / \`AuthenticationFailed\`. Bad tokens leave the request anonymous so the view's permission check returns 401/403.
- Any other exception (DB connection, mis-configured \`SECRET_KEY\`, etc.) propagates per crash-loud doctrine — no blanket swallow.
- Logs rejected tokens at \`INFO\` (normal client error, not server bug).

## Test plan

- [x] **Positive** (\`test_valid_bearer_jwt_authenticates_request_as_owner\`): real \`User\` + \`Project\`, mint JWT via \`RefreshToken.for_user(owner).access_token\`, \`GET /<u>/<slug>/api/git/status/\` with the Bearer header, assert body does NOT contain \"Permission denied\".
- [x] **Negative** (\`test_garbage_bearer_leaves_request_anonymous_and_denies\`): same fixtures, garbage Bearer \`\"Bearer this.is.not-a-real-jwt\"\`, assert body DOES contain \"Permission denied\" — proves the fail-closed path.
- No mocks, no monkeypatch, real Django \`Client\` + DB.

## Follow-ups (not in this PR)

- APIKey-on-DRF endpoints (the user-token canonical case) — separate PR per the 8-PR breakdown in the in-flight a2a thread.
- \`scitex-hub auth login\` CLI (browser-free token issuance) — separate PR.

Critical path for the agent publish demo. Self-merge on CI green per the operator's directive.