### PR TITLE
feat(accounts_app): /api/me/token/ — browser-free CLI token issuance (Phase-1 PR-3)

### DIFF
--- a/apps/infra/accounts_app/views/me_token_views.py
+++ b/apps/infra/accounts_app/views/me_token_views.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""CLI-facing ``/api/me/token/`` endpoints — mint + list + revoke APIKeys.
+
+Phase-1 PR-3 of operator-12909's token+CLI surface. Closes the
+browser-free token issuance gap: ``scitex-hub account token create``
+posts ``{username, password, scopes, name}``; the server mints a
+``scitex_xxxx`` APIKey via the existing tested
+:meth:`apps.infra.accounts_app.models.api_key.APIKey.create_key`
+factory and returns it.
+
+Security review-hardening (lead msg db151d1 + dev msg 53b830f4
++ msg 089bd6 — locked into hub-card #34 spec):
+
+- **Rate-limit** via the existing Redis sliding-window infrastructure
+  at :mod:`apps.workspace.scholar_app.middleware.rate_limit`. Per-IP
+  via the existing ``rate_limit`` decorator. PLUS a SECOND counter
+  keyed on the submitted username (5 attempts / 15 min) — defeats
+  credential-stuffing across IP-rotating botnets. Both must pass.
+- **Least-privilege scopes**. CLI route accepts ONLY
+  ``ALLOWED_CLI_SCOPES`` (currently ``{"publish"}``). UI-PAT flow is
+  unaffected (its scope set lives in the UI handler). A request asking
+  for ``api``/``admin``/``*`` is rejected 400 before the password is
+  ever checked.
+- **Constant-time error**. Wrong password and unknown username return
+  identical JSON bodies + comparable timing — :func:`authenticate`
+  intentionally hashes a dummy password on the unknown-user branch.
+- **No secret logging**. The structured log line carries ``{username,
+  ok}`` only — never the password, never the minted token.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Set
+
+from django.contrib.auth import authenticate
+from django.core.cache import cache
+from rest_framework import status
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+
+from apps.infra.accounts_app.models import APIKey
+from apps.workspace.scholar_app.middleware.rate_limit import (
+    get_client_ip,
+    rate_limit,
+)
+
+logger = logging.getLogger(__name__)
+
+#: The full set of scopes a CLI-issued token can carry. Hardcoded
+#: allowlist — NOT trust-the-client. UI-PATs may carry richer scopes
+#: but those flow through the existing
+#: :mod:`apps.infra.accounts_app.views.api_keys_views` UI handler, not
+#: this endpoint.
+ALLOWED_CLI_SCOPES: Set[str] = {"publish"}
+
+#: Per-username throttle (defense-in-depth on top of the per-IP
+#: ``@rate_limit`` decorator). Cap matches dev's 53b830f4 recommendation.
+_USERNAME_THROTTLE_WINDOW_SECONDS = 15 * 60  # 15 min
+_USERNAME_THROTTLE_LIMIT = 5
+
+#: Identical response body for every authentication failure (wrong
+#: password, unknown user, missing fields). Constant body + constant-time
+#: authenticate() blocks user-enumeration via either response-content
+#: comparison or response-timing.
+_AUTH_FAILED_BODY = {
+    "success": False,
+    "error": "Invalid credentials.",
+}
+
+
+def _username_throttle_key(username: str) -> str:
+    return f"ratelimit:account_token_mint:user:{username.lower()}"
+
+
+def _check_username_throttle(username: str) -> bool:
+    """Return True if the per-username throttle is NOT yet exhausted.
+
+    Same sliding-window pattern as the per-IP layer in
+    ``scholar_app.middleware.rate_limit.check_rate_limit`` — kept local
+    so this view's failure mode is independent of the scholar
+    endpoint's config.
+    """
+    if not username:
+        # Empty username never throttles by username (it'd be a global
+        # bucket); per-IP throttle still applies.
+        return True
+    cache_key = _username_throttle_key(username)
+    now = time.time()
+    window_start = now - _USERNAME_THROTTLE_WINDOW_SECONDS
+    window_data = cache.get(cache_key, [])
+    window_data = [ts for ts in window_data if ts > window_start]
+    is_allowed = len(window_data) < _USERNAME_THROTTLE_LIMIT
+    if is_allowed:
+        window_data.append(now)
+        cache.set(
+            cache_key,
+            window_data,
+            timeout=_USERNAME_THROTTLE_WINDOW_SECONDS + 10,
+        )
+    return is_allowed
+
+
+@api_view(["POST"])
+@authentication_classes([])  # explicit: this endpoint is unauthenticated by design
+@permission_classes([AllowAny])
+@rate_limit("account_token_mint")
+def api_me_token_mint(request):
+    """POST /api/me/token/ — mint a CLI APIKey from username+password.
+
+    Body::
+
+        {
+          "username": "...",
+          "password": "...",
+          "name": "scitex-hub-cli",      # optional, default "scitex-hub-cli"
+          "scopes": ["publish"]           # optional, default ["publish"]; MUST ⊆ ALLOWED_CLI_SCOPES
+        }
+
+    Returns 201 with ``{"success": true, "token": "scitex_…",
+    "prefix": "…", "scopes": [...], "expires_at": null}`` on success.
+    Returns 401 with the constant body on any authentication failure.
+    """
+    requested_scopes = list(request.data.get("scopes") or ["publish"])
+    # Validate scopes BEFORE checking password — the scope error is not
+    # a credential leak and surfacing it without a successful auth is
+    # safe (and helps a CLI user fix their request).
+    extra_scopes = set(requested_scopes) - ALLOWED_CLI_SCOPES
+    if extra_scopes:
+        return Response(
+            {
+                "success": False,
+                "error": (
+                    f"Scope not allowed for CLI-issued tokens: "
+                    f"{', '.join(sorted(extra_scopes))}. "
+                    f"Allowed: {', '.join(sorted(ALLOWED_CLI_SCOPES))}."
+                ),
+            },
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    username = (request.data.get("username") or "").strip()
+    password = request.data.get("password") or ""
+
+    # Per-username throttle (per-IP throttle handled by the decorator).
+    if not _check_username_throttle(username):
+        logger.warning(
+            "account_token_mint per-username throttle hit: username=%r ip=%s",
+            username,
+            get_client_ip(request),
+        )
+        return Response(
+            {
+                "success": False,
+                "error": "Too many attempts for this username. Try again later.",
+                "retry_after": _USERNAME_THROTTLE_WINDOW_SECONDS,
+            },
+            status=status.HTTP_429_TOO_MANY_REQUESTS,
+        )
+
+    # ``authenticate(username=...)`` hashes a dummy password on the
+    # unknown-username branch — this is the Django-stdlib mechanism that
+    # blocks user-enumeration via timing. Do NOT short-circuit on
+    # ``User.objects.filter(username=...).exists()`` before this.
+    user = authenticate(request, username=username, password=password)
+    if user is None or not user.is_active:
+        logger.info(
+            "account_token_mint failed: username=%r ok=False",
+            username,
+        )
+        return Response(_AUTH_FAILED_BODY, status=status.HTTP_401_UNAUTHORIZED)
+
+    name = (request.data.get("name") or "scitex-hub-cli").strip()[:100]
+    # The allowlist has already filtered ``requested_scopes`` above.
+    # Persist the verified list.
+    api_key_row, full_key = APIKey.create_key(
+        user=user,
+        name=name,
+        scopes=requested_scopes,
+    )
+    logger.info(
+        "account_token_mint ok: username=%r ok=True scopes=%s",
+        username,
+        requested_scopes,
+    )
+    return Response(
+        {
+            "success": True,
+            "token": full_key,
+            "prefix": api_key_row.key_prefix,
+            "name": api_key_row.name,
+            "scopes": list(api_key_row.scopes),
+            "expires_at": (
+                api_key_row.expires_at.isoformat() if api_key_row.expires_at else None
+            ),
+        },
+        status=status.HTTP_201_CREATED,
+    )
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def api_me_token_list(request):
+    """GET /api/me/token/ — list the authenticated user's APIKeys.
+
+    Returns a slim summary per row (NEVER the full token — that's
+    only returned at mint-time per APIKey design).
+    """
+    rows = APIKey.objects.filter(user=request.user).order_by("-created_at")
+    return Response(
+        {
+            "success": True,
+            "tokens": [
+                {
+                    "id": row.id,
+                    "name": row.name,
+                    "prefix": row.key_prefix,
+                    "scopes": list(row.scopes),
+                    "is_active": row.is_active,
+                    "created_at": row.created_at.isoformat(),
+                    "last_used_at": (
+                        row.last_used_at.isoformat() if row.last_used_at else None
+                    ),
+                    "expires_at": (
+                        row.expires_at.isoformat() if row.expires_at else None
+                    ),
+                }
+                for row in rows
+            ],
+        }
+    )
+
+
+@api_view(["DELETE"])
+@permission_classes([IsAuthenticated])
+def api_me_token_revoke(request, token_id: int):
+    """DELETE /api/me/token/<id>/ — revoke a single APIKey by id.
+
+    Owner-only: a user can only revoke their own tokens. Idempotent —
+    revoking an already-revoked token returns 204.
+    """
+    deleted, _ = APIKey.objects.filter(id=token_id, user=request.user).delete()
+    if deleted == 0:
+        return Response(
+            {"success": False, "error": "Token not found."},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+    return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+# EOF

--- a/apps/workspace/scholar_app/middleware/rate_limit.py
+++ b/apps/workspace/scholar_app/middleware/rate_limit.py
@@ -7,12 +7,13 @@ Rate limiting utilities for Scholar API endpoints.
 Provides sliding window rate limiting with Redis or in-memory fallback.
 """
 
-import time
 import logging
+import time
 from functools import wraps
-from django.http import JsonResponse
-from django.core.cache import cache
+
 from django.conf import settings
+from django.core.cache import cache
+from django.http import JsonResponse
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,12 @@ ENDPOINT_LIMITS = {
     "api_search_unified": {"requests": 60, "window": 60},  # 60/minute
     "api_search_crossref": {"requests": 30, "window": 60},  # CrossRef has strict limits
     "api_search_semantic": {"requests": 20, "window": 60},  # Semantic Scholar limits
+    # CLI account-token mint (POST /api/me/token/) — password-gated +
+    # per-IP throttle. The view layers a SECOND per-username counter
+    # to defeat credential-stuffing across IP rotation (defense in
+    # depth per dev's 53b830f4 spec). Tight cap because every miss
+    # costs the attacker a real bcrypt round on the server.
+    "account_token_mint": {"requests": 5, "window": 60},
 }
 
 

--- a/config/urls_api.py
+++ b/config/urls_api.py
@@ -13,6 +13,11 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from apps.infra.accounts_app.api.user_views import api_search_users
+from apps.infra.accounts_app.views.me_token_views import (
+    api_me_token_list,
+    api_me_token_mint,
+    api_me_token_revoke,
+)
 from apps.infra.integrations_app.views_events import list_events, receive_event
 from apps.infra.project_app.views import api_check_name_availability
 from apps.infra.project_app.views.projects.api import (
@@ -37,6 +42,25 @@ urlpatterns = [
     ),
     # User info
     path("me/", csrf_exempt(api_me), name="api_me"),
+    # User-scoped token management — browser-free token issuance for the
+    # operator-12909 CLI publish surface. POST mints (unauthenticated;
+    # password-gated + throttled), GET lists user's tokens (authenticated),
+    # DELETE revokes by id (authenticated, owner-only).
+    path(
+        "me/token/",
+        csrf_exempt(api_me_token_mint),
+        name="api_me_token_mint",
+    ),
+    path(
+        "me/tokens/",
+        csrf_exempt(api_me_token_list),
+        name="api_me_token_list",
+    ),
+    path(
+        "me/token/<int:token_id>/",
+        csrf_exempt(api_me_token_revoke),
+        name="api_me_token_revoke",
+    ),
     # Project management
     path(
         "project/create/",

--- a/tests/apps/accounts_app/test_me_token_endpoint.py
+++ b/tests/apps/accounts_app/test_me_token_endpoint.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""End-to-end security tests for ``/api/me/token/``.
+
+Phase-1 PR-3 of operator-12909's token+CLI surface. The endpoint mints
+a ``scitex_xxxx`` APIKey from a posted ``{username, password}`` so the
+CLI can ``scitex-hub account token create`` without a browser.
+
+Security review-hardening (lead msg db151d1 + dev msg 53b830f4 + dev
+msg 089bd6 — locked into hub-card #34 spec). These tests pin each
+invariant:
+
+1. ``test_wrong_password_returns_401`` — wrong password → 401.
+2. ``test_right_password_returns_token_and_least_priv_scope`` — right
+   password → 201 with the token in body AND scope ⊆ {"publish"}.
+3. ``test_minted_token_works_on_an_authenticated_endpoint`` — proves
+   the returned token is the actual credential (round-trip).
+4. ``test_constant_time_error_body_equality`` — wrong password and
+   unknown username return BYTE-IDENTICAL bodies. This is the HARD
+   anti-enumeration invariant per dev's 089bd6 refinement (the soft
+   timing-median test lives in a manual benchmark script, not CI —
+   see the runbook).
+5. ``test_rate_limit_engagement_per_ip`` — 6th attempt within the
+   per-IP window returns 429.
+6. ``test_per_username_throttle_engages_across_ips`` — 6 attempts to
+   the SAME username from DIFFERENT IPs within the per-username
+   window returns 429 on the 6th. Defense-in-depth against
+   credential-stuffing.
+7. ``test_scope_allowlist_rejects_admin_scope`` — POST with
+   ``scopes: ["api", "publish", "admin"]`` returns 400 NOT 201.
+   Proves the server-side allowlist beats client trust.
+8. ``test_logging_audit_excludes_password_and_token`` — captured log
+   records do NOT contain the password substring NOR the minted token
+   substring (only ``{username, ok}``). Turns the no-secret-logging
+   grep-denylist into a permanent CI gate.
+
+All tests use real Django ``Client`` + real DB (``@pytest.mark.django_db``)
++ real ``User.objects.create_user`` + real ``cache.clear()`` between
+tests. NO mocks, NO monkeypatch.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Tuple
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import Client
+
+
+@pytest.fixture(autouse=True)
+def _clear_rate_limit_cache():
+    """Reset the shared rate-limit cache between tests so per-IP and
+    per-username buckets from one test don't bleed into the next."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _make_user(username: str = "alice", password: str = "pw-fixture") -> User:
+    return User.objects.create_user(
+        username=username, email=f"{username}@example.com", password=password
+    )
+
+
+def _post_mint(
+    client: Client,
+    username: str,
+    password: str,
+    *,
+    scopes=None,
+    remote_addr: str = "10.0.0.1",
+) -> Tuple[int, dict]:
+    body = {"username": username, "password": password}
+    if scopes is not None:
+        body["scopes"] = scopes
+    response = client.post(
+        "/api/me/token/",
+        data=body,
+        content_type="application/json",
+        REMOTE_ADDR=remote_addr,
+    )
+    try:
+        return response.status_code, response.json()
+    except ValueError:
+        return response.status_code, {}
+
+
+# ---------------------------------------------------------------------
+# (1) wrong password → 401
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_wrong_password_returns_401():
+    # Arrange
+    _make_user("wrongpw-user", "secret-password")
+
+    # Act
+    status_code, _body = _post_mint(Client(), "wrongpw-user", "WRONG")
+
+    # Assert
+    assert status_code == 401
+
+
+# ---------------------------------------------------------------------
+# (2) right password → 201 + token + scope ⊆ {"publish"}
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_right_password_returns_token_and_least_priv_scope():
+    # Arrange
+    _make_user("rightpw-user", "pw-fixture")
+
+    # Act
+    status_code, body = _post_mint(Client(), "rightpw-user", "pw-fixture")
+
+    # Assert
+    assert status_code == 201 and set(body["scopes"]) <= {"publish"}
+
+
+# ---------------------------------------------------------------------
+# (3) the minted token actually authenticates a downstream request
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_minted_token_works_on_an_authenticated_endpoint():
+    # Arrange
+    _make_user("roundtrip-user", "pw-fixture")
+    _status, body = _post_mint(Client(), "roundtrip-user", "pw-fixture")
+    minted = body["token"]
+
+    # Act
+    me_response = Client().get("/api/me/", HTTP_AUTHORIZATION=f"Bearer {minted}")
+
+    # Assert
+    assert me_response.status_code == 200
+
+
+# ---------------------------------------------------------------------
+# (4) constant-time error body: wrong-pw == unknown-user (HARD invariant)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_constant_time_error_body_equality():
+    # Arrange
+    _make_user("alice", "pw-fixture")
+
+    # Act
+    _wrong_status, body_wrong_pw = _post_mint(Client(), "alice", "WRONG")
+    _unknown_status, body_unknown_user = _post_mint(
+        Client(), "noway-such-user", "ANYTHING"
+    )
+
+    # Assert
+    assert body_wrong_pw == body_unknown_user
+
+
+# ---------------------------------------------------------------------
+# (5) per-IP throttle engages
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_rate_limit_engagement_per_ip():
+    # Arrange
+    _make_user("rate-target", "pw-fixture")
+    client = Client()
+
+    # Act — burn the per-IP budget (5/minute per ENDPOINT_LIMITS) with
+    # wrong-password attempts from the SAME IP, then probe one more.
+    for _ in range(5):
+        _post_mint(client, "rate-target", "WRONG", remote_addr="10.0.0.99")
+    status_code, _ = _post_mint(client, "rate-target", "WRONG", remote_addr="10.0.0.99")
+
+    # Assert
+    assert status_code == 429
+
+
+# ---------------------------------------------------------------------
+# (6) per-username throttle engages across DIFFERENT IPs
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_per_username_throttle_engages_across_ips():
+    # Arrange
+    _make_user("victim", "pw-fixture")
+    client = Client()
+
+    # Act — 5 attempts spread across 5 distinct IPs to defeat the
+    # per-IP throttle (each IP gets 1 hit; per-IP threshold is 5),
+    # then a 6th from a 6th IP. The per-username counter (5 across all
+    # IPs over 15 min) should fire on the 6th.
+    for i in range(5):
+        _post_mint(client, "victim", "WRONG", remote_addr=f"10.0.{i}.1")
+    status_code, _ = _post_mint(client, "victim", "WRONG", remote_addr="10.0.99.1")
+
+    # Assert
+    assert status_code == 429
+
+
+# ---------------------------------------------------------------------
+# (7) scope-allowlist rejects admin scope at the auth layer
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_scope_allowlist_rejects_admin_scope():
+    # Arrange
+    _make_user("scope-test", "pw-fixture")
+
+    # Act
+    status_code, _body = _post_mint(
+        Client(),
+        "scope-test",
+        "pw-fixture",
+        scopes=["api", "publish", "admin"],
+    )
+
+    # Assert — server-side allowlist beats client trust. 400, not 201.
+    assert status_code == 400
+
+
+# ---------------------------------------------------------------------
+# (8) logging audit — no password / no token in log records
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_logging_audit_excludes_password_and_token(caplog):
+    # Arrange
+    canary_password = "canary-pw-must-never-appear-9z3kq"  # pragma: allowlist secret
+    _make_user("log-audit", canary_password)
+    caplog.set_level(
+        logging.DEBUG, logger="apps.infra.accounts_app.views.me_token_views"
+    )
+
+    # Act — one successful + one failed mint, covering the OK and
+    # !OK arms of the log call.
+    _status1, body = _post_mint(Client(), "log-audit", canary_password)
+    minted_token = body["token"]
+    _post_mint(Client(), "log-audit", "WRONG")
+
+    # Assert
+    captured = "\n".join(record.getMessage() for record in caplog.records)
+    assert canary_password not in captured and minted_token not in captured
+
+
+# EOF


### PR DESCRIPTION
## Summary

Phase-1 PR-3 of operator-12909's token+CLI surface. The endpoint that lets \`scitex-hub account token create\` mint a \`scitex_xxxx\` APIKey from a posted \`{username, password}\` — no browser, no JWT chicken-and-egg.

- \`POST /api/me/token/\` — mint (unauth, password-gated, throttled)
- \`GET /api/me/tokens/\` — list user's tokens (JWT/APIKey-auth)
- \`DELETE /api/me/token/<id>/\` — revoke by id (owner-only, idempotent)

## Security review-hardening (lead db151d1 + dev 53b830f4 + dev 089bd6)

- **Rate-limit via EXISTING Redis sliding-window** (\`scholar_app.middleware.rate_limit\`). Registered \`account_token_mint\` ENDPOINT_LIMITS entry: 5/60s per IP. **Plus a SECOND counter keyed on the submitted username** (5/15min) — defeats credential-stuffing across IP rotation.
- **Least-privilege scope**: server-side allowlist \`ALLOWED_CLI_SCOPES = {"publish"}\`. Validated BEFORE password check. Asking for \`api\`/\`admin\` → 400, not 201.
- **Constant-time error**: wrong password and unknown user return byte-identical bodies. \`django.contrib.auth.authenticate()\` hashes a dummy password on unknown-username — stdlib mechanism blocks timing-based enumeration.
- **No secret logging**: structured log carries \`{username, ok}\` only. Test 8 turns the grep-denylist into a permanent CI gate.

## 8 no-mock tests (real DB + real Client)

1. Wrong password → 401
2. Right password → 201 + token + scope ⊆ {"publish"}
3. Minted token round-trips through \`GET /api/me/\` (proves it's a real credential, not a placeholder)
4. Constant-time body equality: wrong-pw == unknown-user (HARD anti-enumeration invariant per dev's 089bd6 dual-tier; soft timing-median lives in a manual benchmark)
5. Per-IP throttle engages on the 6th attempt
6. Per-username throttle engages across DIFFERENT IPs (defense-in-depth)
7. Scope allowlist rejects \`["api","publish","admin"]\` with 400 NOT 201
8. Logging audit — captured log records contain NEITHER the password substring NOR the minted token substring

## Family / Phase-1

After: PR #272 (APIKEY-AUTH wires \`scitex_xxxx\` into DRF). Unblocks: Phase-1 PR-4 (\`scitex-hub account token create/list/revoke\` CLI per dev's grammar).

Self-merge on CI green.