### PR TITLE
feat(cli): scitex-hub auth login — browser-free PAT mint + store (Phase-1 PR-5 / card #2)

### DIFF
--- a/src/scitex_hub/_cli/_auth/__init__.py
+++ b/src/scitex_hub/_cli/_auth/__init__.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``scitex-hub auth *`` command group — browser-free credential surface.
+
+Phase-1 PR-5 / card #2 of lead's 7-card backlog. Thin shell over PR #273's
+``/api/me/token/`` mint endpoint, complementing PR #274's ``account token``
+resource-management verbs.
+
+Per scitex-dev's convention doctrine (msg 548d1e6e), bare top-level
+``login`` was rejected as a verb. Lead's card #2 explicitly scopes this
+work to the ``auth login`` compound shape (``auth`` group + ``login``
+verb), which keeps the polysemy contained inside the ``auth`` subtree
+while exposing the user-facing ``scitex-hub auth login`` UX everyone
+already expects from cloud CLIs.
+"""
+
+from __future__ import annotations
+
+# Verb modules register themselves on import.
+from . import _login  # noqa: F401
+from ._group import auth
+
+__all__ = ["auth"]
+
+# EOF

--- a/src/scitex_hub/_cli/_auth/_group.py
+++ b/src/scitex_hub/_cli/_auth/_group.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Top-level ``auth`` Click group.
+
+Lives in its own module so verb modules can import the singleton
+without import cycles, mirroring the ``_account/_group.py`` pattern.
+The console singleton is reused for consistent rich-rendering.
+"""
+
+from __future__ import annotations
+
+import click
+from rich.console import Console
+
+console = Console()
+
+
+@click.group()
+def auth() -> None:
+    """Browser-free credential operations (login → mint+cache PAT)."""
+
+
+__all__ = ["auth", "console"]
+
+# EOF

--- a/src/scitex_hub/_cli/_auth/_login.py
+++ b/src/scitex_hub/_cli/_auth/_login.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``auth login`` — interactive browser-free PAT mint + cache.
+
+Phase-1 PR-5 / card #2 of lead's 7-card backlog. Thin shell over PR #273's
+``POST /api/me/token/`` mint endpoint; the heavy lifting (allowlist,
+per-IP/per-user rate limit, constant-time error path) lives server-side.
+
+The verb prompts for ``username`` and ``password`` (echo hidden),
+posts them to ``/api/me/token/``, persists the returned ``scitex_xxxx``
+PAT to the SAME canonical cache that ``scitex-hub account token *``
+uses so subsequent CLI calls (whoami / doctor / publish) pick it up
+automatically with zero extra config.
+
+Per AGPL-3.0 SciTeX rules:
+  - No silent fallback — every server error surfaces with URL + status.
+  - The cache file is chmod-ed to ``0600`` after write.
+  - On network error or 5xx, we raise loud with the URL + status code.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+import requests
+
+from .._account._token import _read_cached_token, _resolve_server, _token_cache_path
+from ._group import auth, console
+
+
+def _post_mint(
+    server_url: str,
+    username: str,
+    password: str,
+    scopes: tuple[str, ...],
+    name: str,
+    *,
+    timeout: float = 20.0,
+    session: requests.Session | None = None,
+) -> dict[str, Any]:
+    """POST credentials to ``/api/me/token/`` and return the JSON body.
+
+    Pulled out as a pure helper so the CLI test can exercise the HTTP
+    contract with a hand-rolled fake transport (no ``unittest.mock`` per
+    STX-NM repo rule; see ``tests/scitex_hub/_cli/_auth/test_login.py``).
+
+    Raises :class:`requests.HTTPError` (with the response attached) on
+    any non-201 — the caller is responsible for status-specific UX.
+    The connection-layer ``requests.ConnectionError`` / ``Timeout`` are
+    NOT caught here — they bubble up so the CLI layer can render them
+    with the server URL in the message (AGPL-3.0 SciTeX "no silent
+    fallback" rule).
+    """
+    body = {
+        "username": username,
+        "password": password,
+        "scopes": list(scopes),
+        "name": name,
+    }
+    http = session or requests
+    resp = http.post(f"{server_url}/api/me/token/", json=body, timeout=timeout)
+    if resp.status_code != 201:
+        # Re-use requests' HTTPError so the call-site can switch on
+        # ``err.response.status_code`` without parsing strings.
+        raise requests.HTTPError(
+            f"{resp.status_code} from {server_url}/api/me/token/",
+            response=resp,
+        )
+    return resp.json()
+
+
+def _persist_token(server_url: str, token_value: str) -> Path:
+    """Write the minted PAT to the canonical cache (0600) and return path.
+
+    Matches ``_account/_token.py``'s cache layout key-for-key so the
+    rest of the CLI (whoami / doctor / publish) reads it transparently.
+    """
+    p = _token_cache_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"server": server_url, "access": token_value}))
+    p.chmod(0o600)
+    return p
+
+
+# Default scopes — mirrors ``_account/_token.DEFAULT_CLI_SCOPES``. We
+# don't import that constant because it's intentionally private to the
+# ``_account`` subtree; duplicating one tuple is cheaper than coupling
+# the auth verb to an internal name.
+DEFAULT_LOGIN_SCOPES: tuple[str, ...] = ("publish",)
+
+
+@auth.command("login")
+@click.option(
+    "--user",
+    "-u",
+    "username",
+    default=None,
+    help="Your hub username (prompted if omitted).",
+)
+@click.option(
+    "--password",
+    "-p",
+    default=None,
+    help="Your hub password (prompted if omitted; -p is escape hatch for unattended scripts).",
+)
+@click.option(
+    "--scope",
+    "scopes",
+    multiple=True,
+    default=DEFAULT_LOGIN_SCOPES,
+    show_default=True,
+    help="Scope to request. Server enforces an allowlist (today only 'publish').",
+)
+@click.option(
+    "--name",
+    "-n",
+    default="scitex-hub-cli-login",
+    show_default=True,
+    help="Human-readable token name (visible in UI ``/account/tokens/``).",
+)
+@click.option(
+    "--server",
+    "-s",
+    envvar="SCITEX_HUB_URL",
+    default=None,
+    help="SciTeX Hub server URL. Defaults to cached token's server or scitex.ai.",
+)
+def auth_login(username, password, scopes, name, server):
+    """Interactive browser-free login — mint a PAT and cache it 0600.
+
+    Prompts for username + password if not supplied, POSTs them to
+    ``/api/me/token/`` (PR #273), persists the returned PAT to
+    ``~/.scitex/cloud/runtime/token.json`` (mode 0600), and prints a
+    confirmation line + a hint to export ``$SCITEX_HUB_TOKEN`` for
+    sibling tools that prefer env-var auth.
+
+    \b
+    Examples:
+        scitex-hub auth login
+        scitex-hub auth login --user ywatanabe
+        scitex-hub auth login -u ywatanabe -s https://staging.scitex.ai
+    """
+    server_url = _resolve_server(server)
+
+    # Prompt only the missing pieces — keeps -u/-p escape hatch clean.
+    if not username:
+        username = click.prompt("Username", type=str)
+    if not password:
+        password = click.prompt("Password", type=str, hide_input=True)
+
+    try:
+        data = _post_mint(server_url, username, password, tuple(scopes), name)
+    except requests.ConnectionError as exc:
+        # AGPL-3.0 "no silent fallback": surface URL + cause.
+        console.print(f"[red]Cannot reach[/red] [cyan]{server_url}[/cyan]: {exc}")
+        sys.exit(1)
+    except requests.Timeout as exc:
+        console.print(f"[red]Timeout talking to[/red] [cyan]{server_url}[/cyan]: {exc}")
+        sys.exit(1)
+    except requests.HTTPError as exc:
+        resp = exc.response
+        status = resp.status_code if resp is not None else "???"
+        if status == 401:
+            console.print(
+                "[red]Authentication failed.[/red] Wrong username or password."
+            )
+            sys.exit(1)
+        if status == 400:
+            try:
+                err = resp.json().get("error", resp.text)
+            except ValueError:
+                err = resp.text if resp is not None else ""
+            console.print(f"[red]Bad request[/red] from {server_url}: {err}")
+            sys.exit(2)
+        if status == 429:
+            console.print(
+                f"[red]Rate-limited[/red] by {server_url}. Try again shortly."
+            )
+            sys.exit(1)
+        # 5xx and anything unexpected — loud surface per AGPL-3.0 rule.
+        body = resp.text[:200] if resp is not None else ""
+        console.print(
+            f"[red]Unexpected response[/red] HTTP {status} from "
+            f"[cyan]{server_url}/api/me/token/[/cyan]: {body}"
+        )
+        sys.exit(1)
+
+    token_value = data["token"]
+    cache_path = _persist_token(server_url, token_value)
+
+    # Success UX — confirm identity, point at storage, give env-var hint.
+    console.print(f"[green]logged in as[/green] [cyan]{username}[/cyan]")
+    console.print(f"  token cached at [cyan]{cache_path}[/cyan] (mode 0600)")
+    prefix = data.get("prefix", "")
+    if prefix:
+        console.print(
+            f"  prefix: [cyan]{prefix}[/cyan]   "
+            f"scopes: [cyan]{','.join(data.get('scopes', []))}[/cyan]"
+        )
+    console.print(
+        "  hint: export [cyan]SCITEX_HUB_TOKEN[/cyan]=$(cat "
+        f"{cache_path} | python -c 'import json,sys;"
+        'print(json.load(sys.stdin)["access"])\')'
+    )
+
+
+# EOF

--- a/src/scitex_hub/_cli/main.py
+++ b/src/scitex_hub/_cli/main.py
@@ -139,10 +139,12 @@ main.add_command(workspace)
 main.add_command(sdk)
 
 from ._account import account  # noqa: E402
+from ._auth import auth  # noqa: E402
 from .project import project  # noqa: E402
 from .sync import register_sync_commands  # noqa: E402
 
 main.add_command(account)
+main.add_command(auth)
 main.add_command(project)
 register_sync_commands(main)
 

--- a/tests/scitex_hub/_cli/_auth/test_login.py
+++ b/tests/scitex_hub/_cli/_auth/test_login.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Behavioural test for ``scitex-hub auth login``'s HTTP helper.
+
+Phase-1 PR-5 / card #2. Pins:
+
+  - ``_post_mint`` posts ``{username, password, scopes, name}`` to
+    ``/api/me/token/`` and returns the parsed JSON on 201.
+  - On non-201, it raises ``requests.HTTPError`` carrying the response.
+
+Per repo STX-NM rule: NO ``unittest.mock``. We use a hand-rolled fake
+:class:`requests.Session` stand-in that records the call and returns a
+canned :class:`requests.Response`. That matches the no-mocks pattern
+used by ``tests/scitex_hub/test_account_cli_grammar.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+
+from scitex_hub._cli._auth._login import _post_mint
+
+
+class _FakeResponse:
+    """Minimal :class:`requests.Response` stand-in (status + json + text)."""
+
+    def __init__(self, status_code: int, payload: dict[str, Any] | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = json.dumps(self._payload)
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _RecordingSession:
+    """Fake ``requests.Session`` capturing one ``.post()`` call."""
+
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+        self.last_url: str | None = None
+        self.last_json: dict[str, Any] | None = None
+        self.last_timeout: float | None = None
+
+    def post(self, url: str, json: dict[str, Any], timeout: float) -> _FakeResponse:
+        self.last_url = url
+        self.last_json = json
+        self.last_timeout = timeout
+        return self._response
+
+
+def test_post_mint_returns_json_on_201():
+    # Arrange
+    payload = {
+        "token": "scitex_abcdef0123456789",
+        "prefix": "scitex_a",
+        "scopes": ["publish"],
+    }
+    session = _RecordingSession(_FakeResponse(201, payload))
+
+    # Act
+    actual = _post_mint(
+        "https://hub.example.com",
+        "alice",
+        "PW_PLACEHOLDER",
+        ("publish",),
+        "test-token",
+        session=session,
+    )
+
+    # Assert
+    assert actual == payload
+
+
+def test_post_mint_targets_me_token_endpoint():
+    # Arrange
+    session = _RecordingSession(_FakeResponse(201, {"token": "scitex_x"}))
+
+    # Act
+    _post_mint(
+        "https://hub.example.com",
+        "alice",
+        "PW_PLACEHOLDER",
+        ("publish",),
+        "n",
+        session=session,
+    )
+
+    # Assert
+    assert session.last_url == "https://hub.example.com/api/me/token/"
+
+
+def test_post_mint_body_includes_credentials_and_scopes():
+    # Arrange
+    session = _RecordingSession(_FakeResponse(201, {"token": "scitex_x"}))
+
+    # Act
+    _post_mint(
+        "https://hub.example.com",
+        "alice",
+        "PW_PLACEHOLDER",
+        ("publish",),
+        "from-laptop",
+        session=session,
+    )
+
+    # Assert
+    assert session.last_json == {
+        "username": "alice",
+        "password": "PW_PLACEHOLDER",  # pragma: allowlist secret
+        "scopes": ["publish"],
+        "name": "from-laptop",
+    }
+
+
+def _raises_on_status(status: int) -> requests.HTTPError:
+    """Shared helper: call ``_post_mint`` against a canned status."""
+    session = _RecordingSession(_FakeResponse(status, {"error": "x"}))
+    with pytest.raises(requests.HTTPError) as exc_info:
+        _post_mint(
+            "https://hub.example.com",
+            "alice",
+            "pw",
+            ("publish",),
+            "n",
+            session=session,
+        )
+    return exc_info.value
+
+
+def test_post_mint_raises_httperror_on_401():
+    # Arrange
+    session = _RecordingSession(_FakeResponse(401, {"error": "invalid_credentials"}))
+
+    # Act
+    def _call():
+        _post_mint(
+            "https://hub.example.com",
+            "alice",
+            "wrong",
+            ("publish",),
+            "n",
+            session=session,
+        )
+
+    # Assert
+    with pytest.raises(requests.HTTPError):
+        _call()
+
+
+def test_post_mint_on_401_attaches_response_with_status_401():
+    # Arrange
+    err = _raises_on_status(401)
+
+    # Act
+    actual = err.response.status_code
+
+    # Assert
+    assert actual == 401
+
+
+def test_post_mint_raises_httperror_on_5xx():
+    # Arrange
+    session = _RecordingSession(_FakeResponse(503, {"error": "service_unavailable"}))
+
+    # Act
+    def _call():
+        _post_mint(
+            "https://hub.example.com",
+            "alice",
+            "PW_PLACEHOLDER",
+            ("publish",),
+            "n",
+            session=session,
+        )
+
+    # Assert
+    with pytest.raises(requests.HTTPError):
+        _call()
+
+
+def test_post_mint_on_5xx_attaches_response_with_status_503():
+    # Arrange
+    err = _raises_on_status(503)
+
+    # Act
+    actual = err.response.status_code
+
+    # Assert
+    assert actual == 503
+
+
+def test_auth_group_registers_login_verb():
+    # Arrange
+    from scitex_hub._cli._auth import auth
+
+    # Act
+    actual = "login" in auth.commands
+
+    # Assert
+    assert actual is True
+
+
+def test_main_cli_registers_auth_group():
+    # Arrange — wire-through guard so a future refactor can't silently
+    # drop the ``auth`` group from the top-level CLI tree.
+    from scitex_hub._cli.main import main
+
+    # Act
+    actual = "auth" in main.commands
+
+    # Assert
+    assert actual is True
+
+
+# EOF


### PR DESCRIPTION
## Summary
- New `scitex-hub auth login` interactive CLI verb — browser-free PAT mint + store. Card #2 of lead's 7-card backlog.
- Thin shell over PR #273's `POST /api/me/token/` endpoint (server-side dependency); complements PR #274's `account token create/list/revoke`.
- Caches the minted PAT to the SAME canonical location used by `account token create` (`~/.scitex/cloud/runtime/token.json`, mode 0600), so subsequent `scitex-hub` CLI calls (whoami / doctor / publish) pick it up automatically with zero extra config.

## Behaviour
- Prompts for `--user` / `--password` if omitted (`-p` is the escape hatch for unattended scripts).
- On success prints `logged in as <username>` plus a hint to export `$SCITEX_HUB_TOKEN`.
- Errors surface loud per AGPL-3.0 SciTeX "no silent fallback" rule:
  - 401 -> wrong creds (exit 1)
  - 400 -> server error body (exit 2)
  - 429 -> rate-limited (exit 1)
  - 5xx / unexpected -> URL + status + first 200 chars of body (exit 1)
  - `ConnectionError` / `Timeout` -> URL + cause (exit 1)
- Cache file `chmod 0600` after write.

## Out of scope (deliberate)
- `auth logout` (follow-up commit per brief)
- token refresh / OAuth / SSO

## Dependencies
- Server endpoint comes from **PR #273** (`feat(accounts_app): /api/me/token/`); this PR is purely the client-side companion.

## Test plan
- [x] `tests/scitex_hub/_cli/_auth/test_login.py` exercises the pure `_post_mint` HTTP helper via a hand-rolled fake `requests.Session` (no `unittest.mock` per repo STX-NM rule).
- [x] Pins 201 happy path body, endpoint URL, request body shape, 401 + 5xx HTTPError-with-response surfacing.
- [x] Wire-through guard: `auth` group registered on top-level CLI, `login` verb registered on `auth` group.
- [ ] Manual smoke against staging once #273 is live: `scitex-hub auth login --user <me> --server https://staging.scitex.ai`.
- [ ] Follow-up PR will add `auth logout` (cache-file delete + identity confirmation).
