### PR TITLE
fix(project_app): correct stale import path for _clone_gitea_repo_to_data_dir

### DIFF
--- a/apps/infra/project_app/services/repository_health_service.py
+++ b/apps/infra/project_app/services/repository_health_service.py
@@ -9,11 +9,13 @@ Gitea repositories. Ensures strict 1:1 mapping between:
 """
 
 import logging
-from typing import Dict, List, Tuple
 from pathlib import Path
+from typing import Dict, List, Tuple
+
 from django.contrib.auth.models import User
+
+from apps.infra.gitea_app.api_client import GiteaAPIError, GiteaClient
 from apps.infra.project_app.models import Project
-from apps.infra.gitea_app.api_client import GiteaClient, GiteaAPIError
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +112,7 @@ class RepositoryHealthChecker:
                     issue = RepositoryHealthIssue(
                         "orphaned_in_gitea",
                         gitea_name=gitea_name,
-                        message=f"Repository exists in Gitea but no Django project found",
+                        message="Repository exists in Gitea but no Django project found",
                     )
                     issues.append(issue)
                     stats["critical_issues"] += 1
@@ -131,7 +133,7 @@ class RepositoryHealthChecker:
             return RepositoryHealthIssue(
                 "missing_in_gitea",
                 project_slug=project.slug,
-                message=f"Django project exists but Gitea repository not found",
+                message="Django project exists but Gitea repository not found",
             )
 
         # Check if local directory exists
@@ -148,7 +150,7 @@ class RepositoryHealthChecker:
         return RepositoryHealthIssue(
             "healthy",
             project_slug=project.slug,
-            message=f"Repository healthy and in sync",
+            message="Repository healthy and in sync",
         )
 
     def delete_orphaned_repository(self, gitea_name: str) -> Tuple[bool, str]:
@@ -192,7 +194,9 @@ class RepositoryHealthChecker:
 
             # Re-clone from Gitea if directory is missing
             if not project.git_clone_path or not Path(project.git_clone_path).exists():
-                from apps.infra.project_app.signals import _clone_gitea_repo_to_data_dir
+                from apps.infra.project_app.signals.project_initialization import (
+                    _clone_gitea_repo_to_data_dir,
+                )
 
                 _clone_gitea_repo_to_data_dir(project)
                 return True, f"✓ Re-cloned repository to: {project.git_clone_path}"
@@ -266,7 +270,9 @@ class RepositoryHealthChecker:
             )
 
             # Clone the repository to local filesystem
-            from apps.infra.project_app.signals import _clone_gitea_repo_to_data_dir
+            from apps.infra.project_app.signals.project_initialization import (
+                _clone_gitea_repo_to_data_dir,
+            )
 
             _clone_gitea_repo_to_data_dir(project)
 

--- a/tests/apps/project_app/services/test_repository_health_service.py
+++ b/tests/apps/project_app/services/test_repository_health_service.py
@@ -1,21 +1,63 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for apps/project_app/services/repository_health_service.py"""
+"""Tests for apps/project_app/services/repository_health_service.py.
+
+Currently focused on the clone-import-path regression: the file used to
+``from apps.infra.project_app.signals import _clone_gitea_repo_to_data_dir``
+(stale; the package root doesn't re-export that helper), which crashed
+``RepositoryHealthChecker.sync_repository`` and ``.restore_repository`` at
+runtime with ``ImportError`` — observed during the operator-12834
+agent-publish demo against prod scitex.ai. The fix moves both imports to
+the canonical submodule path. These tests pin the fix in two complementary
+ways without mocks: (1) the real production source has no occurrence of
+the broken path, (2) the helper is actually importable from the canonical
+path the production source now uses.
+"""
+
+import inspect
+from pathlib import Path
 
 import pytest
 
-# from apps.infra.project_app.services.repository_health_service import ...
+
+def test_clone_helper_importable_from_canonical_submodule():
+    # Arrange
+    # Act
+    from apps.infra.project_app.signals.project_initialization import (
+        _clone_gitea_repo_to_data_dir,
+    )
+
+    # Assert
+    assert callable(_clone_gitea_repo_to_data_dir)
 
 
-class TestPlaceholder:
-    """Placeholder test class - replace with actual tests."""
+def test_repository_health_service_source_has_no_stale_clone_import():
+    # Arrange
+    from apps.infra.project_app.services import repository_health_service
 
-    def test_placeholder_pending_implementation(self):
-        """Placeholder test - implement actual tests."""
-        # Arrange
-        # Act
-        # Assert
-        pytest.skip("Not implemented yet")
+    src = Path(inspect.getsourcefile(repository_health_service)).read_text()
+    stale = "from apps.infra.project_app.signals import _clone_gitea_repo_to_data_dir"
+
+    # Act
+    occurrences = src.count(stale)
+
+    # Assert — guards against future regressions reintroducing the bare
+    # package-root import path.
+    assert occurrences == 0
+
+
+def test_repository_health_checker_class_imports_without_error():
+    # Arrange
+    # Act
+    from apps.infra.project_app.services.repository_health_service import (
+        RepositoryHealthChecker,
+    )
+
+    # Assert — module-level execution succeeded (no ImportError surfacing
+    # from any of the lazy local imports inside sync_repository /
+    # restore_repository was the bug; the class-level smoke import is the
+    # cheapest regression proof).
+    assert RepositoryHealthChecker is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two identical occurrences in \`apps/infra/project_app/services/repository_health_service.py\` imported \`_clone_gitea_repo_to_data_dir\` from \`apps.infra.project_app.signals\` (the package root, which does **not** re-export the helper) instead of from the canonical submodule path \`apps.infra.project_app.signals.project_initialization\`.

**Runtime result**: \`RepositoryHealthChecker.sync_repository(slug)\` and \`.restore_repository(...)\` both crashed with:

\`\`\`
ImportError: cannot import name '_clone_gitea_repo_to_data_dir' from 'apps.infra.project_app.signals'
\`\`\`

…the moment the local working tree was missing — i.e. exactly the recovery path the service exists for.

## How it surfaced

Operator-12834 agent-publish demo against prod scitex.ai. After PR #268 deployed the JWT middleware, my publish recipe POSTed \`/api/project/create/\` → server created the Django Project AND the Gitea repo, but the post-create \`_clone_gitea_repo_to_data_dir(instance)\` call silently failed (caught + logged in the signal's broad exception handler). The Project then had no local working tree, so every project-scoped endpoint returned \`Project directory not found\`. Recovery via \`/api/repository-sync/\` → 200 but with the ImportError above in the body.

## Fix

Two import lines, identical change:

\`\`\`diff
-                from apps.infra.project_app.signals import _clone_gitea_repo_to_data_dir
+                from apps.infra.project_app.signals.project_initialization import (
+                    _clone_gitea_repo_to_data_dir,
+                )
\`\`\`

Same shape of stale-path fix family as the URL fixes in PR #267 (\`/api/v1/projects/*\` → canonical \`/api/project/*\`).

## Tests (no mocks, no monkeypatch — real imports + source-text grep)

- \`test_clone_helper_importable_from_canonical_submodule\` — asserts the helper IS importable from the canonical submodule path the production source now uses. This proves the fix.
- \`test_repository_health_service_source_has_no_stale_clone_import\` — reads the production source via \`inspect.getsourcefile\` + \`Path.read_text\` and asserts **zero** occurrences of the broken package-root import string. Guards against future regressions reintroducing it.
- \`test_repository_health_checker_class_imports_without_error\` — cheapest smoke regression proof: the class-level import succeeds.

## Hot-patch coordination

Lead applied the equivalent surgical hot-patch to the running prod container in parallel (idempotent applicator + django restart) so the agent-publish demo can proceed without waiting for image rebuild. This PR closes the durable fix in develop so the next image rebuild bakes it in. No reconciliation debt — the hot-patch and this PR converge on the same end state.

CI-green → self-merge per the operator's blanket sequencing.