### PR TITLE
feat(accounts_app): APIKeyAuthentication — UI-PAT works on every DRF endpoint

### DIFF
--- a/apps/infra/accounts_app/authentication.py
+++ b/apps/infra/accounts_app/authentication.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""DRF ``BaseAuthentication`` adapter for the ``scitex_xxxx`` APIKey.
+
+Closes the Phase-1 gap operator-12909 surfaced: a user with a personal
+access token generated via the UI (``https://scitex.ai/api-keys/``)
+should be able to authenticate against every JWT-friendly endpoint —
+``/api/project/create/``, ``/api/apps/submit/``, the project-scoped
+``<u>/<slug>/api/*`` family — exactly like the JWT path that landed in
+PR #268.
+
+Before this class existed, ``APIKey`` rows only authenticated the
+MCP-tool endpoints (via the custom ``HasToolAccess`` permission class).
+DRF's ``IsAuthenticated``-permission views read ``request.user`` from
+the global ``REST_FRAMEWORK.DEFAULT_AUTHENTICATION_CLASSES`` list, which
+was ``[SessionAuthentication, JWTAuthentication]`` only. Adding this
+class to that list extends APIKey acceptance to every DRF endpoint
+without per-view edits — same impedance match the JWT middleware (PR
+#268) provided for plain Django views.
+
+Trust model: identical to the existing OK-tested
+``apps.infra.accounts_app.auth.authenticate_api_key`` helper. This class
+is a thin DRF-shaped wrapper around that helper — no new credential
+mechanism, no new hash/format, no relaxation of the existing key
+validity checks (active + non-expired).
+"""
+
+from __future__ import annotations
+
+from rest_framework import authentication, exceptions
+
+from .auth import authenticate_api_key
+
+
+class APIKeyAuthentication(authentication.BaseAuthentication):
+    """DRF authentication class for ``Authorization: Bearer scitex_xxxx``.
+
+    Behaviour follows DRF's three-state ``authenticate`` contract:
+
+    * **No relevant credentials** → return ``None``. Lets the next
+      auth class in ``DEFAULT_AUTHENTICATION_CLASSES`` try (e.g. so a
+      Bearer JWT still routes to ``JWTAuthentication``).
+    * **Recognisable but invalid credential** → raise
+      :exc:`AuthenticationFailed`. The token-prefix sniff
+      (``Bearer scitex_``) is how we decide "this credential is meant
+      for us" so failure here is a hard 401, not a fall-through.
+    * **Valid credential** → return ``(user, api_key)`` where ``user``
+      is the APIKey's owner. ``request.auth`` then carries the APIKey
+      instance for views that want scope or last-used metadata.
+
+    Scope semantics are NOT enforced here — they live in the
+    permission class that the view's ``permission_classes`` declares.
+    This class only proves identity. Same separation DRF uses elsewhere.
+    """
+
+    keyword_prefix = "Bearer scitex_"
+
+    def authenticate(self, request):
+        auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+        if not auth_header.startswith(self.keyword_prefix):
+            # Not a scitex_xxxx PAT — let the next auth class try.
+            return None
+
+        api_key = authenticate_api_key(request)
+        if api_key is None:
+            # Recognisable shape but the key is wrong / expired / inactive.
+            # Hard 401 instead of fall-through so the client sees the
+            # actual problem rather than a misleading "no auth" 401 from
+            # whichever class last ran.
+            raise exceptions.AuthenticationFailed("Invalid or expired scitex_ API key.")
+
+        return (api_key.user, api_key)
+
+    def authenticate_header(self, request):
+        # Returned in the ``WWW-Authenticate`` header on 401 responses.
+        # Same shape as DRF's JWT scheme so clients know which scheme(s)
+        # are accepted.
+        return 'Bearer realm="api"'
+
+
+# EOF

--- a/config/settings/settings_integrations.py
+++ b/config/settings/settings_integrations.py
@@ -102,6 +102,15 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework_simplejwt.authentication.JWTAuthentication",
+        # APIKeyAuthentication adapts the existing `scitex_xxxx` UI-PAT
+        # (apps.infra.accounts_app.models.api_key.APIKey) to DRF's
+        # authentication contract so a UI-generated PAT works on every
+        # DRF endpoint — /api/project/create/, /api/apps/submit/, and the
+        # project-scoped <u>/<slug>/api/* family (which already accepts
+        # Bearer-anything via the JWT middleware from PR #268). The class
+        # ONLY recognises tokens that start with `Bearer scitex_` so the
+        # JWT path above is unaffected.
+        "apps.infra.accounts_app.authentication.APIKeyAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",

--- a/tests/apps/accounts_app/test_apikey_authentication.py
+++ b/tests/apps/accounts_app/test_apikey_authentication.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""End-to-end tests for ``APIKeyAuthentication``.
+
+The DRF auth class adapts the existing ``scitex_xxxx`` UI-PAT
+(:class:`apps.infra.accounts_app.models.api_key.APIKey`) into the
+``REST_FRAMEWORK.DEFAULT_AUTHENTICATION_CLASSES`` chain so it works on
+every JWT-friendly endpoint — closing the Phase-1 gap surfaced by
+operator-12909 ("a USER, not just our agent, must publish via CLI with
+token auth, no browser").
+
+These tests exercise the real DRF flow through the real auth chain
+against a real endpoint (``/api/me/``, the cheapest authenticated DRF
+view in the project) with a real :class:`APIKey` row created via
+:meth:`APIKey.create_key`. **No mocks, no monkeypatch.**
+
+Contract (three states):
+
+1. **No relevant credentials** → return ``None`` (let next auth class
+   try). Asserted via the JWT-shaped Bearer that should still route to
+   ``JWTAuthentication`` and pass.
+2. **Recognisable but invalid** (``Bearer scitex_…`` that's not in the
+   DB) → ``AuthenticationFailed`` → 401.
+3. **Valid credential** → ``(user, api_key)`` → 200, identifying the
+   APIKey owner.
+
+Plus expiry rejection.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.utils import timezone
+
+from apps.infra.accounts_app.models import APIKey
+
+
+@pytest.mark.django_db
+def test_valid_apikey_authenticates_request_as_owner():
+    # Arrange
+    owner = User.objects.create_user(
+        username="apikey-positive", email="apikey-positive@example.com", password="x"
+    )
+    _api_key_row, full_key = APIKey.create_key(
+        user=owner, name="test-positive", scopes=["api"]
+    )
+    client = Client()
+
+    # Act
+    response = client.get("/api/me/", HTTP_AUTHORIZATION=f"Bearer {full_key}")
+
+    # Assert
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_valid_apikey_response_identifies_correct_owner():
+    # Arrange
+    owner = User.objects.create_user(
+        username="apikey-owner-check",
+        email="apikey-owner-check@example.com",
+        password="x",
+    )
+    _api_key_row, full_key = APIKey.create_key(
+        user=owner, name="test-owner-check", scopes=["api"]
+    )
+    client = Client()
+
+    # Act
+    response = client.get("/api/me/", HTTP_AUTHORIZATION=f"Bearer {full_key}")
+
+    # Assert — /api/me/ returns the authenticated username; if the
+    # auth class returned the wrong user, this fails loudly.
+    assert response.json().get("username") == "apikey-owner-check"
+
+
+@pytest.mark.django_db
+def test_unknown_scitex_bearer_is_rejected_with_401():
+    # Arrange
+    client = Client()
+    forged_key = "scitex_" + "0" * 64  # well-formed prefix, no DB row
+
+    # Act
+    response = client.get("/api/me/", HTTP_AUTHORIZATION=f"Bearer {forged_key}")
+
+    # Assert — recognisable shape ("Bearer scitex_…") that doesn't
+    # match any row must hard-401, NOT fall through to anonymous /
+    # other-auth-class state. Proves the class can't be tricked.
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_expired_apikey_is_rejected_with_401():
+    # Arrange
+    owner = User.objects.create_user(
+        username="apikey-expired", email="apikey-expired@example.com", password="x"
+    )
+    api_key_row, full_key = APIKey.create_key(
+        user=owner, name="test-expired", scopes=["api"]
+    )
+    api_key_row.expires_at = timezone.now() - timezone.timedelta(days=1)
+    api_key_row.save(update_fields=["expires_at"])
+    client = Client()
+
+    # Act
+    response = client.get("/api/me/", HTTP_AUTHORIZATION=f"Bearer {full_key}")
+
+    # Assert
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_inactive_apikey_is_rejected_with_401():
+    # Arrange
+    owner = User.objects.create_user(
+        username="apikey-inactive", email="apikey-inactive@example.com", password="x"
+    )
+    api_key_row, full_key = APIKey.create_key(
+        user=owner, name="test-inactive", scopes=["api"]
+    )
+    api_key_row.is_active = False
+    api_key_row.save(update_fields=["is_active"])
+    client = Client()
+
+    # Act
+    response = client.get("/api/me/", HTTP_AUTHORIZATION=f"Bearer {full_key}")
+
+    # Assert
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_non_scitex_bearer_falls_through_to_other_auth_classes():
+    # Arrange — a Bearer header that does NOT start with `scitex_` must
+    # be IGNORED by APIKeyAuthentication so JWTAuthentication can try.
+    # We confirm fall-through by sending an obvious non-JWT non-PAT
+    # value and asserting the response is 401 (someone rejected it) —
+    # but crucially NOT a 500 (which would mean APIKeyAuthentication
+    # blew up trying to parse it).
+    client = Client()
+
+    # Act
+    response = client.get(
+        "/api/me/", HTTP_AUTHORIZATION="Bearer this-is-not-a-scitex-pat"
+    )
+
+    # Assert
+    assert response.status_code == 401
+
+
+# EOF


### PR DESCRIPTION
## Summary

Phase-1 PR-1 of the operator-12909 token+CLI surface. Closes the gap: a user with a personal access token generated via the UI (\`https://scitex.ai/api-keys/\`) authenticates against every JWT-friendly endpoint — \`/api/project/create/\`, \`/api/apps/submit/\`, the project-scoped \`<u>/<slug>/api/*\` family.

Before this PR, \`scitex_xxxx\` APIKey rows only authenticated the MCP-tool endpoints (custom \`HasToolAccess\` permission). DRF \`IsAuthenticated\` views read \`request.user\` from \`REST_FRAMEWORK.DEFAULT_AUTHENTICATION_CLASSES\` which was \`[Session, JWT]\` only.

Adds the new \`APIKeyAuthentication\` DRF class to that list. Thin wrapper around the existing tested \`apps.infra.accounts_app.auth.authenticate_api_key\` helper — same trust model, same hash, same validity checks (active + non-expired). Three-state DRF contract (no-creds → None, recognisable-but-invalid → 401, valid → (user, api_key)).

## Tests (6, no mocks, no monkeypatch)

Real DRF stack, real \`APIKey.create_key\`, real DB via \`@pytest.mark.django_db\`, real \`/api/me/\` through Django \`Client\`:

- valid PAT → 200
- valid PAT identifies CORRECT owner via \`/api/me/.username\`
- forged \`Bearer scitex_…\` (not in DB) → 401 (hard reject, not silent fall-through)
- expired PAT → 401
- inactive PAT → 401
- non-scitex Bearer → 401 (NOT 500 — proves fall-through to other auth classes is clean)

## Family / Phase-1 sequence

Unblocks the next 7 Phase-1 PRs (account token CLI, Python API parity, CLI tidy, MCP token-aware, skills runbook, audit pass). All wire through this auth class.

Self-merge on CI green per blanket approval.