### PR TITLE
test(apps_app): fix loud-logging guards (DRF-wrapper false-fail) — pytest-matrix gate

### DIFF
--- a/tests/apps/apps_app/views/test_api_registry_loud_logging.py
+++ b/tests/apps/apps_app/views/test_api_registry_loud_logging.py
@@ -32,9 +32,17 @@ def _read_function_source(func) -> str:
 
 def test_api_submit_jwt_body_is_wrapped_in_try_except_logger_exception():
     # Arrange
+    # NOTE: we read the on-disk file rather than inspect.getsource() on the
+    # imported view. ``api_submit_jwt`` is wrapped by DRF's ``@api_view``
+    # decorator, which returns a ``WrappedAPIView`` callable. On Python 3.11+
+    # ``inspect.getsource`` of that wrapped object returns only the decorator
+    # wrapper body (no ``try:`` / ``except Exception:`` lines), so the
+    # ``in src`` guards never see the wrap that IS in the file. Reading the
+    # file via ``_read_function_source`` (already defined above for exactly
+    # this purpose) preserves the source-text-guard intent.
     from apps.workspace.apps_app.views.api_registry import api_submit_jwt
 
-    src = inspect.getsource(api_submit_jwt)
+    src = _read_function_source(api_submit_jwt)
 
     # Act
     has_try_block = "    try:" in src
@@ -51,10 +59,10 @@ def test_api_submit_jwt_body_is_wrapped_in_try_except_logger_exception():
 
 
 def test_api_submit_jwt_logs_at_least_username_and_project_name():
-    # Arrange
+    # Arrange — same DRF-wrapper bypass as above: read the file directly.
     from apps.workspace.apps_app.views.api_registry import api_submit_jwt
 
-    src = inspect.getsource(api_submit_jwt)
+    src = _read_function_source(api_submit_jwt)
 
     # Act
     # The log call must include enough context to correlate a 500 with


### PR DESCRIPTION
## Summary

- `test_api_registry_loud_logging` was using `inspect.getsource(api_submit_jwt)` on a DRF-wrapped view (`@api_view` returns `WrappedAPIView`), so the source-text guards were checking the decorator's wrapper body, not the actual function source. The wrap is in the file but the test never saw it, so both tests have been red on every pytest-matrix run since PR #271 landed.
- This is one of the broken pieces lead identified in the pytest-matrix-gate-fix card #0: real failures hiding behind infra / test-mechanics noise, leading to admin-merges like #275 / #276.
- Fix: switch both tests to `_read_function_source(api_submit_jwt)` — a helper already defined in the file for exactly this case — which reads the on-disk source directly and survives DRF's wrap.

## What's NOT in this PR (intentional)

- The 7 API-key auth contract failures (`test_apikey_authentication.py` + `test_me_token_endpoint.py`) — separate workstream, parent is on this.
- The useradd / chown warnings in the test log are red herrings: those tests actually pass (they mock `subprocess.run`); the warnings are just the logger emission from the deliberate error-path simulation.

## Test plan

- [ ] CI: pytest-matrix-on-ubuntu-py3.{11,12,13} — the 2 loud-logging FAILED entries should drop off the failure list (leaving the 7 API-key ones for the parent's lane).
- [ ] Local: `pytest tests/apps/apps_app/views/test_api_registry_loud_logging.py -v`.
