### PR TITLE
fix(broker): hotfix #275 ImportError — USER_DATA_ROOT via settings, not stubbed config

### DIFF
--- a/apps/workspace/console_app/services/terminal_broker/_handlers_shared.py
+++ b/apps/workspace/console_app/services/terminal_broker/_handlers_shared.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from apps.workspace.console_app.views.terminal.config import SLURM_TIME_LIMIT_SECONDS
 
 from ._handler_utils import respawn_pty, send_state
+from ._paths import broker_user_data_root
 from .allocation import Allocation, AllocationState
 from .session import SessionState
 from .shell import MAX_RESPAWNS as SHELL_MAX_RESPAWNS
@@ -201,9 +202,7 @@ def handle_spawn_shared(broker, msg: dict, client: socket.socket) -> dict:
     # 3. Spawn shell inside allocation. Resolve broker-visible project_dir so
     # BasePTY chdirs to the project root before fork (falls back to HOME → /tmp
     # if the path is missing, e.g. first-time user — no silent swallow).
-    from apps.workspace.console_app.views.terminal.config import USER_DATA_ROOT
-
-    broker_project_dir = USER_DATA_ROOT / username / "proj" / project_slug
+    broker_project_dir = broker_user_data_root() / username / "proj" / project_slug
     shell_id = str(uuid.uuid4())
     shell = Shell(
         shell_id=shell_id,

--- a/apps/workspace/console_app/services/terminal_broker/_paths.py
+++ b/apps/workspace/console_app/services/terminal_broker/_paths.py
@@ -1,0 +1,33 @@
+"""Broker-side data-dir paths used by terminal_broker handlers.
+
+Defined here, not re-imported from ``apps/workspace/console_app/views/
+terminal/config``, because the views.terminal.config module gets a
+sys.modules stub installed by
+``tests/apps/console_app/views/terminal/test_execution.py`` (sibling
+tests leave that stub in place across the whole session). A function-
+local import of ``USER_DATA_ROOT`` from views/terminal/config in
+``_handlers_shared.handle_spawn_shared`` therefore hit ImportError under
+test once PR #275 introduced it (caught by lead's pytest-matrix verify
+on 2026-06-13 → develop hotfix PR #276).
+
+Production behaviour mirrors views/terminal/config.py exactly: if
+``settings.USER_DATA_ROOT`` is set (via env var
+``SCITEX_HUB_USER_DATA_ROOT``), it wins; otherwise the canonical
+Docker-internal mount path ``/app/data/users`` is used. No silent
+fallback — the documented default is the same value the production
+container already pins.
+"""
+
+from pathlib import Path
+
+from django.conf import settings
+
+#: Docker-internal data-dir mount baked into the production image.
+_BROKER_USER_DATA_ROOT_DEFAULT = Path("/app/data/users")
+
+
+def broker_user_data_root() -> Path:
+    """Return the broker Docker-internal root of the user-data mount."""
+    return Path(
+        getattr(settings, "USER_DATA_ROOT", None) or _BROKER_USER_DATA_ROOT_DEFAULT
+    )


### PR DESCRIPTION
## Summary

Develop-hotfix for the `ImportError: cannot import name 'USER_DATA_ROOT' from 'apps.workspace.console_app.views.terminal.config'` regression that PR #275 (`fix(console): PTY chdir to workspace project root, fall back to HOME`) landed into develop @ d85f94fe6.

PR #275 added a function-local
\`from apps.workspace.console_app.views.terminal.config import USER_DATA_ROOT\`
inside \`handle_spawn_shared\`. That symbol is missing from the sys.modules stub installed by \`tests/apps/console_app/views/terminal/test_execution.py\` (the stub is intentionally left in place for the rest of the pytest session — sibling tests rely on it). The late import therefore raised ImportError in
\`tests/apps/console_app/services/terminal_broker/test_handlers_shared.py::TestAllocationKeyPerUser::test_same_user_different_projects_share_allocation\`,
which now red-bars **every** hub PR's pytest-matrix-on-ubuntu-py3.{11,12,13} (verified on PR #274 run 27460197158).

## Fix

Lift the broker-side USER_DATA_ROOT resolution into a new \`_paths.broker_user_data_root()\` helper that reads \`django.conf.settings\` directly. The new module is fresh — no test stub intercepts it — so \`_handlers_shared\` no longer pulls the symbol off views.terminal.config.

Semantics unchanged: same \`settings.USER_DATA_ROOT or "/app/data/users"\` default that \`views/terminal/config.py\` documents. Same Docker mount path, same env-var override, no silent fallback.

## Files

- NEW \`apps/workspace/console_app/services/terminal_broker/_paths.py\` (36 lines, broker-internal paths module)
- MOD \`apps/workspace/console_app/services/terminal_broker/_handlers_shared.py\` (-3 / +2 net, removes the function-local import, uses the new helper)

## Test plan

- [x] handle_spawn_shared no longer raises ImportError when \`views.terminal.config\` is the test_execution stub
- [x] views/terminal/config.py production lookup is unchanged (still \`settings.USER_DATA_ROOT or "/app/data/users"\`)
- [x] No skip_rules, no \`# stx-allow:\`, no silent fallback

## Why this is the hotfix path

The alternative — patching the stub in \`tests/apps/console_app/views/terminal/test_execution.py\` — was rejected by the project lint hooks (the file is pre-existing 60+ STX-NM violations). Decoupling \`_handlers_shared\` from \`views.terminal.config\` is also a cleaner production design — the broker handler should not depend on a views-layer module just to read a settings constant.

Self-merge on CI green per the operator's "develop-breaker first" directive (2026-06-13 lead msg 2c70654d).