### PR TITLE
feat(api): scitex_hub.account — Python parity for token + whoami CLI (card #3 chunk 1)

### DIFF
--- a/src/scitex_hub/__init__.py
+++ b/src/scitex_hub/__init__.py
@@ -46,6 +46,7 @@ def _get_version() -> str:
 __version__ = _get_version()
 __author__ = "SciTeX Team"
 
+from . import account as account
 from ._api import CloudClient as CloudClient
 from ._config._environments import Environment as Environment
 from ._config._environments import get_environment as get_environment
@@ -154,6 +155,7 @@ def health_check(endpoint: str | None = None) -> dict:
 
 __all__ = [
     "__version__",
+    "account",
     "get_version",
     "health_check",
     "get_context",

--- a/src/scitex_hub/account/__init__.py
+++ b/src/scitex_hub/account/__init__.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_hub/account/__init__.py
+"""SciTeX Hub account namespace — Python parity for the ``account`` CLI tree.
+
+Mirrors the ``scitex-hub account`` CLI verbs as a thin importable surface so
+agent-programmatic callers don't have to shell out:
+
+    >>> import scitex_hub
+    >>> scitex_hub.account.whoami.whoami()
+    {'username': 'ywatanabe', 'email': 'ywatanabe@scitex.ai'}
+    >>> scitex_hub.account.token.create(name="cli", scopes=["publish"])
+    {'token': 'scitex_...', 'prefix': '...', 'scopes': ['publish']}
+
+Card #3 chunk 1 (PR ``feat/hub-python-api-parity``): only ``token`` and
+``whoami`` ship in this slot. The remaining sub-trees (``gitea``,
+``docker``, ``mcp``) follow in later chunks.
+
+Each function thin-wraps the HTTP call to ``/api/me/...`` and reuses the
+:func:`scitex_hub._mcp_tools.api._make_request` transport so the
+``SCITEX_HUB_URL`` / ``SCITEX_HUB_IS_ON_SITE`` resolution stays
+single-sourced.
+"""
+
+from __future__ import annotations
+
+from . import token as token
+from . import whoami as whoami
+
+__all__ = ["token", "whoami"]
+
+# EOF

--- a/src/scitex_hub/account/_auth.py
+++ b/src/scitex_hub/account/_auth.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_hub/account/_auth.py
+"""Shared bearer-token resolution for the account Python API.
+
+The CLI (``src/scitex_hub/_cli/_account/_token.py``) caches a freshly
+minted ``scitex_xxxx`` API token at
+``~/.scitex/cloud/runtime/token.json`` (mode 0600). The Python API
+mirrors that contract but ALSO honours ``SCITEX_HUB_TOKEN`` as the
+canonical env-var override so CI / agent code can inject a token
+without touching disk.
+
+Resolution order (first match wins):
+
+1. ``os.environ["SCITEX_HUB_TOKEN"]`` — explicit env-var override.
+2. ``~/.scitex/cloud/runtime/token.json`` ``access`` field — same path
+   the CLI ``account token create --save`` writes.
+
+If neither is set we raise ``RuntimeError`` rather than silently
+falling back to anonymous — the operator-12845 rule for the Python
+API is "fail loud, never publish anonymously."
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _token_cache_path() -> Path:
+    """Resolve the canonical cached-token path.
+
+    Mirrors :func:`scitex_hub._cli._account._token._token_cache_path` —
+    same precedence: scitex_config's ecosystem helper first, plain
+    ``~/.scitex/cloud/runtime/token.json`` fallback for environments
+    without scitex_config installed.
+    """
+    try:
+        from scitex_config._ecosystem import local_state
+
+        return local_state.runtime_path("cloud", "token.json")
+    except Exception:
+        return Path.home() / ".scitex" / "cloud" / "runtime" / "token.json"
+
+
+def _read_cached_token() -> dict[str, Any] | None:
+    """Return the cached token dict, or ``None`` if absent/unreadable."""
+    p = _token_cache_path()
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def resolve_bearer() -> str:
+    """Resolve the bearer token for an authenticated request.
+
+    Returns:
+        The bearer-token string (without the ``Bearer `` prefix).
+
+    Raises:
+        RuntimeError: Neither ``SCITEX_HUB_TOKEN`` nor a cached
+            ``token.json`` ``access`` field is set. Operator-12845
+            policy: fail loud so the user knows to log in.
+    """
+    env_token = os.environ.get("SCITEX_HUB_TOKEN")
+    if env_token:
+        return env_token
+    cached = _read_cached_token() or {}
+    access = cached.get("access")
+    if access:
+        return str(access)
+    raise RuntimeError("not logged in — run `scitex-hub auth login` first")
+
+
+def resolve_server(server: str | None = None) -> str:
+    """Resolve the server URL.
+
+    Precedence:
+      1. Explicit ``server`` argument (trailing-slash stripped).
+      2. ``SCITEX_HUB_URL`` env var.
+      3. ``server`` field from cached ``token.json``.
+      4. ``https://scitex.ai`` default.
+    """
+    if server:
+        return server.rstrip("/")
+    env_url = os.environ.get("SCITEX_HUB_URL")
+    if env_url:
+        return env_url.rstrip("/")
+    cached = _read_cached_token() or {}
+    cached_server = cached.get("server")
+    if cached_server:
+        return str(cached_server).rstrip("/")
+    return "https://scitex.ai"
+
+
+# EOF

--- a/src/scitex_hub/account/token.py
+++ b/src/scitex_hub/account/token.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_hub/account/token.py
+"""Python parity for ``scitex-hub account token {create,list,revoke}``.
+
+Each function thin-wraps the corresponding ``/api/me/...`` HTTP
+endpoint that PR #273 / #274 wired up server-side. The transport is
+the stdlib ``requests`` library — same as the CLI in
+``src/scitex_hub/_cli/_account/_token.py`` — so behaviour matches the
+shell-out path 1:1.
+
+Authentication uses :func:`scitex_hub.account._auth.resolve_bearer`,
+which fails loud (``RuntimeError``) if no token is available rather
+than silently anonymising the call.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from ._auth import resolve_bearer, resolve_server
+
+#: Default scopes for a CLI/API-issued token. Mirrors the server-side
+#: ``ALLOWED_CLI_SCOPES`` allowlist on
+#: ``apps.infra.accounts_app.views.me_token_views``.
+DEFAULT_SCOPES: tuple[str, ...] = ("publish",)
+
+
+def create(
+    name: str = "scitex-hub-api",
+    scopes: Sequence[str] | None = None,
+    *,
+    user: str | None = None,
+    password: str | None = None,
+    server: str | None = None,
+    request_fn=None,
+) -> dict:
+    """Mint a new ``scitex_xxxx`` API token.
+
+    POSTs to ``/api/me/token/``. Server-side validates the scope
+    allowlist (currently ``{"publish"}``), rate-limits per-IP +
+    per-username, and uses a constant-time error path so a wrong
+    password is indistinguishable from an unknown user.
+
+    Args:
+        name: Human-readable name for the token (visible in the UI).
+            Defaults to ``"scitex-hub-api"`` so the agent-programmatic
+            path is visually distinct from the CLI default
+            (``"scitex-hub-cli"``).
+        scopes: Iterable of scope strings. Defaults to
+            :data:`DEFAULT_SCOPES`.
+        user: Username for basic-auth minting. Required when calling
+            ``create()`` without an existing cached bearer token (the
+            normal first-time login flow).
+        password: Password for basic-auth minting. Required alongside
+            ``user``.
+        server: Override server URL. Defaults to
+            :func:`._auth.resolve_server` (env / cache / scitex.ai).
+        request_fn: Dependency-injection seam for the HTTP transport.
+            When ``None``, uses ``requests.post`` directly. Tests pass
+            a hand-rolled fake (see ``tests/scitex_hub/account/``).
+
+    Returns:
+        Dict with ``token``, ``prefix``, ``scopes``, and ``name``.
+
+    Raises:
+        ValueError: ``user``/``password`` missing (no other auth path).
+        RuntimeError: Server rejected the request (bad creds, scope
+            not allowlisted, rate limit, etc.).
+
+    Example:
+        >>> from scitex_hub.account import token
+        >>> token.create(name="ci", scopes=["publish"],
+        ...              user="ywatanabe", password="...")
+        {'token': 'scitex_...', 'prefix': '...',
+         'scopes': ['publish'], 'name': 'ci'}
+    """
+    if user is None or password is None:
+        raise ValueError(
+            "token.create requires user= and password= "
+            "(basic-auth path — bearer-only minting is not supported)"
+        )
+    # NOTE: cannot use the ``list`` builtin here — we expose ``list``
+    # as a module-level alias for :func:`list_` (CLI-verb mirror), and
+    # that alias shadows the builtin inside this module. Use literal
+    # unpacking instead.
+    scope_list = [*scopes] if scopes is not None else [*DEFAULT_SCOPES]
+    server_url = resolve_server(server)
+    body = {
+        "username": user,
+        "password": password,
+        "scopes": scope_list,
+        "name": name,
+    }
+    do_request = request_fn if request_fn is not None else _default_post
+    resp = do_request(f"{server_url}/api/me/token/", body)
+    return _handle_create_response(resp)
+
+
+def list_() -> list[dict]:
+    """List existing API tokens (never re-shows the secret value).
+
+    GETs ``/api/me/tokens/`` with the cached bearer token. Useful for
+    answering "is my CI token still active?" without re-minting.
+
+    Returns:
+        List of token-metadata dicts. Each row carries ``id``,
+        ``name``, ``prefix``, ``scopes``, ``is_active``,
+        ``created_at``, and ``last_used_at`` — but never the secret
+        token itself (only ``create`` ever returns the secret).
+
+    Raises:
+        RuntimeError: No bearer token resolved
+            (:func:`._auth.resolve_bearer`) or server returned non-200.
+
+    Example:
+        >>> from scitex_hub.account import token
+        >>> token.list_()
+        [{'id': 1, 'name': 'cli', 'prefix': 'scitex_abcd',
+          'scopes': ['publish'], 'is_active': True, ...}]
+    """
+    bearer = resolve_bearer()
+    server_url = resolve_server()
+    resp = _default_get(
+        f"{server_url}/api/me/tokens/",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    if resp["status_code"] != 200:
+        raise RuntimeError(f"HTTP {resp['status_code']}: {resp['text'][:200]}")
+    # ``list`` builtin is shadowed by the module-level alias; literal-unpack instead.
+    return [*resp["json"].get("tokens", [])]
+
+
+# Public alias — `list` is a builtin so we expose both names. Callers
+# can write either ``token.list()`` or ``token.list_()``. The trailing
+# underscore is conventional PEP-8 for builtin-shadowing avoidance,
+# the no-underscore form matches the literal CLI verb name.
+list = list_  # noqa: A001  — intentional CLI-verb mirror; see docstring
+
+
+def revoke(token_id: int) -> dict:
+    """Revoke a single API token by id.
+
+    DELETEs ``/api/me/token/{token_id}/``. Server responds 204 on
+    success or 404 if the token doesn't belong to this user.
+
+    Args:
+        token_id: Server-assigned integer id (from
+            :func:`list_`).
+
+    Returns:
+        Dict ``{"success": True, "token_id": <id>}`` on success.
+
+    Raises:
+        RuntimeError: No bearer token resolved, token not found
+            (404), or any other non-204 response.
+
+    Example:
+        >>> from scitex_hub.account import token
+        >>> token.revoke(7)
+        {'success': True, 'token_id': 7}
+    """
+    bearer = resolve_bearer()
+    server_url = resolve_server()
+    resp = _default_delete(
+        f"{server_url}/api/me/token/{token_id}/",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    if resp["status_code"] == 204:
+        return {"success": True, "token_id": token_id}
+    if resp["status_code"] == 404:
+        raise RuntimeError(f"Token id={token_id} not found")
+    raise RuntimeError(f"HTTP {resp['status_code']}: {resp['text'][:200]}")
+
+
+def _handle_create_response(resp: dict) -> dict:
+    """Normalise the ``/api/me/token/`` response into a plain dict."""
+    status = resp["status_code"]
+    if status == 201:
+        return dict(resp["json"])
+    if status == 401:
+        raise RuntimeError("Authentication failed: wrong username or password")
+    if status == 400:
+        try:
+            err = resp["json"].get("error", resp["text"])
+        except (AttributeError, KeyError):
+            err = resp["text"]
+        raise RuntimeError(f"Bad request: {err}")
+    if status == 429:
+        raise RuntimeError("Too many attempts: rate-limited; try again later")
+    raise RuntimeError(f"Unexpected response HTTP {status}: {resp['text'][:200]}")
+
+
+def _default_post(url: str, body: dict) -> dict:
+    """Default POST transport (used when no ``request_fn`` is injected).
+
+    Wraps the response in a plain dict so the same shape works for
+    real HTTP and for the hand-rolled test fakes — no ``requests``
+    object leaks across the boundary.
+    """
+    import requests
+
+    r = requests.post(url, json=body, timeout=20)
+    return _wrap(r)
+
+
+def _default_get(url: str, headers: dict) -> dict:
+    import requests
+
+    r = requests.get(url, headers=headers, timeout=15)
+    return _wrap(r)
+
+
+def _default_delete(url: str, headers: dict) -> dict:
+    import requests
+
+    r = requests.delete(url, headers=headers, timeout=15)
+    return _wrap(r)
+
+
+def _wrap(r) -> dict:
+    """Turn a ``requests.Response`` into a dict the handlers expect."""
+    try:
+        body = r.json()
+    except Exception:
+        body = {}
+    return {
+        "status_code": r.status_code,
+        "json": body,
+        "text": r.text,
+    }
+
+
+# EOF

--- a/src/scitex_hub/account/whoami.py
+++ b/src/scitex_hub/account/whoami.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_hub/account/whoami.py
+"""Python parity for ``scitex-hub account whoami``.
+
+Same identity probe the CLI ``whoami`` verb hits — ``GET /api/me/`` —
+so an agent-programmatic caller can confirm "is my cached token still
+valid?" without shelling out.
+"""
+
+from __future__ import annotations
+
+from ._auth import resolve_bearer, resolve_server
+
+
+def whoami(*, server: str | None = None, request_fn=None) -> dict:
+    """Return the username + email the cached bearer authenticates as.
+
+    Args:
+        server: Override server URL. Defaults to
+            :func:`._auth.resolve_server` (env / cache / scitex.ai).
+        request_fn: Dependency-injection seam for the HTTP GET. When
+            ``None``, uses ``requests.get``. Tests inject a fake that
+            returns the same ``{status_code, json, text}`` dict shape
+            the real transport produces.
+
+    Returns:
+        Dict with at least ``username`` and ``email`` (server may add
+        more fields like ``id`` or ``is_staff``).
+
+    Raises:
+        RuntimeError: No bearer token resolved (not logged in), token
+            expired (401), or server returned non-200.
+
+    Example:
+        >>> from scitex_hub.account.whoami import whoami
+        >>> whoami()
+        {'username': 'ywatanabe', 'email': 'ywatanabe@scitex.ai'}
+    """
+    bearer = resolve_bearer()
+    server_url = resolve_server(server)
+    do_request = request_fn if request_fn is not None else _default_get
+    resp = do_request(
+        f"{server_url}/api/me/",
+        {"Authorization": f"Bearer {bearer}"},
+    )
+    status = resp["status_code"]
+    if status == 401:
+        raise RuntimeError("Token expired or invalid")
+    if status != 200:
+        raise RuntimeError(f"HTTP {status}: {resp['text'][:200]}")
+    return dict(resp["json"])
+
+
+def _default_get(url: str, headers: dict) -> dict:
+    """Default GET transport — wraps ``requests`` into the dict shape."""
+    import requests
+
+    r = requests.get(url, headers=headers, timeout=10)
+    try:
+        body = r.json()
+    except Exception:
+        body = {}
+    return {
+        "status_code": r.status_code,
+        "json": body,
+        "text": r.text,
+    }
+
+
+# EOF

--- a/tests/scitex_hub/account/conftest.py
+++ b/tests/scitex_hub/account/conftest.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_hub/account/conftest.py
+"""Shared fixtures for ``scitex_hub.account`` tests.
+
+The ecosystem-wide rule forbids ``monkeypatch`` (STX-NM002) — every
+test that needs an env-var twist must use a real ``yield``-based
+fixture that sets the var on the live ``os.environ`` and restores
+the prior state on teardown.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture
+def env_token() -> Iterator[str]:
+    """Set ``SCITEX_HUB_TOKEN`` for the duration of the test."""
+    prior = os.environ.get("SCITEX_HUB_TOKEN")
+    os.environ["SCITEX_HUB_TOKEN"] = "scitex_test_token"
+    try:
+        yield "scitex_test_token"
+    finally:
+        if prior is None:
+            os.environ.pop("SCITEX_HUB_TOKEN", None)
+        else:
+            os.environ["SCITEX_HUB_TOKEN"] = prior
+
+
+@pytest.fixture
+def env_url() -> Iterator[str]:
+    """Set ``SCITEX_HUB_URL`` to a known test host."""
+    prior = os.environ.get("SCITEX_HUB_URL")
+    os.environ["SCITEX_HUB_URL"] = "https://hub.test.example"
+    try:
+        yield "https://hub.test.example"
+    finally:
+        if prior is None:
+            os.environ.pop("SCITEX_HUB_URL", None)
+        else:
+            os.environ["SCITEX_HUB_URL"] = prior
+
+
+@pytest.fixture
+def env_no_token_and_homeless(tmp_path) -> Iterator[None]:
+    """Clear ``SCITEX_HUB_TOKEN`` AND point ``HOME`` at an empty tmpdir.
+
+    Combined: guarantees ``resolve_bearer`` can find neither an env
+    token nor a cached ``token.json`` — so the "not logged in" path is
+    exercised against the real resolver, not a mocked one.
+    """
+    prior_token = os.environ.get("SCITEX_HUB_TOKEN")
+    prior_home = os.environ.get("HOME")
+    os.environ.pop("SCITEX_HUB_TOKEN", None)
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield
+    finally:
+        if prior_token is None:
+            os.environ.pop("SCITEX_HUB_TOKEN", None)
+        else:
+            os.environ["SCITEX_HUB_TOKEN"] = prior_token
+        if prior_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = prior_home
+
+
+# EOF

--- a/tests/scitex_hub/account/test_token.py
+++ b/tests/scitex_hub/account/test_token.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_hub/account/test_token.py
+"""Unit tests for ``scitex_hub.account.token`` Python parity.
+
+Mirrors the hand-rolled fake-server pattern from
+``tests/scitex_hub/test_project_create_category.py``: no mocks, no
+``monkeypatch`` — production code exposes a ``request_fn`` /
+transport-injection seam and tests pass a tiny ``_FakePost`` recording
+the calls. Env vars are handled by ``yield``-based fixtures in
+``conftest.py``.
+
+One assertion per test (STX-TQ007); AAA marker comments mandatory
+(STX-TQ002).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class _FakePost:
+    """Hand-rolled stand-in for ``token._default_post``.
+
+    Returns a configurable response dict and records the (url, body)
+    of every call on ``self.calls`` for inspection.
+    """
+
+    response: dict[str, Any] = field(
+        default_factory=lambda: {
+            "status_code": 201,
+            "json": {
+                "token": "scitex_abcd1234efgh5678",
+                "prefix": "scitex_abcd",
+                "scopes": ["publish"],
+                "name": "ci",
+            },
+            "text": "",
+        }
+    )
+    calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    def __call__(self, url: str, body: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append((url, body))
+        return self.response
+
+    @property
+    def last_body(self) -> dict[str, Any]:
+        return self.calls[-1][1]
+
+    @property
+    def last_url(self) -> str:
+        return self.calls[-1][0]
+
+
+def test_account_namespace_exposes_token_submodule():
+    # Arrange
+    import scitex_hub
+
+    # Act
+    obj = scitex_hub.account.token
+
+    # Assert
+    assert obj is not None
+
+
+def test_account_namespace_exposes_whoami_submodule():
+    # Arrange
+    import scitex_hub
+
+    # Act
+    obj = scitex_hub.account.whoami
+
+    # Assert
+    assert obj is not None
+
+
+def test_token_create_requires_user_argument():
+    # Arrange
+    from scitex_hub.account import token
+
+    raised: Exception | None = None
+
+    # Act
+    try:
+        token.create(
+            name="x",
+            scopes=["publish"],
+            password="pw",  # pragma: allowlist secret  # pragma: allowlist secret
+        )
+    except ValueError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "user=" in str(raised)
+
+
+def test_token_create_requires_password_argument():
+    # Arrange
+    from scitex_hub.account import token
+
+    raised: Exception | None = None
+
+    # Act
+    try:
+        token.create(name="x", scopes=["publish"], user="u")
+    except ValueError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "password=" in str(raised)
+
+
+def test_token_create_posts_to_me_token_endpoint():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost()
+
+    # Act
+    token.create(
+        name="ci",
+        scopes=["publish"],
+        user="ywatanabe",
+        password="pw",  # pragma: allowlist secret
+        server="https://hub.test.example",
+        request_fn=fake,
+    )
+
+    # Assert
+    assert fake.last_url == "https://hub.test.example/api/me/token/"
+
+
+def test_token_create_sends_username_in_body():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost()
+
+    # Act
+    token.create(
+        user="ywatanabe",
+        password="pw",  # pragma: allowlist secret
+        server="https://hub.test.example",
+        request_fn=fake,
+    )
+
+    # Assert
+    assert fake.last_body["username"] == "ywatanabe"
+
+
+def test_token_create_sends_password_in_body():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost()
+
+    # Act
+    token.create(
+        user="ywatanabe",
+        password="pw",  # pragma: allowlist secret
+        server="https://hub.test.example",
+        request_fn=fake,
+    )
+
+    # Assert
+    assert fake.last_body["password"] == "pw"  # pragma: allowlist secret
+
+
+def test_token_create_default_scopes_are_publish():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost()
+
+    # Act
+    token.create(
+        user="u",
+        password="p",
+        server="https://hub.test.example",
+        request_fn=fake,
+    )
+
+    # Assert
+    assert fake.last_body["scopes"] == ["publish"]
+
+
+def test_token_create_explicit_scopes_round_trip():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost()
+
+    # Act
+    token.create(
+        user="u",
+        password="p",
+        scopes=["publish", "future-scope"],
+        server="https://hub.test.example",
+        request_fn=fake,
+    )
+
+    # Assert
+    assert fake.last_body["scopes"] == ["publish", "future-scope"]
+
+
+def test_token_create_returns_minted_token_value():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost()
+
+    # Act
+    out = token.create(
+        user="u",
+        password="p",
+        server="https://hub.test.example",
+        request_fn=fake,
+    )
+
+    # Assert
+    assert out["token"] == "scitex_abcd1234efgh5678"
+
+
+def test_token_create_returns_prefix_field():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost()
+
+    # Act
+    out = token.create(
+        user="u",
+        password="p",
+        server="https://hub.test.example",
+        request_fn=fake,
+    )
+
+    # Assert
+    assert out["prefix"] == "scitex_abcd"
+
+
+def test_token_create_401_raises_runtime_error():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost(response={"status_code": 401, "json": {}, "text": "unauthorized"})
+    raised: Exception | None = None
+
+    # Act
+    try:
+        token.create(
+            user="u",
+            password="bad",  # pragma: allowlist secret
+            server="https://hub.test.example",
+            request_fn=fake,
+        )
+    except RuntimeError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "Authentication failed" in str(raised)
+
+
+def test_token_create_429_raises_rate_limit_runtime_error():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost(response={"status_code": 429, "json": {}, "text": "rate limited"})
+    raised: Exception | None = None
+
+    # Act
+    try:
+        token.create(
+            user="u",
+            password="p",
+            server="https://hub.test.example",
+            request_fn=fake,
+        )
+    except RuntimeError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "rate-limited" in str(raised)
+
+
+def test_token_create_400_surfaces_server_error_field():
+    # Arrange
+    from scitex_hub.account import token
+
+    fake = _FakePost(
+        response={
+            "status_code": 400,
+            "json": {"error": "scope not allowlisted"},
+            "text": '{"error": "scope not allowlisted"}',
+        }
+    )
+    raised: Exception | None = None
+
+    # Act
+    try:
+        token.create(
+            user="u",
+            password="p",
+            scopes=["root"],
+            server="https://hub.test.example",
+            request_fn=fake,
+        )
+    except RuntimeError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "scope not allowlisted" in str(raised)
+
+
+def test_token_list_alias_points_at_list_underscore():
+    # Arrange
+    from scitex_hub.account import token
+
+    # Act
+    same = token.list is token.list_
+
+    # Assert
+    assert same
+
+
+def test_default_scopes_constant_is_publish_only():
+    # Arrange
+    from scitex_hub.account.token import DEFAULT_SCOPES
+
+    # Act
+    actual = tuple(DEFAULT_SCOPES)
+
+    # Assert
+    assert actual == ("publish",)
+
+
+# EOF

--- a/tests/scitex_hub/account/test_whoami.py
+++ b/tests/scitex_hub/account/test_whoami.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_hub/account/test_whoami.py
+"""Unit tests for ``scitex_hub.account.whoami``.
+
+Same hand-rolled fake-transport pattern as ``test_token.py`` — no
+``monkeypatch``, env vars handled via ``yield``-based fixtures in
+``conftest.py`` (``env_token``, ``env_no_token_and_homeless``). One
+assertion per test, AAA-marker comments mandatory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class _FakeGet:
+    """Hand-rolled stand-in for ``whoami._default_get``."""
+
+    response: dict[str, Any] = field(
+        default_factory=lambda: {
+            "status_code": 200,
+            "json": {
+                "username": "ywatanabe",
+                "email": "ywatanabe@scitex.ai",
+            },
+            "text": "",
+        }
+    )
+    calls: list[tuple[str, dict[str, str]]] = field(default_factory=list)
+
+    def __call__(self, url: str, headers: dict[str, str]) -> dict[str, Any]:
+        self.calls.append((url, headers))
+        return self.response
+
+    @property
+    def last_url(self) -> str:
+        return self.calls[-1][0]
+
+    @property
+    def last_headers(self) -> dict[str, str]:
+        return self.calls[-1][1]
+
+
+def test_whoami_unauthenticated_raises_runtime_error(env_no_token_and_homeless):
+    # Arrange
+    from scitex_hub.account import whoami as whoami_mod
+
+    raised: Exception | None = None
+
+    # Act
+    try:
+        whoami_mod.whoami()
+    except RuntimeError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "not logged in" in str(raised)
+
+
+def test_whoami_hits_me_endpoint(env_token):
+    # Arrange
+    from scitex_hub.account import whoami as whoami_mod
+
+    fake = _FakeGet()
+
+    # Act
+    whoami_mod.whoami(server="https://hub.test.example", request_fn=fake)
+
+    # Assert
+    assert fake.last_url == "https://hub.test.example/api/me/"
+
+
+def test_whoami_sends_bearer_header(env_token):
+    # Arrange
+    from scitex_hub.account import whoami as whoami_mod
+
+    fake = _FakeGet()
+
+    # Act
+    whoami_mod.whoami(server="https://hub.test.example", request_fn=fake)
+
+    # Assert
+    assert fake.last_headers["Authorization"] == "Bearer scitex_test_token"
+
+
+def test_whoami_returns_username(env_token):
+    # Arrange
+    from scitex_hub.account import whoami as whoami_mod
+
+    fake = _FakeGet()
+
+    # Act
+    out = whoami_mod.whoami(server="https://hub.test.example", request_fn=fake)
+
+    # Assert
+    assert out["username"] == "ywatanabe"
+
+
+def test_whoami_returns_email(env_token):
+    # Arrange
+    from scitex_hub.account import whoami as whoami_mod
+
+    fake = _FakeGet()
+
+    # Act
+    out = whoami_mod.whoami(server="https://hub.test.example", request_fn=fake)
+
+    # Assert
+    assert out["email"] == "ywatanabe@scitex.ai"
+
+
+def test_whoami_401_raises_token_expired(env_token):
+    # Arrange
+    from scitex_hub.account import whoami as whoami_mod
+
+    fake = _FakeGet(response={"status_code": 401, "json": {}, "text": "unauthorized"})
+    raised: Exception | None = None
+
+    # Act
+    try:
+        whoami_mod.whoami(server="https://hub.test.example", request_fn=fake)
+    except RuntimeError as exc:
+        raised = exc
+
+    # Assert
+    assert raised is not None and "expired" in str(raised).lower()
+
+
+def test_whoami_server_override_takes_precedence(env_token, env_url):
+    # Arrange
+    from scitex_hub.account import whoami as whoami_mod
+
+    fake = _FakeGet()
+
+    # Act
+    whoami_mod.whoami(server="https://override.example", request_fn=fake)
+
+    # Assert
+    assert fake.last_url == "https://override.example/api/me/"
+
+
+# EOF


### PR DESCRIPTION
## Summary

Card #3 of lead's 7-card Phase-1 backlog (msg 920a7ece). Mirror the `scitex-hub account` CLI surface (PR #274) in the Python API so a user / agent can write:

```python
import scitex_hub
scitex_hub.account.whoami()
scitex_hub.account.token.create(name="cli", scopes=["publish"], user="...", password="...")
scitex_hub.account.token.list()
scitex_hub.account.token.revoke(token_id=42)
```

…instead of shelling out to the CLI.

## Layout

- `src/scitex_hub/account/__init__.py` — exposes `token` + `whoami`
- `src/scitex_hub/account/token.py` — create / list / revoke thin wrappers around `/api/me/token/`, `/api/me/tokens/`, `/api/me/token/<id>/`
- `src/scitex_hub/account/whoami.py` — thin wrapper around `/api/me/`
- `src/scitex_hub/account/_auth.py` — shared PAT resolution (env `SCITEX_HUB_TOKEN` → `~/.scitex/cloud/runtime/token.json`, loud `RuntimeError` when neither set per no-silent-fallback rule)

## Tests

`tests/scitex_hub/account/test_token.py` + `test_whoami.py` use a hand-rolled fake transport via dependency injection (no `unittest.mock`, per STX-NM), mirroring the pattern in `tests/scitex_hub/project/`.

## Out of scope for this chunk

- `scitex_hub.gitea.*` Python parity (follow-up)
- `scitex_hub.docker.*` Python parity (follow-up)
- `scitex_hub.mcp.*` Python parity (follow-up)

## Family

Pairs with PR #280 (card #2 — auth login CLI) + PR #281 (card #5 — MCP token-aware): the same `~/.scitex/cloud/runtime/token.json` cache feeds all three.