### PR TITLE
fix(console): PTY chdir to workspace project root, fall back to HOME

### DIFF
--- a/apps/workspace/console_app/services/terminal_broker/_handlers_shared.py
+++ b/apps/workspace/console_app/services/terminal_broker/_handlers_shared.py
@@ -198,7 +198,12 @@ def handle_spawn_shared(broker, msg: dict, client: socket.socket) -> dict:
                 "error": "Environment startup timed out, please retry",
             }
 
-    # 3. Spawn shell inside allocation
+    # 3. Spawn shell inside allocation. Resolve broker-visible project_dir so
+    # BasePTY chdirs to the project root before fork (falls back to HOME → /tmp
+    # if the path is missing, e.g. first-time user — no silent swallow).
+    from apps.workspace.console_app.views.terminal.config import USER_DATA_ROOT
+
+    broker_project_dir = USER_DATA_ROOT / username / "proj" / project_slug
     shell_id = str(uuid.uuid4())
     shell = Shell(
         shell_id=shell_id,
@@ -206,6 +211,7 @@ def handle_spawn_shared(broker, msg: dict, client: socket.socket) -> dict:
         username=username,
         screen_session=screen_session,
         command=alloc.get_shell_command(project_slug=project_slug),
+        project_dir=broker_project_dir,
     )
 
     if not shell.spawn():

--- a/apps/workspace/console_app/services/terminal_broker/session.py
+++ b/apps/workspace/console_app/services/terminal_broker/session.py
@@ -36,10 +36,24 @@ class SessionState(enum.Enum):
 class BasePTY:
     """Common PTY lifecycle: fork, read, write, resize, cleanup, respawn."""
 
-    def __init__(self, pty_id: str, username: str, screen_session: str = "scitex-0"):
+    def __init__(
+        self,
+        pty_id: str,
+        username: str,
+        screen_session: str = "scitex-0",
+        project_dir: Optional[Path] = None,
+    ):
         self.pty_id = pty_id
         self.username = username
         self.screen_session = screen_session
+        # When the PTY is launched from a workspace project, ``project_dir``
+        # is the broker-visible (Docker-side) path to that project so the
+        # parent ``os.chdir`` lands the pre-fork cwd on the project root.
+        # Caller is responsible for passing a path that exists in the
+        # broker's filesystem (e.g. ``USER_DATA_ROOT/<user>/proj/<slug>``);
+        # if it does not exist at fork time, ``_prepare_child_env`` falls
+        # back to ``HOME`` then ``/tmp`` (same escalation as PR #246).
+        self.project_dir: Optional[Path] = project_dir
         self.pid: Optional[int] = None
         self.fd: Optional[int] = None
         self.state = SessionState.DEAD
@@ -143,10 +157,29 @@ class BasePTY:
         env["LOGNAME"] = self.username
         env["TERM"] = "xterm-256color"
         env["SHELL"] = "/bin/bash"
-        # chdir to HOME so the host-side bash prompt (PS1 \w) shows the
-        # user's home rather than "tmp". For broker shells, apptainer's
-        # --pwd flag overrides this inside the container. Fall back to
-        # /tmp if HOME does not exist on the host (broker container).
+        # chdir order (host-side bash PS1 \w, plus the cwd srun inherits):
+        #   1. self.project_dir — the workspace project root, when set and
+        #      reachable by the broker process. This makes the prompt land
+        #      on the user's project instead of bare $HOME.
+        #   2. env["HOME"] — same fallback as PR #246, used when no project
+        #      context is plumbed through (e.g. legacy callers) or when the
+        #      project_dir does not exist in the broker filesystem yet.
+        #   3. "/tmp" — last-ditch safety so we never raise out of
+        #      _prepare_child_env (the apptainer ``--pwd`` flag fixes the
+        #      in-container cwd regardless).
+        # OSError from a missing/unreadable dir is the documented signal to
+        # escalate to the next candidate; it is not a silent error swallow.
+        if self.project_dir is not None:
+            try:
+                os.chdir(str(self.project_dir))
+                return env
+            except OSError as exc:
+                logger.debug(
+                    "PTY %s: project_dir %s not chdir-able (%s); falling back to HOME",
+                    self.pty_id[:8],
+                    self.project_dir,
+                    exc,
+                )
         try:
             os.chdir(env["HOME"])
         except OSError:

--- a/apps/workspace/console_app/services/terminal_broker/shell.py
+++ b/apps/workspace/console_app/services/terminal_broker/shell.py
@@ -8,6 +8,7 @@ Inherits all PTY lifecycle from ``BasePTY``.  The only difference from
 import os
 import socket
 import sys
+from pathlib import Path
 from typing import Optional
 
 from .session import BasePTY
@@ -25,9 +26,13 @@ class Shell(BasePTY):
         username: str,
         screen_session: str,
         command: list[str],
+        project_dir: Optional[Path] = None,
     ):
         super().__init__(
-            pty_id=shell_id, username=username, screen_session=screen_session
+            pty_id=shell_id,
+            username=username,
+            screen_session=screen_session,
+            project_dir=project_dir,
         )
         self.shell_id = shell_id
         self.allocation_id = allocation_id

--- a/tests/apps/console_app/services/terminal_broker/test_session_project_dir_chdir.py
+++ b/tests/apps/console_app/services/terminal_broker/test_session_project_dir_chdir.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for BasePTY project_dir chdir resolution (no mocks; real fs).
+
+Background: PR #246 fixed the host-side PTY chdir from hardcoded ``/tmp``
+to ``HOME``. This module locks in the follow-up behaviour: when the
+broker knows the workspace project root, the parent ``os.chdir`` lands
+on that project dir (so bash PS1 \\w shows the project, not bare $HOME),
+with a documented escalation to HOME and finally ``/tmp``.
+
+All tests run real ``os.chdir`` against real ``tmp_path`` directories; a
+``restore_cwd`` yield fixture snapshots and resets the working directory
+around each test so a failure does not leak into siblings.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from apps.workspace.console_app.services.terminal_broker.session import BasePTY
+
+
+@pytest.fixture
+def restore_cwd():
+    """Snapshot and restore CWD so a failing chdir does not leak."""
+    # Arrange
+    saved = os.getcwd()
+    # Act
+    yield
+    # Assert
+    try:
+        os.chdir(saved)
+    except OSError:
+        os.chdir("/tmp")
+
+
+class TestBasePTYProjectDirAttribute:
+    """The new project_dir attribute is plumbed through __init__."""
+
+    def test_basepty_default_project_dir_is_none(self):
+        # Arrange
+        pty_id = "test-pty-1"
+        username = "alice"
+        # Act
+        pty = BasePTY(pty_id=pty_id, username=username)
+        # Assert
+        assert pty.project_dir is None
+
+    def test_basepty_stores_project_dir_when_provided(self, tmp_path: Path):
+        # Arrange
+        project_dir = tmp_path / "proj" / "myproj"
+        project_dir.mkdir(parents=True)
+        # Act
+        pty = BasePTY(
+            pty_id="test-pty-2",
+            username="alice",
+            project_dir=project_dir,
+        )
+        # Assert
+        assert pty.project_dir == project_dir
+
+
+class TestBasePTYChdirToProjectDir:
+    """_prepare_child_env chdirs into project_dir when it is set and exists."""
+
+    def test_chdir_lands_on_project_dir_when_set_and_exists(
+        self, tmp_path: Path, restore_cwd
+    ):
+        # Arrange
+        project_dir = tmp_path / "alice" / "proj" / "myproj"
+        project_dir.mkdir(parents=True)
+        pty = BasePTY(
+            pty_id="test-pty-3",
+            username="alice",
+            project_dir=project_dir,
+        )
+        # Act
+        pty._prepare_child_env()
+        # Assert
+        assert Path(os.getcwd()).resolve() == project_dir.resolve()
+
+
+class TestBasePTYChdirFallbackWhenProjectDirMissing:
+    """When project_dir does not exist, escalation moves cwd off it."""
+
+    def test_chdir_escalates_off_missing_project_dir(self, tmp_path: Path, restore_cwd):
+        # Arrange
+        missing_project_dir = tmp_path / "does" / "not" / "exist"
+        username = "scitex-test-missing-proj-{}".format(os.getpid())
+        pty = BasePTY(
+            pty_id="test-pty-4",
+            username=username,
+            project_dir=missing_project_dir,
+        )
+        os.chdir(str(tmp_path))
+        # Act
+        pty._prepare_child_env()
+        # Assert
+        # The missing project_dir must NOT be where we ended up — the
+        # escalation moved us off it (to HOME or /tmp).
+        assert Path(os.getcwd()).resolve() != missing_project_dir.resolve()
+
+
+class TestBasePTYChdirFallbackWhenProjectDirNone:
+    """When project_dir is None, we leave the caller's starting cwd."""
+
+    def test_chdir_does_not_stay_on_caller_cwd_when_project_dir_none(
+        self, tmp_path: Path, restore_cwd
+    ):
+        # Arrange
+        # Use a username unlikely to have /home/<u> on the runner so the
+        # HOME chdir will fail and tip the resolver into /tmp; either
+        # way we should NOT still be sitting on tmp_path.
+        username = "scitex-test-no-home-{}".format(os.getpid())
+        pty = BasePTY(
+            pty_id="test-pty-5",
+            username=username,
+            project_dir=None,
+        )
+        os.chdir(str(tmp_path))
+        # Act
+        pty._prepare_child_env()
+        # Assert
+        assert Path(os.getcwd()).resolve() != tmp_path.resolve()
+
+
+class TestBasePTYChdirFallbackToTmp:
+    """When project_dir and HOME are both missing, /tmp is the floor."""
+
+    def test_chdir_lands_on_tmp_when_project_dir_and_home_missing(
+        self, tmp_path: Path, restore_cwd
+    ):
+        # Arrange
+        missing_project_dir = tmp_path / "no" / "such" / "project"
+        username = "scitex-test-fallback-{}".format(os.getpid())
+        pty = BasePTY(
+            pty_id="test-pty-6",
+            username=username,
+            project_dir=missing_project_dir,
+        )
+        os.chdir(str(tmp_path))
+        # Act
+        pty._prepare_child_env()
+        # Assert
+        assert Path(os.getcwd()).resolve() == Path("/tmp").resolve()
+
+
+# EOF


### PR DESCRIPTION
## Summary

Follow-up to PR #246. That PR moved the BasePTY chdir from a hardcoded `/tmp` to `env["HOME"]` so the host-side bash prompt (`PS1 \w`) no longer showed `tmp $` at console open. It explicitly deferred plumbing `project_slug` through `BasePTY`, calling it "a 4-file diff for cosmetic gain". The operator asked for that next step: when a workspace project is known, the parent `os.chdir` should land on the project root before the PTY fork, so the in-host prompt (and the cwd `srun` inherits) reflects the project the user is opening — matching what apptainer's `--pwd` already does inside the container.

| Commit | Scope |
|---|---|
| 1. `fix(console): PTY chdir to workspace project root, fall back to HOME` | `session.py` + `shell.py` + `_handlers_shared.py` plumb an optional `project_dir: Path \| None` from the Shell call site through `BasePTY`. New chdir order: `project_dir → HOME → /tmp` with documented OSError escalation (no silent swallow). |

## Why

- `BasePTY._prepare_child_env()` runs in the broker process, just before `pty.fork()`. The PTY child inherits cwd. Whatever the broker chdirs to is what bash sees as `\w` and what `srun` inherits as its default working dir.
- The workspace consumer (`broker_spawn.py`) already knows `username` + `project_slug` when it spawns a shell. The Shell call site can compute `USER_DATA_ROOT / username / "proj" / project_slug` — the broker-visible mount of the same volume `srun` sees as `SLURM_USER_DATA_ROOT`. Pass that to Shell, plumb it to `BasePTY`, and the parent `os.chdir` lands on the project root before fork.
- `Shell._prepare_child_env` already overrides `HOME` for apptainer's instance-database lookup; the chdir happens in `super()._prepare_child_env`, which now honors `project_dir`. apptainer's `--pwd` continues to handle the in-container cwd.

## Files touched

- `apps/workspace/console_app/services/terminal_broker/session.py` — `BasePTY.__init__` takes `project_dir`; `_prepare_child_env` walks the chdir chain.
- `apps/workspace/console_app/services/terminal_broker/shell.py` — `Shell.__init__` accepts `project_dir` and forwards to `super()`.
- `apps/workspace/console_app/services/terminal_broker/_handlers_shared.py` — Shell call site resolves `broker_project_dir = USER_DATA_ROOT / username / "proj" / project_slug` and passes it in.
- `tests/apps/console_app/services/terminal_broker/test_session_project_dir_chdir.py` — real-filesystem unit tests (no mock library, per repo rule STX-NM001).

`TerminalSession` (the legacy one-srun-per-tab class) is intentionally untouched: it already receives a slurm-host `project_dir` that is NOT visible inside the broker Docker, so the chdir would OSError and fall back to HOME — i.e. identical to today's behaviour. Plumbing TerminalSession to a broker-visible path would expand scope without changing observable behaviour for that legacy mode.

## Tests

- [x] New: `test_session_project_dir_chdir.py` — 6 tests, all real `os.chdir` against `tmp_path`:
  - default `project_dir` is None
  - `project_dir` stored when provided
  - chdir lands on `project_dir` when set and exists
  - escalates off `project_dir` when missing
  - escalates off caller cwd when `project_dir` is None
  - lands on `/tmp` when both `project_dir` and HOME are missing
- [x] Local hand-verification of the BasePTY logic (4/4 PASS) — covered all chdir branches without Django apps loaded.
- [ ] Full pytest matrix in CI (this repo's pytest needs the full Django app environment; locally it cannot load due to missing optional packages).

## Blast radius

- Code path: only the broker process's pre-fork `os.chdir`. apptainer `--pwd` still drives the in-container cwd.
- Failure mode if `broker_project_dir` doesn't exist (first-time user, race with workspace provisioning): documented escalation to HOME → `/tmp`. Same end behaviour as PR #246 with one extra debug log.
- No new syscalls per spawn; one extra `chdir` attempt at most.
- No changes to TerminalSession, allocation, slurm command builders, or in-container shell logic.

## Refs

- PR #246 (commit `36d2698a6`) — the HOME fallback this builds on, including the original "4-file diff for cosmetic gain" rationale this PR delivers on.
- `session.py:160-187` — chdir escalation comment block.
- Operator request: workspace-aware chdir so the prompt opens on the project, not bare `$HOME`.
