### PR TITLE
chore(cli): hub-audit-cli-pass — gitea noun group conformance (1 of N)

### DIFF
--- a/src/scitex_hub/_cli/_gitea_auth.py
+++ b/src/scitex_hub/_cli/_gitea_auth.py
@@ -126,6 +126,11 @@ def login(url, token, user, password, name):
 
     The Gitea URL is auto-detected from SCITEX_HUB_GITEA_URL_DEV env var
     or SECRET/.env.dev file. Override with --url.
+
+    \b
+    Example:
+      $ scitex-hub gitea login --token "$SCITEX_HUB_GITEA_TOKEN"
+      $ scitex-hub gitea login --user alice --password "$PW"
     """
     from ._gitea_utils import get_gitea_url
 
@@ -196,6 +201,11 @@ def logout(name, url, user, password, delete_token):
     the API token on the Gitea server. In that mode, password is required
     non-interactively via --password or SCITEX_HUB_GITEA_PASSWORD
     (fail-fast with exit code 2 if missing — no prompt, spec §2).
+
+    \b
+    Example:
+      $ scitex-hub gitea logout
+      $ scitex-hub gitea logout --delete-token --user alice
     """
     if delete_token:
         # Try to pull connection details from tea config if not given

--- a/src/scitex_hub/_cli/_gitea_collab.py
+++ b/src/scitex_hub/_cli/_gitea_collab.py
@@ -10,6 +10,14 @@ import time
 import click
 import requests
 
+from ._flags import (
+    confirm_or_abort,
+    dry_run_flag,
+    emit_json,
+    json_flag,
+    mutating_flags,
+    print_dry_run,
+)
 from ._gitea_utils import ensure_gitea_remote, ensure_not_in_workspace, run_tea
 
 # ---------------------------------------------------------------------------
@@ -28,8 +36,24 @@ def pr():
 @click.option("--description", "-d", help="PR description")
 @click.option("--base", "-b", default="main", help="Base branch")
 @click.option("--head", "-h", help="Head branch")
-def pr_create(title, description, base, head):
-    """Create a pull request"""
+@mutating_flags()
+def pr_create(title, description, base, head, dry_run, yes):
+    """Create a pull request.
+
+    \b
+    Example:
+      $ scitex-hub gitea pr create --title "Fix audit" --base develop --yes
+      $ scitex-hub gitea pr create -t "WIP" --dry-run
+    """
+    if dry_run:
+        print_dry_run(
+            f"open pull request '{title or '<no title>'}' "
+            f"({head or 'current'} -> {base})"
+        )
+        return
+    confirm_or_abort(
+        f"Open pull request '{title or '<no title>'}'?", yes=yes, dry_run=dry_run
+    )
     args = ["pr", "create"]
     if title:
         args.extend(["--title", title])
@@ -43,8 +67,37 @@ def pr_create(title, description, base, head):
 
 
 @pr.command(name="list")
-def pr_list():
-    """List pull requests"""
+@json_flag()
+def pr_list(json_output):
+    """List pull requests.
+
+    \b
+    Example:
+      $ scitex-hub gitea pr list
+      $ scitex-hub gitea pr list --json
+    """
+    if json_output:
+        try:
+            from pathlib import Path
+
+            tea_bin = str(Path.home() / ".local" / "bin" / "tea")
+            result = subprocess.run(
+                [tea_bin, "pr", "list", "--output", "json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            import json as _json
+
+            try:
+                payload = _json.loads(result.stdout or "[]")
+            except _json.JSONDecodeError:
+                payload = {"raw": result.stdout}
+            emit_json(payload)
+        except subprocess.CalledProcessError as e:
+            emit_json({"error": str(e), "stderr": e.stderr})
+            sys.exit(1)
+        return
     run_tea("pr", "list")
 
 
@@ -62,8 +115,19 @@ def issue():
 @issue.command(name="create")
 @click.option("--title", "-t", required=True, help="Issue title")
 @click.option("--body", "-b", help="Issue body")
-def issue_create(title, body):
-    """Create an issue"""
+@mutating_flags()
+def issue_create(title, body, dry_run, yes):
+    """Create an issue.
+
+    \b
+    Example:
+      $ scitex-hub gitea issue create --title "Bug X" --yes
+      $ scitex-hub gitea issue create -t "Audit follow-up" --dry-run
+    """
+    if dry_run:
+        print_dry_run(f"open issue '{title}'")
+        return
+    confirm_or_abort(f"Open issue '{title}'?", yes=yes, dry_run=dry_run)
     args = ["issue", "create", "--title", title]
     if body:
         args.extend(["--body", body])
@@ -71,8 +135,37 @@ def issue_create(title, body):
 
 
 @issue.command(name="list")
-def issue_list():
-    """List issues"""
+@json_flag()
+def issue_list(json_output):
+    """List issues.
+
+    \b
+    Example:
+      $ scitex-hub gitea issue list
+      $ scitex-hub gitea issue list --json
+    """
+    if json_output:
+        try:
+            from pathlib import Path
+
+            tea_bin = str(Path.home() / ".local" / "bin" / "tea")
+            result = subprocess.run(
+                [tea_bin, "issue", "list", "--output", "json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            import json as _json
+
+            try:
+                payload = _json.loads(result.stdout or "[]")
+            except _json.JSONDecodeError:
+                payload = {"raw": result.stdout}
+            emit_json(payload)
+        except subprocess.CalledProcessError as e:
+            emit_json({"error": str(e), "stderr": e.stderr})
+            sys.exit(1)
+        return
     run_tea("issue", "list")
 
 
@@ -88,11 +181,17 @@ def issue_list():
 )
 @click.option("--repo", default=None, help="Override repo name (default: cwd name)")
 @click.option("--login", "-l", default="scitex-dev", help="Tea login to use")
-def push(remote, branch_opt, repo, login):
+@mutating_flags()
+def push(remote, branch_opt, repo, login, dry_run, yes):
     """Push local changes to Gitea.
 
     Sets up the Gitea remote with token authentication if it does not exist,
     then pushes the specified (or current) branch.
+
+    \b
+    Example:
+      $ scitex-hub gitea push --yes
+      $ scitex-hub gitea push --branch develop --dry-run
     """
     ensure_not_in_workspace()
     try:
@@ -110,6 +209,14 @@ def push(remote, branch_opt, repo, login):
                 click.echo("Error: Not on any branch", err=True)
                 sys.exit(1)
 
+        if dry_run:
+            print_dry_run(
+                f"git push -u {remote} {branch} (after ensuring remote '{remote}' "
+                f"is configured with login '{login}')"
+            )
+            return
+        confirm_or_abort(f"Push {branch} to {remote}?", yes=yes, dry_run=dry_run)
+
         ensure_gitea_remote(remote_name=remote, login_name=login, repo=repo)
 
         click.echo(f"Pushing {branch} -> {remote}/{branch} ...")
@@ -121,8 +228,15 @@ def push(remote, branch_opt, repo, login):
 
 
 @click.command()
-def pull():
-    """Pull workspace changes to local machine"""
+@mutating_flags()
+def pull(dry_run, yes):
+    """Pull workspace changes to local machine.
+
+    \b
+    Example:
+      $ scitex-hub gitea pull --yes
+      $ scitex-hub gitea pull --dry-run
+    """
     ensure_not_in_workspace()
     try:
         result = subprocess.run(
@@ -135,6 +249,12 @@ def pull():
         if not branch:
             click.echo("Error: Not on any branch", err=True)
             sys.exit(1)
+        if dry_run:
+            print_dry_run(f"git pull origin {branch}")
+            return
+        confirm_or_abort(
+            f"Pull origin/{branch} into current branch?", yes=yes, dry_run=dry_run
+        )
         click.echo("Pulling from workspace...")
         subprocess.run(["git", "pull", "origin", branch], check=True)
         click.echo(f"Pulled from workspace (origin/{branch})")
@@ -144,9 +264,38 @@ def pull():
 
 
 @click.command("show-status")
-def status():
-    """Show repository status"""
+@json_flag()
+def status(json_output):
+    """Show repository status.
+
+    \b
+    Example:
+      $ scitex-hub gitea show-status
+      $ scitex-hub gitea show-status --json
+    """
     ensure_not_in_workspace()
+    if json_output:
+        try:
+            result = subprocess.run(
+                ["git", "status", "--porcelain=v2", "--branch"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            entries = []
+            branch_info = {}
+            for line in result.stdout.splitlines():
+                if line.startswith("# branch."):
+                    parts = line.split(" ", 2)
+                    if len(parts) >= 3:
+                        branch_info[parts[1].replace("branch.", "")] = parts[2]
+                elif line:
+                    entries.append(line)
+            emit_json({"branch": branch_info, "entries": entries})
+        except subprocess.CalledProcessError as e:
+            emit_json({"error": str(e), "stderr": e.stderr})
+            sys.exit(1)
+        return
     subprocess.run(["git", "status"])
 
 
@@ -181,7 +330,12 @@ def status():
 @click.option("--no-cache", is_flag=True, help="Disable cache")
 @click.option("--url", default="https://scitex.cloud", help="SciTeX Hub URL")
 def enrich(input_file, output_file, api_key, no_cache, url):
-    """Enrich BibTeX file with metadata"""
+    """Enrich BibTeX file with metadata.
+
+    \b
+    Example:
+      $ scitex-hub gitea enrich -i refs.bib -o refs.enriched.bib
+    """
     if not api_key:
         click.echo("Error: API key required", err=True)
         click.echo("Set SCITEX_HUB_API_KEY or use --api-key", err=True)

--- a/src/scitex_hub/_cli/_gitea_repo.py
+++ b/src/scitex_hub/_cli/_gitea_repo.py
@@ -9,6 +9,15 @@ from pathlib import Path
 
 import click
 
+from ._flags import (
+    confirm_or_abort,
+    dry_run_flag,
+    emit_json,
+    json_flag,
+    mutating_flags,
+    print_dry_run,
+    yes_flag,
+)
 from ._gitea_utils import get_gitea_http_url, get_tea_config, run_tea
 
 
@@ -16,8 +25,22 @@ from ._gitea_utils import get_gitea_http_url, get_tea_config, run_tea
 @click.argument("repository")
 @click.argument("destination", required=False)
 @click.option("--login", "-l", default="scitex-dev", help="Tea login to use")
-def clone(repository, destination, login):
-    """Clone a repository from SciTeX Hub"""
+@mutating_flags()
+def clone(repository, destination, login, dry_run, yes):
+    """Clone a repository from SciTeX Hub.
+
+    \b
+    Example:
+      $ scitex-hub gitea clone scitex-hub
+      $ scitex-hub gitea clone scitex-dev/scitex-hub ./hub --yes
+    """
+    if dry_run:
+        target = destination or "<basename of repo>"
+        print_dry_run(
+            f"clone repository '{repository}' into '{target}' via tea login '{login}'"
+        )
+        return
+    confirm_or_abort(f"Clone repository '{repository}'?", yes=yes, dry_run=dry_run)
     if "/" not in repository:
         try:
             result = subprocess.run(
@@ -61,12 +84,26 @@ def clone(repository, destination, login):
 @click.option("--login", "-l", default="scitex-dev", help="Tea login to use")
 @click.option("--push", "do_push", is_flag=True, help="Do initial push after creating")
 @click.option("--remote", default="scitex", help="Remote name to add (default: scitex)")
-def create(name, description, private, login, do_push, remote):
+@mutating_flags()
+def create(name, description, private, login, do_push, remote, dry_run, yes):
     """Create a new repository on Gitea.
 
     Also adds a Gitea remote to the current git repo (if in one) and
     prints the clone URL.  Use --push to immediately push the current branch.
+
+    \b
+    Example:
+      $ scitex-hub gitea create my-new-repo --description "demo" --yes
+      $ scitex-hub gitea create my-new-repo --private --push
     """
+    if dry_run:
+        visibility = "private" if private else "public"
+        print_dry_run(
+            f"create {visibility} Gitea repository '{name}' via tea login '{login}'"
+            + (f" then push current branch to remote '{remote}'" if do_push else "")
+        )
+        return
+    confirm_or_abort(f"Create repository '{name}'?", yes=yes, dry_run=dry_run)
     args = ["repo", "create", "--name", name, "--login", login]
     if description:
         args.extend(["--description", description])
@@ -124,15 +161,45 @@ def _in_git_repo():
 @click.option("--login", "-l", default="scitex-dev", help="Tea login to use")
 @click.option("--starred", "-s", is_flag=True, help="List starred repos")
 @click.option("--watched", "-w", is_flag=True, help="List watched repos")
-def list_repos(user, login, starred, watched):
-    """List repositories"""
-    args = ["repos", "--login", login, "--output", "table"]
+@json_flag()
+def list_repos(user, login, starred, watched, json_output):
+    """List repositories.
+
+    \b
+    Example:
+      $ scitex-hub gitea list
+      $ scitex-hub gitea list --user scitex-dev --json
+    """
+    args = ["repos", "--login", login]
+    if json_output:
+        args.extend(["--output", "json"])
+    else:
+        args.extend(["--output", "table"])
     if starred:
         args.append("--starred")
     if watched:
         args.append("--watched")
     if user:
         args.append(user)
+    if json_output:
+        # Capture tea output and re-emit as canonical JSON so callers don't
+        # have to trust tea's raw text formatting.
+        try:
+            tea_bin = str(Path.home() / ".local" / "bin" / "tea")
+            result = subprocess.run(
+                [tea_bin, *args], capture_output=True, text=True, check=True
+            )
+            import json as _json
+
+            try:
+                payload = _json.loads(result.stdout or "[]")
+            except _json.JSONDecodeError:
+                payload = {"raw": result.stdout}
+            emit_json(payload)
+        except subprocess.CalledProcessError as e:
+            emit_json({"error": str(e), "stderr": e.stderr})
+            sys.exit(1)
+        return
     run_tea(*args)
 
 
@@ -140,9 +207,37 @@ def list_repos(user, login, starred, watched):
 @click.argument("query")
 @click.option("--login", "-l", default="scitex-dev", help="Tea login to use")
 @click.option("--limit", type=int, default=10, help="Maximum results")
-def search(query, login, limit):
-    """Search for repositories"""
-    run_tea("repos", "search", "--login", login, "--limit", str(limit), query)
+@json_flag()
+def search(query, login, limit, json_output):
+    """Search for repositories.
+
+    \b
+    Example:
+      $ scitex-hub gitea search scholar
+      $ scitex-hub gitea search scholar --limit 5 --json
+    """
+    args = ["repos", "search", "--login", login, "--limit", str(limit), query]
+    if json_output:
+        try:
+            tea_bin = str(Path.home() / ".local" / "bin" / "tea")
+            result = subprocess.run(
+                [tea_bin, *args, "--output", "json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            import json as _json
+
+            try:
+                payload = _json.loads(result.stdout or "[]")
+            except _json.JSONDecodeError:
+                payload = {"raw": result.stdout}
+            emit_json(payload)
+        except subprocess.CalledProcessError as e:
+            emit_json({"error": str(e), "stderr": e.stderr})
+            sys.exit(1)
+        return
+    run_tea(*args)
 
 
 @click.command()
@@ -154,8 +249,20 @@ def search(query, login, limit):
     is_flag=True,
     help="Confirm destructive action (required for non-interactive use)",
 )
-def delete(repository, login, yes):
-    """Delete a repository (DANGEROUS!). Requires --yes/-y (no prompt)."""
+@dry_run_flag()
+def delete(repository, login, yes, dry_run):
+    """Delete a repository (DANGEROUS!). Requires --yes/-y (no prompt).
+
+    \b
+    Example:
+      $ scitex-hub gitea delete scitex-dev/old-repo --yes
+      $ scitex-hub gitea delete scitex-dev/old-repo --dry-run
+    """
+    if dry_run:
+        print_dry_run(
+            f"delete repository '{repository}' via Gitea API (login '{login}')"
+        )
+        return
     if not yes:
         click.echo(
             f"error: pass --yes/-y to confirm destructive action: "
@@ -209,7 +316,12 @@ def delete(repository, login, yes):
 @click.command()
 @click.argument("repository")
 def fork(repository):
-    """Fork a repository"""
+    """Fork a repository.
+
+    \b
+    Example:
+      $ scitex-hub gitea fork scitex-dev/scitex-hub
+    """
     run_tea("repo", "fork", repository)
 
 


### PR DESCRIPTION
## Summary

Card #7 (hub-audit-cli-pass) — first chunk. Addresses the §2/§4
violations in the audit log that `test_audit_all_clean` fails on
for every hub PR.

This PR covers the **gitea noun group** (`scitex-hub gitea *`):
14 leaf commands, ~24 of the 119 violations.

## What changed

**§2 mutating verbs** — added `--dry-run` + `--yes/-y`:
- `gitea clone`, `gitea create`, `gitea delete`
- `gitea pr create`, `gitea issue create`
- `gitea push`, `gitea pull`

**§2 read verbs** — added `--json`:
- `gitea list`, `gitea search`, `gitea pr list`, `gitea issue list`
- `gitea show-status`

**§4 concrete `Example:` block** added to every leaf command in the
gitea group (login, logout, clone, create, list, search, delete,
fork, pr create, pr list, issue create, issue list, push, pull,
show-status, enrich).

## Flag semantics (real effect, not no-ops)

- `--dry-run` prints `[dry-run] <action>` via
  `scitex_hub._cli._flags.print_dry_run` and exits 0 without
  mutating state.
- `--yes/-y` skips the interactive confirmation prompt via
  `_flags.confirm_or_abort` (no-TTY stays non-interactive).
- `--json` emits canonical `json.dumps` output — for tea-backed
  commands we re-parse `tea --output json` and re-emit through
  `emit_json` so callers consume valid JSON, not stringified
  Python repr.

## Constraint compliance

- No `skip_rules` / `# stx-allow:` entries (operator policy
  2026-06-12 msg 78).
- No `Co-Authored-By` trailer.
- Examples use real command syntax (no `<placeholder>` only).

## Iteration plan

Card #7 totals **119 violations**; this chunk covers the gitea
group (~24). Remaining noun groups to cover in follow-up
commits/PRs on this same branch:

| Group | Approx. count |
|---|---|
| `app` (create/list/...) | ~8 |
| `deploy-project` | ~2 |
| `mcp` (start/install/list-tools/doctor) | ~8 |
| `context` (get/eval/trigger-action) | ~3 |
| `show-status` (root) | ~1 |
| `workspace`, `docker`, `sdk`, `setup`, `project`, `sync`, `ssh`, `completion` | balance |

Estimate ~4 more iterations of similar size to clear all 119.

## Test plan

- [ ] CI `quality` workflow audit step shows §2/§4 violations for
      the gitea group drop to **0**.
- [ ] `scitex-hub gitea list --json` emits parseable JSON.
- [ ] `scitex-hub gitea clone foo --dry-run` prints
      `[dry-run] clone repository 'foo' ...` and exits 0.
- [ ] `scitex-hub gitea delete a/b --dry-run` exits 0 without
      hitting the Gitea API.