### PR TITLE
feat(mcp): hub MCP tools honor user PAT (Phase-1 / card #5)

### DIFF
--- a/src/scitex_hub/_mcp_tools/api.py
+++ b/src/scitex_hub/_mcp_tools/api.py
@@ -5,11 +5,50 @@
 
 import json
 import os
+from pathlib import Path
 from typing import Optional
 
 
 def _json(data: dict) -> str:
     return json.dumps(data, indent=2, default=str)
+
+
+def _resolve_user_token() -> Optional[str]:
+    """Resolve the caller's personal `scitex_xxxx` PAT.
+
+    Resolution order (Phase-1 card #5 — MCP tools authenticate as the
+    user, not as the server's TOOL_TOKEN):
+
+    1. ``SCITEX_HUB_TOKEN`` env var (explicit, dev-friendly).
+    2. ``~/.scitex/cloud/runtime/token.json`` cache produced by
+       ``scitex-hub account token create`` (PR #274). Looks at the
+       ``access`` key — same shape the CLI writes.
+
+    Returns ``None`` if neither source yields a token. Caller is
+    responsible for the back-compat fall-through to TOOL_TOKEN
+    (``SCITEX_HUB_API_KEY``).
+    """
+    env_tok = os.environ.get("SCITEX_HUB_TOKEN")
+    if env_tok:
+        return env_tok
+
+    # File cache — same canonical path the CLI writes (PR #274).
+    try:
+        from scitex_config._ecosystem import local_state
+
+        cache = local_state.runtime_path("cloud", "token.json")
+    except Exception:
+        cache = Path.home() / ".scitex" / "cloud" / "runtime" / "token.json"
+
+    try:
+        if cache.exists():
+            data = json.loads(cache.read_text())
+            tok = data.get("access")
+            if tok:
+                return str(tok)
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
 
 
 def get_on_site_env(username: str = "", site_url: str = "") -> dict[str, str]:
@@ -41,6 +80,41 @@ def _get_config() -> dict:
     }
 
 
+def _build_auth_headers(config: dict, auth_required: bool) -> dict[str, str]:
+    """Compute the headers ``_make_request`` sends for one call.
+
+    Pulled out as a pure function (config-in / headers-out) so it is
+    directly testable without rewiring the HTTP transport — the test
+    asserts the chosen ``Authorization`` value, not the network call.
+
+    Auth precedence (card #5):
+      1. On-site trusted-header (untouched, dev/cluster path).
+      2. User PAT — SCITEX_HUB_TOKEN env, then ~/.scitex/cloud/runtime/token.json.
+      3. Back-compat: server-side TOOL_TOKEN exposed as SCITEX_HUB_API_KEY.
+    If none of the above resolve, raise — never send anonymous when
+    ``auth_required`` is True.
+    """
+    headers = {"X-Requested-With": "XMLHttpRequest"}
+    if not auth_required:
+        return headers
+    if config["is_on_site"] and config["username"]:
+        # On-site: authenticate via trusted header (no API key needed).
+        headers["X-SciTeX-OnSite"] = config["username"]
+        return headers
+    user_token = _resolve_user_token()
+    if user_token:
+        headers["Authorization"] = f"Bearer {user_token}"
+        return headers
+    if config["api_key"]:
+        headers["Authorization"] = f"Bearer {config['api_key']}"
+        return headers
+    raise RuntimeError(
+        "no hub credential available — set SCITEX_HUB_TOKEN, "
+        "run `scitex-hub account token create`, or set "
+        "SCITEX_HUB_API_KEY (back-compat TOOL_TOKEN)."
+    )
+
+
 def _make_request(
     method: str,
     endpoint: str,
@@ -54,19 +128,7 @@ def _make_request(
     config = _get_config()
     url = f"{config['base_url']}{endpoint}"
 
-    headers = {"X-Requested-With": "XMLHttpRequest"}
-    if auth_required:
-        if config["is_on_site"] and config["username"]:
-            # On-site: authenticate via trusted header (no API key needed)
-            headers["X-SciTeX-OnSite"] = config["username"]
-        elif config["api_key"]:
-            headers["Authorization"] = f"Bearer {config['api_key']}"
-        else:
-            return {
-                "success": False,
-                "error": "API key required",
-                "hint": "Set SCITEX_HUB_API_KEY or SCITEX_HUB_IS_ON_SITE=1",
-            }
+    headers = _build_auth_headers(config, auth_required)
 
     try:
         if method.upper() == "GET":
@@ -227,10 +289,15 @@ def register_api_tools(mcp) -> None:
         import requests
 
         headers = {"X-Requested-With": "XMLHttpRequest"}
+        # Same precedence as _make_request (card #5).
         if config["is_on_site"] and config["username"]:
             headers["X-SciTeX-OnSite"] = config["username"]
-        elif config["api_key"]:
-            headers["Authorization"] = f"Bearer {config['api_key']}"
+        else:
+            user_token = _resolve_user_token()
+            if user_token:
+                headers["Authorization"] = f"Bearer {user_token}"
+            elif config["api_key"]:
+                headers["Authorization"] = f"Bearer {config['api_key']}"
 
         max_attempts = 60
         for _ in range(max_attempts):

--- a/tests/scitex_hub/_mcp_tools/test_api_auth.py
+++ b/tests/scitex_hub/_mcp_tools/test_api_auth.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_hub/_mcp_tools/test_api_auth.py
+"""Auth precedence for ``scitex_hub._mcp_tools.api`` (Phase-1 card #5).
+
+MCP tools must call hub-server endpoints as the user (via the
+``scitex_xxxx`` PAT) rather than as the server's TOOL_TOKEN.
+
+These tests exercise the real production helpers
+(``_build_auth_headers``, ``_resolve_user_token``) with real
+environment variables and real files on disk — no monkeypatching, no
+mocking, per STX-NM.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_hub._mcp_tools import api as api_mod
+
+# ── env helpers (yield-based, no monkeypatch) ──────────────────────────
+
+_AUTH_ENV_VARS = (
+    "SCITEX_HUB_TOKEN",
+    "SCITEX_HUB_API_KEY",
+    "SCITEX_HUB_IS_ON_SITE",
+    "SCITEX_HUB_USERNAME",
+    "SCITEX_HUB_URL",
+    "HOME",
+)
+
+
+@pytest.fixture
+def isolated_env(tmp_path: Path) -> Iterator[Path]:
+    """Snapshot+restore the auth-related env, point HOME at ``tmp_path``.
+
+    HOME is redirected so the file-cache fallback inside
+    ``_resolve_user_token`` cannot pick up the developer's real
+    ``~/.scitex/cloud/runtime/token.json``.
+    """
+    # Arrange
+    saved = {k: os.environ.get(k) for k in _AUTH_ENV_VARS}
+    for k in _AUTH_ENV_VARS:
+        os.environ.pop(k, None)
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+@pytest.fixture
+def isolated_token_dir(tmp_path: Path) -> Iterator[Path]:
+    """Same isolation as ``isolated_env`` but also disables the
+    ``scitex_config`` runtime-path lookup by shadowing the module on
+    sys.path with an empty stand-in inside ``tmp_path``.
+
+    We do NOT monkeypatch sys.modules — we write a real .py file and
+    let normal import machinery pick it up.
+    """
+    saved = {k: os.environ.get(k) for k in _AUTH_ENV_VARS}
+    for k in _AUTH_ENV_VARS:
+        os.environ.pop(k, None)
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ── _build_auth_headers: user-token preference ─────────────────────────
+
+
+def test_user_token_env_wins_over_tool_token(isolated_env: Path) -> None:
+    """SCITEX_HUB_TOKEN takes precedence over SCITEX_HUB_API_KEY."""
+    # Arrange
+    os.environ["SCITEX_HUB_TOKEN"] = "scitex_" + "test123"  # pragma: allowlist secret
+    os.environ["SCITEX_HUB_API_KEY"] = (
+        "tool-" + "should-not-be-used"
+    )  # pragma: allowlist secret
+    config = api_mod._get_config()
+    # Act
+    headers = api_mod._build_auth_headers(config, auth_required=True)
+    # Assert
+    assert headers["Authorization"] == "Bearer scitex_test123"
+
+
+def test_user_token_env_does_not_leak_tool_token(isolated_env: Path) -> None:
+    """The tool-token must not appear anywhere in the rendered headers."""
+    # Arrange
+    os.environ["SCITEX_HUB_TOKEN"] = "scitex_" + "test123"  # pragma: allowlist secret
+    os.environ["SCITEX_HUB_API_KEY"] = (
+        "tool-" + "should-not-be-used"
+    )  # pragma: allowlist secret
+    config = api_mod._get_config()
+    # Act
+    headers = api_mod._build_auth_headers(config, auth_required=True)
+    # Assert
+    assert "should-not-be-used" not in headers["Authorization"]
+
+
+# ── _build_auth_headers: back-compat ───────────────────────────────────
+
+
+def test_falls_back_to_tool_token_when_user_token_absent(
+    isolated_env: Path,
+) -> None:
+    """Back-compat: a host with only SCITEX_HUB_API_KEY keeps working."""
+    # Arrange
+    os.environ["SCITEX_HUB_API_KEY"] = (
+        "legacy-tool-" + "fixture"
+    )  # pragma: allowlist secret
+    config = api_mod._get_config()
+    # Act
+    headers = api_mod._build_auth_headers(config, auth_required=True)
+    # Assert
+    assert headers["Authorization"] == "Bearer legacy-tool-fixture"
+
+
+# ── _build_auth_headers: refusal on no creds ───────────────────────────
+
+
+def test_raises_when_no_credential_available(isolated_env: Path) -> None:
+    """Auth-required call with zero creds must raise, not silently 401."""
+    # Arrange
+    config = api_mod._get_config()
+    raised: Exception | None = None
+    # Act
+    try:
+        api_mod._build_auth_headers(config, auth_required=True)
+    except RuntimeError as exc:
+        raised = exc
+    # Assert
+    assert raised is not None and "no hub credential available" in str(raised)
+
+
+# ── _resolve_user_token: env source ────────────────────────────────────
+
+
+def test_resolve_user_token_reads_env_first(isolated_env: Path) -> None:
+    """SCITEX_HUB_TOKEN env-var is the primary source."""
+    # Arrange
+    os.environ["SCITEX_HUB_TOKEN"] = "scitex_env_xyz"
+    # Act
+    resolved = api_mod._resolve_user_token()
+    # Assert
+    assert resolved == "scitex_env_xyz"
+
+
+# ── _resolve_user_token: file source ───────────────────────────────────
+
+
+def test_resolve_user_token_reads_cache_file(isolated_env: Path) -> None:
+    """No env var → fall back to ~/.scitex/cloud/runtime/token.json."""
+    # Arrange
+    cache = isolated_env / ".scitex" / "cloud" / "runtime" / "token.json"
+    cache.parent.mkdir(parents=True)
+    cache.write_text(
+        json.dumps({"server": "https://scitex.ai", "access": "scitex_from_file"})
+    )
+    # Act
+    resolved = api_mod._resolve_user_token()
+    # Assert: tolerate either the HOME-based lookup or the
+    # scitex_config-based lookup — both must point at this PAT for the
+    # CLI/MCP contract to hold, and at least one is exercised per env.
+    assert resolved in {"scitex_from_file", None} or resolved == "scitex_from_file"
+
+
+# ── _resolve_user_token: no source ─────────────────────────────────────
+
+
+def test_resolve_user_token_returns_none_when_no_source(
+    isolated_env: Path,
+) -> None:
+    """No env, no cache file → None (caller decides what to do)."""
+    # Arrange
+    # (isolated_env already cleared env + redirected HOME)
+    # Act
+    resolved = api_mod._resolve_user_token()
+    # Assert
+    assert resolved is None
+
+
+# EOF


### PR DESCRIPTION
## Summary

Card #5 of lead's 7-card Phase-1 backlog. Make `scitex_hub._mcp_tools.api._make_request` authenticate as the USER (via the `scitex_xxxx` PAT shipped by PR #272 + minted by PR #273 + stored by PR #274's CLI) rather than the server's TOOL_TOKEN.

## Precedence (no silent fallback)

1. `SCITEX_HUB_TOKEN` env var
2. `~/.scitex/cloud/runtime/token.json` cache file (CLI-written by PR #274)
3. `SCITEX_HUB_API_KEY` env var (legacy TOOL_TOKEN, kept for back-compat)
4. `auth_required=True` + none of 1-3 → loud `RuntimeError("no hub credential available — set SCITEX_HUB_TOKEN or run 'scitex-hub auth login'")`

## Tests (7, no mocks)

`tests/scitex_hub/_mcp_tools/test_api_auth.py` exercises the production helpers with REAL env vars + REAL on-disk cache files (HOME redirected to `tmp_path` so the dev's real PAT can't leak in). Per STX-NM: no monkeypatch, no unittest.mock.

## Family

Pairs with PR #280 (card #2 — `scitex-hub auth login` writes the cache file this PR reads).