### PR TITLE
fix(apps_app): loud-failure logging for api_submit_jwt

### DIFF
--- a/apps/workspace/apps_app/views/api_registry.py
+++ b/apps/workspace/apps_app/views/api_registry.py
@@ -39,71 +39,97 @@ def api_submit_jwt(request):
 
     Accepts: {"project_name": "...", "manifest": {...}}
     Creates AppsModule + ModuleSubmission + opens cross-repo PR.
+
+    Loud-failure logging: the entire body is wrapped so any unhandled
+    exception is logged at ERROR level with the full traceback BEFORE
+    DRF's generic 500-handler converts the response to a no-frame HTML
+    page (or a no-traceback DRF response, depending on settings). This
+    is the diagnostic enabler for fixing the registry-submission path —
+    surfaced during the operator-12834 demo when an indirect
+    paramiko-SSH banner error produced a 500 with no frames in
+    DEBUG=False prod logs. Re-raises so the response surface is
+    unchanged.
     """
-    project_name = request.data.get("project_name", "").strip()
-    manifest = request.data.get("manifest", {})
+    try:
+        project_name = request.data.get("project_name", "").strip()
+        manifest = request.data.get("manifest", {})
 
-    if not project_name:
-        return Response(
-            {"success": False, "error": "project_name is required"}, status=400
+        if not project_name:
+            return Response(
+                {"success": False, "error": "project_name is required"}, status=400
+            )
+
+        from apps.infra.project_app.models import Project
+
+        project = Project.objects.filter(name=project_name, owner=request.user).first()
+        if not project:
+            return Response(
+                {"success": False, "error": f"Project '{project_name}' not found"},
+                status=404,
+            )
+
+        module_name = manifest.get("name", project.slug)
+        version = manifest.get("version", "0.1.0")
+
+        # Fetch HEAD commit SHA from author's Gitea repo
+        pinned_commit = _fetch_head_commit(request.user.username, project.slug)
+
+        # Create or update AppsModule
+        app_module, _created = AppsModule.objects.update_or_create(
+            module_name=module_name,
+            defaults={
+                "author": request.user,
+                "project": project,
+                "short_description": manifest.get("description", ""),
+                "category": manifest.get("category", "other"),
+                "visibility": "private",
+                "pinned_commit": pinned_commit,
+            },
         )
 
-    from apps.infra.project_app.models import Project
+        # Reject if already pending
+        if ModuleSubmission.objects.filter(
+            module=app_module, status="pending"
+        ).exists():
+            return Response(
+                {
+                    "success": False,
+                    "error": "A submission is already pending review.",
+                },
+                status=400,
+            )
 
-    project = Project.objects.filter(name=project_name, owner=request.user).first()
-    if not project:
-        return Response(
-            {"success": False, "error": f"Project '{project_name}' not found"},
-            status=404,
+        # Open cross-repo PR: user/<app> -> scitex-apps/<app>
+        pr_url = _submit_app_pr(
+            app_module=app_module,
+            version=version,
         )
 
-    module_name = manifest.get("name", project.slug)
-    version = manifest.get("version", "0.1.0")
-
-    # Fetch HEAD commit SHA from author's Gitea repo
-    pinned_commit = _fetch_head_commit(request.user.username, project.slug)
-
-    # Create or update AppsModule
-    app_module, _created = AppsModule.objects.update_or_create(
-        module_name=module_name,
-        defaults={
-            "author": request.user,
-            "project": project,
-            "short_description": manifest.get("description", ""),
-            "category": manifest.get("category", "other"),
-            "visibility": "private",
-            "pinned_commit": pinned_commit,
-        },
-    )
-
-    # Reject if already pending
-    if ModuleSubmission.objects.filter(module=app_module, status="pending").exists():
-        return Response(
-            {"success": False, "error": "A submission is already pending review."},
-            status=400,
+        submission = ModuleSubmission.objects.create(
+            module=app_module,
+            submitted_by=request.user,
+            pr_url=pr_url,
         )
 
-    # Open cross-repo PR: user/<app> -> scitex-apps/<app>
-    pr_url = _submit_app_pr(
-        app_module=app_module,
-        version=version,
-    )
-
-    submission = ModuleSubmission.objects.create(
-        module=app_module,
-        submitted_by=request.user,
-        pr_url=pr_url,
-    )
-
-    return Response(
-        {
-            "success": True,
-            "message": f"Submitted {module_name} for review.",
-            "pr_url": pr_url,
-            "submission_id": submission.pk,
-        },
-        status=201,
-    )
+        return Response(
+            {
+                "success": True,
+                "message": f"Submitted {module_name} for review.",
+                "pr_url": pr_url,
+                "submission_id": submission.pk,
+            },
+            status=201,
+        )
+    except Exception:
+        # crash-loud: log the full traceback BEFORE DRF wraps the
+        # response. The HTTP surface is unchanged — we re-raise so
+        # callers still get the same 500. The point is the log line.
+        logger.exception(
+            "api_submit_jwt failed for user=%s project_name=%r",
+            getattr(request.user, "username", "<anon>"),
+            request.data.get("project_name", "") if hasattr(request, "data") else "",
+        )
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps/apps_app/views/test_api_registry_loud_logging.py
+++ b/tests/apps/apps_app/views/test_api_registry_loud_logging.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Source-text guards for the ``api_submit_jwt`` loud-failure wrap.
+
+The endpoint ``apps.workspace.apps_app.views.api_registry.api_submit_jwt``
+must wrap its body in a ``try / except Exception`` that calls
+``logger.exception(...)`` before re-raising. This pattern surfaces the
+real traceback in production logs BEFORE DRF's generic-500 handler
+converts the response to a no-frame HTML page (or no-traceback DRF
+response, depending on ``DEBUG``). It was added in response to the
+operator-12834 demo where an indirect paramiko-SSH banner error
+produced a 500 with zero usable log frames in ``DEBUG=False`` prod
+logs — the silent-failure mode that motivated this PR.
+
+These tests pin the wrap shape with two source-text guards so a future
+"cleanup" PR that drops the wrap fails loudly. Same no-mock pattern
+as the source-text guards in PR #269 (stale-import) and PR #270
+(clone-URL).
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+
+def _read_function_source(func) -> str:
+    """Read the on-disk source of a module-level function (no mocks)."""
+    src_path = Path(inspect.getsourcefile(func))
+    return src_path.read_text()
+
+
+def test_api_submit_jwt_body_is_wrapped_in_try_except_logger_exception():
+    # Arrange
+    from apps.workspace.apps_app.views.api_registry import api_submit_jwt
+
+    src = inspect.getsource(api_submit_jwt)
+
+    # Act
+    has_try_block = "    try:" in src
+    has_except_handler = "    except Exception:" in src
+    has_logger_exception = "logger.exception(" in src
+    has_reraise = "        raise" in src
+
+    # Assert — all four pieces are the wrap. Dropping any of them
+    # reverts the loud-failure semantics: a missing ``except`` lets the
+    # exception bubble pre-DRF (re-introducing the silent-500); a
+    # missing ``logger.exception`` swallows the traceback; a missing
+    # ``raise`` changes the HTTP surface.
+    assert has_try_block and has_except_handler and has_logger_exception and has_reraise
+
+
+def test_api_submit_jwt_logs_at_least_username_and_project_name():
+    # Arrange
+    from apps.workspace.apps_app.views.api_registry import api_submit_jwt
+
+    src = inspect.getsource(api_submit_jwt)
+
+    # Act
+    # The log call must include enough context to correlate a 500 with
+    # the offending request: which user and which project_name. Without
+    # those the log line is just "an exception happened somewhere".
+    log_includes_username = (
+        "username" in src.split("logger.exception(")[1].split(")")[0]
+    )
+    log_includes_project_name = (
+        "project_name" in src.split("logger.exception(")[1].split(")")[0]
+    )
+
+    # Assert
+    assert log_includes_username and log_includes_project_name
+
+
+# EOF


### PR DESCRIPTION
## Summary

Operator-12834 demo surfaced a silent-failure mode: a paramiko-SSH banner error fired somewhere indirectly reached from \`api_submit_jwt\`, DRF wrapped it in a generic-500 HTML page with no traceback in \`DEBUG=False\` prod logs, and the only way to diagnose was iterative log grepping that produced only sibling code-path noise.

This PR wraps \`api_submit_jwt\`'s body in \`try/except\` that calls \`logger.exception(...)\` BEFORE re-raising, so the full traceback hits the logger BEFORE DRF wraps it. HTTP surface unchanged; only behavioural change is the log line.

The log call includes both \`username\` and \`project_name\` for multi-tenant correlation.

## Diagnostic enabler

With this in develop → next image rebuild → next prod submit attempt logs REAL frames → indirect paramiko trigger gets diagnosed → durable registry-submit fix becomes possible. The submit step itself is NOT blocking the publish demo per the operator's separate-later-cert framing.

## Tests (no mocks, source-text guards — same pattern as #269 #270)

- \`test_api_submit_jwt_body_is_wrapped_in_try_except_logger_exception\` — asserts the wrap shape (try / except Exception / logger.exception / raise). A future cleanup PR that drops any of those four pieces fails loudly.
- \`test_api_submit_jwt_logs_at_least_username_and_project_name\` — asserts the log call includes enough context to correlate the 500 with the offending request.

## Family

#267 (stale URLs), #268 (JWT middleware), #269 (stale import), #270 (clone URL), now #271 (loud-fail logging). All operator-12834 demo-derived bugs.

Self-merge on CI green per blanket approval. **No prod hot-patch** — next image rebuild bakes it in.