### PR TITLE
fix(project_app): build clone URL from settings.GITEA_URL, not project.gitea_clone_url

### DIFF
--- a/apps/infra/project_app/signals/project_initialization.py
+++ b/apps/infra/project_app/signals/project_initialization.py
@@ -61,9 +61,24 @@ def _clone_gitea_repo_to_data_dir(project):
 
             shutil.rmtree(project_dir)
 
-        # Clone from Gitea using HTTP with embedded token for authentication
-        # Format: http://{token}@gitea:3000/{owner}/{repo}.git
-        clone_url = project.gitea_clone_url
+        # Clone from Gitea using HTTP with embedded token for authentication.
+        #
+        # Build the clone URL from the in-container Gitea service hostname
+        # (``settings.GITEA_URL``, defaults to ``http://gitea:3000`` in
+        # docker-compose deployments) rather than trusting
+        # ``project.gitea_clone_url``. Gitea's API reports ``clone_url`` from
+        # its own ``ROOT_URL`` config, which is set to the host-visible URL
+        # (e.g. ``http://localhost:3000`` in prod, ``https://git.scitex.ai``
+        # publicly). Neither of those resolves the same way from inside the
+        # django container, so trusting the API value cloned to an
+        # unreachable host and the broad ``except`` below swallowed the
+        # subprocess failure — surfaced during operator-12834 publish demo.
+        # ``settings.GITEA_URL`` is the URL Django ALREADY uses to talk to
+        # Gitea (see GiteaClient), so it's the right source of truth.
+        clone_url = (
+            f"{settings.GITEA_URL.rstrip('/')}"
+            f"/{project.owner.username}/{project.slug}.git"
+        )
 
         # Inject Gitea admin token into URL for authentication
         # Clone URL format from Gitea: http://gitea:3000/owner/repo.git

--- a/tests/apps/project_app/signals/test_project_initialization.py
+++ b/tests/apps/project_app/signals/test_project_initialization.py
@@ -1,21 +1,76 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for apps/project_app/signals/project_initialization.py"""
+"""Tests for apps/project_app/signals/project_initialization.py.
 
-import pytest
+Currently focused on the clone-URL-source regression: the function
+``_clone_gitea_repo_to_data_dir`` used to take its clone URL from
+``project.gitea_clone_url`` — the value returned by Gitea's API, which
+Gitea constructs from its own ``ROOT_URL`` config. In the production
+deployment ``ROOT_URL`` is the host-visible URL
+(``http://localhost:3000``), which does NOT resolve from inside the
+django container — so ``git clone`` connected to the django container
+itself (port 3000 unbound) and failed silently inside the function's
+broad ``except`` clause. Observed during the operator-12834 agent-publish
+demo against prod scitex.ai.
 
-# from apps.infra.project_app.signals.project_initialization import ...
+The fix sources the clone URL from ``settings.GITEA_URL`` — the same
+URL Django already uses to talk to Gitea (see
+``apps.infra.gitea_app.api_client.GiteaClient``). It is the
+container-internal service hostname that DOES resolve. These tests pin
+that invariant with two source-text guards so the regression can't
+silently reappear.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
 
 
-class TestPlaceholder:
-    """Placeholder test class - replace with actual tests."""
+def _read_function_source(func) -> str:
+    """Read the on-disk source of a module-level function (no mocks)."""
+    src_path = Path(inspect.getsourcefile(func))
+    return src_path.read_text()
 
-    def test_placeholder_pending_implementation(self):
-        """Placeholder test - implement actual tests."""
-        # Arrange
-        # Act
-        # Assert
-        pytest.skip("Not implemented yet")
+
+def test_clone_helper_builds_url_from_settings_gitea_url():
+    # Arrange
+    from apps.infra.project_app.signals.project_initialization import (
+        _clone_gitea_repo_to_data_dir,
+    )
+
+    src = _read_function_source(_clone_gitea_repo_to_data_dir)
+
+    # Act
+    has_settings_gitea_url = "settings.GITEA_URL" in src
+    has_username_path_segment = "project.owner.username" in src
+    has_slug_path_segment = "project.slug" in src
+
+    # Assert — all three pieces are required for the in-container URL
+    # construction. A future "simplification" PR that drops any one of
+    # them reverts the fix; this guard fails loudly instead.
+    assert (
+        has_settings_gitea_url and has_username_path_segment and has_slug_path_segment
+    )
+
+
+def test_clone_helper_does_not_use_project_gitea_clone_url():
+    # Arrange
+    from apps.infra.project_app.signals.project_initialization import (
+        _clone_gitea_repo_to_data_dir,
+    )
+
+    src = _read_function_source(_clone_gitea_repo_to_data_dir)
+
+    # Act
+    # The buggy assignment was ``clone_url = project.gitea_clone_url``.
+    # Allow ``project.gitea_clone_url`` to appear elsewhere in the file
+    # (e.g. as a logging value or in unrelated helpers) but assert the
+    # assignment pattern itself never returns.
+    buggy_assignment_pattern = "clone_url = project.gitea_clone_url"
+
+    # Assert
+    assert buggy_assignment_pattern not in src
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

\`_clone_gitea_repo_to_data_dir\` sourced its clone URL from \`project.gitea_clone_url\` — the value Gitea's REST API returns from \`repo.clone_url\`. Gitea constructs that value from its own \`ROOT_URL\` config, which in the prod docker-compose deployment is the **host-visible URL** (\`http://localhost:3000\` via the \`*_URL_IN_HOST_PROD\` env, or \`https://git.scitex.ai\` publicly). Neither resolves the same way from inside the django container.

**Effect**: \`git clone http://<token>@localhost:3000/...\` from inside the django container connects to the django container itself (port 3000 unbound) and fails. The subprocess error gets swallowed by the broad \`except Exception\` at the bottom of the function (and downstream by \`RepositoryHealthChecker.sync_repository\`'s no-check \`True\` return), producing the famous false-positive:

\`\`\`json
{\"success\": true, \"message\": \"\\u2713 Re-cloned repository to: \"}
\`\`\`

…with no working tree on disk.

## How it surfaced

Operator-12834 agent-publish demo against prod scitex.ai. After PR #268 (JWT middleware) deployed, project creation succeeded but every project-scoped endpoint returned \`Project directory not found\`. PR #269 fixed a stale import that blocked the recovery path. This PR fixes the underlying bug those failure modes pointed at.

## Fix

One source of truth for \"where Django reaches Gitea\": \`settings.GITEA_URL\`. The same setting \`apps.infra.gitea_app.api_client.GiteaClient\` already uses for its (successful) API calls (\`http://gitea:3000\` inside the docker network).

\`\`\`python
clone_url = (
    f\"{settings.GITEA_URL.rstrip('/')}\"
    f\"/{project.owner.username}/{project.slug}.git\"
)
\`\`\`

Downstream token-injection block is unchanged — it already handles \`http://gitea:3000/...\` shape correctly.

## Test plan

- [x] **test_clone_helper_builds_url_from_settings_gitea_url** — asserts the fixed construction has \`settings.GITEA_URL\` + \`project.owner.username\` + \`project.slug\`. A future simplification PR that drops any of those reverts the fix; this guard fails loudly.
- [x] **test_clone_helper_does_not_use_project_gitea_clone_url** — asserts the buggy assignment pattern \`clone_url = project.gitea_clone_url\` never reappears in the source.
- No mocks, no monkeypatch — real source-text guards (same pattern as #269's stale-import guard).

## Hot-patch coordination

Lead applied the equivalent surgical hot-patch to the running prod container in parallel (idempotent applicator + django restart) so the agent-publish demo can proceed without waiting for image rebuild. This PR closes the durable fix in develop so the next image rebuild bakes it in. No reconciliation debt — hot-patch and this PR converge on the same end state.

## Family

Same shape of stale-path/source fix family as #267 (URL fixes), #268 (JWT middleware that exposed the gap), #269 (clone-helper import path).

CI-green → self-merge per blanket approval.