### PR TITLE
chore(cli): hub-audit-cli-pass — deploy + context + mcp noun groups (2 of N)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -352,7 +352,7 @@
         "filename": "src/scitex_hub/_cli/mcp.py",
         "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
         "is_verified": false,
-        "line_number": 221
+        "line_number": 243
       }
     ],
     "src/scitex_hub/_skills/scitex-hub/30_infrastructure.md": [
@@ -528,5 +528,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T12:26:55Z"
+  "generated_at": "2026-06-13T11:50:32Z"
 }

--- a/src/scitex_hub/_cli/context.py
+++ b/src/scitex_hub/_cli/context.py
@@ -7,6 +7,14 @@ import json
 
 import click
 
+from ._flags import (
+    confirm_or_abort,
+    emit_json,
+    json_flag,
+    mutating_flags,
+    print_dry_run,
+)
+
 
 @click.group()
 def context():
@@ -16,54 +24,85 @@ def context():
     Query web app state, evaluate JS, and drive browser UI.
 
     \b
-    Examples:
-        scitex-hub context get                # Get full context
+    Example:
+        scitex-hub context get                 # Get full context
         scitex-hub context get --page /writer/ # Context for writer page
         scitex-hub context eval "document.title"
+        scitex-hub context trigger-action '[{"action":"click","selector":"#go"}]'
     """
 
 
 @context.command("get")
 @click.option("--page", default="", help="Current page URL (e.g. /writer/)")
-@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
-def context_get(page, as_json):
-    """Get web app context: username, page, skills, available actions."""
+@json_flag()
+def context_get(page, json_output):
+    """Get web app context: username, page, skills, available actions.
+
+    \b
+    Example:
+        scitex-hub context get
+        scitex-hub context get --page /writer/
+        scitex-hub context get --json
+    """
     from .._api import CloudClient
 
     client = CloudClient()
     result = client.get_context(page)
 
-    if as_json:
-        click.echo(json.dumps(result, indent=2, default=str))
-    else:
-        click.echo(click.style("Web App Context", fg="cyan", bold=True))
-        click.echo(f"  Username: {result.get('username', 'N/A')}")
-        click.echo(f"  Page: {result.get('page', '(none)')}")
+    if json_output:
+        emit_json(result)
+        return
 
-        skill = result.get("active_skill")
-        if skill:
-            click.echo(f"  Active Skill: {skill.get('display_name', 'N/A')}")
+    click.echo(click.style("Web App Context", fg="cyan", bold=True))
+    click.echo(f"  Username: {result.get('username', 'N/A')}")
+    click.echo(f"  Page: {result.get('page', '(none)')}")
 
-        skills = result.get("all_skills", {})
-        if skills:
-            click.echo(f"  Registered Skills: {len(skills)}")
-            for name, s in sorted(skills.items()):
-                click.echo(f"    - {s.get('display_name', name)}")
+    skill = result.get("active_skill")
+    if skill:
+        click.echo(f"  Active Skill: {skill.get('display_name', 'N/A')}")
 
-        actions = result.get("available_actions", [])
-        if actions:
-            click.echo(f"  Actions: {', '.join(actions)}")
+    skills = result.get("all_skills", {})
+    if skills:
+        click.echo(f"  Registered Skills: {len(skills)}")
+        for name, s in sorted(skills.items()):
+            click.echo(f"    - {s.get('display_name', name)}")
 
-        media = result.get("media_rendering", [])
-        if media:
-            click.echo(f"  Media: {', '.join(media)}")
+    actions = result.get("available_actions", [])
+    if actions:
+        click.echo(f"  Actions: {', '.join(actions)}")
+
+    media = result.get("media_rendering", [])
+    if media:
+        click.echo(f"  Media: {', '.join(media)}")
 
 
 @context.command("eval")
 @click.argument("code")
 @click.option("--timeout", type=int, default=10, help="Timeout in seconds (max 30)")
-def context_eval(code, timeout):
-    """Evaluate JavaScript in the user's browser."""
+@mutating_flags()
+def context_eval(code, timeout, dry_run, yes):
+    """Evaluate JavaScript in the user's browser.
+
+    Executes ``code`` remotely; the result is whatever the JS expression
+    returns. This is a side-effectful operation (mutating verb): it may
+    drive the user's browser, so ``--dry-run`` / ``--yes`` apply.
+
+    \b
+    Example:
+        scitex-hub context eval "document.title"
+        scitex-hub context eval "window.scrollTo(0, 0)" --yes
+        scitex-hub context eval "document.title" --dry-run
+    """
+    if dry_run:
+        print_dry_run(f"evaluate JS in user's browser (timeout={timeout}s): {code!r}")
+        return
+
+    confirm_or_abort(
+        f"Evaluate JS in user's browser: {code!r}?",
+        yes=yes,
+        dry_run=dry_run,
+    )
+
     from .._api import CloudClient
 
     client = CloudClient()
@@ -78,16 +117,36 @@ def context_eval(code, timeout):
 @context.command("trigger-action")
 @click.argument("steps_json")
 @click.option("--delay", type=int, default=900, help="Delay between steps (ms)")
-def context_action(steps_json, delay):
+@mutating_flags()
+def context_action(steps_json, delay, dry_run, yes):
     """Send UI action steps to the browser.
 
     STEPS_JSON is a JSON array of action dicts.
+
+    \b
+    Example:
+        scitex-hub context trigger-action '[{"action":"click","selector":"#go"}]'
+        scitex-hub context trigger-action '[{"action":"type","text":"hi"}]' --delay 500
+        scitex-hub context trigger-action '[{"action":"click","selector":"#go"}]' --yes
     """
     try:
         steps = json.loads(steps_json)
     except json.JSONDecodeError:
         click.echo(click.style("Error: Invalid JSON", fg="red"), err=True)
+        raise SystemExit(1)
+
+    if dry_run:
+        print_dry_run(
+            f"send {len(steps)} UI action step(s) to browser "
+            f"(delay={delay}ms): {steps_json}"
+        )
         return
+
+    confirm_or_abort(
+        f"Send {len(steps)} UI action step(s) to user's browser?",
+        yes=yes,
+        dry_run=dry_run,
+    )
 
     from .._api import CloudClient
 

--- a/src/scitex_hub/_cli/deploy.py
+++ b/src/scitex_hub/_cli/deploy.py
@@ -10,6 +10,7 @@ import click
 
 from .._config._environments import ENVIRONMENTS, get_environment
 from .._utils._docker import DockerManager
+from ._flags import confirm_or_abort, mutating_flags, print_dry_run
 
 
 @click.command()
@@ -21,8 +22,8 @@ from .._utils._docker import DockerManager
 )
 @click.option("--build", is_flag=True, help="Rebuild containers before deploying")
 @click.option("--no-cache", is_flag=True, help="Build without cache")
-@click.pass_context
-def deploy(ctx, env, build, no_cache):
+@mutating_flags()
+def deploy(env, build, no_cache, dry_run, yes):
     """Deploy SciTeX Hub.
 
     \b
@@ -30,12 +31,29 @@ def deploy(ctx, env, build, no_cache):
     Automatically handles configuration and container orchestration.
 
     \b
-    Examples:
-        scitex-hub deploy              # Deploy with current settings
-        scitex-hub deploy --env prod   # Deploy to production environment
-        scitex-hub deploy --build      # Rebuild and deploy
+    Example:
+        scitex-hub deploy-project              # Deploy with current settings
+        scitex-hub deploy-project --env prod   # Deploy to production environment
+        scitex-hub deploy-project --build      # Rebuild and deploy
+        scitex-hub deploy-project --dry-run    # Show what would be deployed
+        scitex-hub deploy-project --env prod --yes
     """
     environment = get_environment(env)
+
+    if dry_run:
+        action = (
+            f"deploy SciTeX Hub to '{environment.description}' "
+            f"(build={build}, no_cache={no_cache})"
+        )
+        print_dry_run(action)
+        return
+
+    confirm_or_abort(
+        f"Deploy SciTeX Hub to '{environment.description}'?",
+        yes=yes,
+        dry_run=dry_run,
+    )
+
     click.echo(
         click.style(f"Deploying: {environment.description}", fg="cyan", bold=True)
     )

--- a/src/scitex_hub/_cli/mcp.py
+++ b/src/scitex_hub/_cli/mcp.py
@@ -7,6 +7,14 @@ import sys
 
 import click
 
+from ._flags import (
+    confirm_or_abort,
+    emit_json,
+    json_flag,
+    mutating_flags,
+    print_dry_run,
+)
+
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
@@ -78,13 +86,23 @@ def mcp_start(transport: str, host: str, port: int):
           }
         }
       }
+
+    \b
+    Example:
+        scitex-hub mcp start
+        scitex-hub mcp start -t http --host 0.0.0.0 --port 8086
     """
     run_mcp_server(transport, host, port)
 
 
 @mcp.command("doctor", context_settings=CONTEXT_SETTINGS)
 def mcp_doctor():
-    """Diagnose MCP server setup and dependencies."""
+    """Diagnose MCP server setup and dependencies.
+
+    \b
+    Example:
+        scitex-hub mcp doctor
+    """
     click.echo("MCP Server Diagnostics")
     click.echo("=" * 50)
     click.echo()
@@ -203,6 +221,10 @@ def mcp_install():
     """Show MCP client installation instructions.
 
     (rename of show-installation)
+
+    \b
+    Example:
+        scitex-hub mcp install
     """
     click.echo("MCP Client Configuration")
     click.echo("=" * 50)
@@ -269,8 +291,8 @@ def _format_signature(tool_obj, indent: str = "  ") -> str:
 @click.option(
     "-v", "--verbose", count=True, help="Verbosity: -v sig, -vv +desc, -vvv full"
 )
-@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
-def mcp_list_tools(verbose: int, as_json: bool):
+@json_flag()
+def mcp_list_tools(verbose: int, json_output: bool):
     """List available MCP tools.
 
     \b
@@ -279,7 +301,14 @@ def mcp_list_tools(verbose: int, as_json: bool):
       -v      - Signatures
       -vv     - Signatures + one-line description
       -vvv    - Signatures + full description
+
+    \b
+    Example:
+        scitex-hub mcp list-tools
+        scitex-hub mcp list-tools -v
+        scitex-hub mcp list-tools --json
     """
+    as_json = json_output
     try:
         from .._mcp_server import FASTMCP_AVAILABLE
         from .._mcp_server import mcp as mcp_server
@@ -305,8 +334,6 @@ def mcp_list_tools(verbose: int, as_json: bool):
         modules[prefix].append(name)
 
     if as_json:
-        import json
-
         output = {
             "name": "scitex-hub",
             "total": len(tools_dict),
@@ -326,7 +353,7 @@ def mcp_list_tools(verbose: int, as_json: bool):
                 for mod, tool_list in modules.items()
             },
         }
-        click.echo(json.dumps(output, indent=2))
+        emit_json(output)
         return
 
     total = len(tools_dict)
@@ -360,8 +387,7 @@ def run_mcp_server(transport: str, host: str, port: int):
         from .._mcp_server import run_server
     except ImportError:
         click.echo(
-            "MCP server requires fastmcp. Install with:\n"
-            "  pip install scitex-hub[mcp]",
+            "MCP server requires fastmcp. Install with:\n  pip install scitex-hub[mcp]",
             err=True,
         )
         sys.exit(1)


### PR DESCRIPTION
## Summary

Chunk 2 of the `hub-audit-cli-pass` campaign (card #7). Mirrors the helper
pattern PR #278 introduced for the gitea noun group, extending it to:

- `scitex-hub deploy-project` (root-level deploy)
- `scitex-hub context` group (`get`, `eval`, `trigger-action`)
- `scitex-hub mcp` group (`start`, `doctor`, `install`, `list-tools`)

### §2 (universal flags) — mutating verbs
Added `--dry-run` + `--yes/-y` with real effects (not no-ops):
- `deploy-project`
- `context eval`
- `context trigger-action`

### §2 — read verbs
Migrated to canonical `--json` via `_flags.json_flag()` + `_flags.emit_json`:
- `context get` (was raw `--json/as_json`)
- `mcp list-tools` (was raw `--json/as_json`)

### §4 — concrete `Example:` block
Added to every leaf command's docstring:
- `deploy-project`
- `context` group + `get` + `eval` + `trigger-action`
- `mcp start` + `doctor` + `install` + `list-tools`

## Coverage notes

- The `app` noun group (under `_cli/_app/`) was already conformant via PR
  #219 and commit d755f5834. No changes needed this chunk.
- `mcp start` is a server-startup verb — adding `--dry-run` requires
  plumbing through the FastMCP runner, which is non-trivial and deferred
  to a follow-up. Only the `Example:` block was added.
- No `skip_rules` / `# stx-allow:` entries added (operator policy
  2026-06-12 msg 78).
- All three files stay well under the 512-line cap.

## Remaining noun groups for subsequent chunks
Per the chunk plan in PR #278:
- `workspace`
- `docker`
- `sdk`
- `setup`
- `project`
- `sync`
- `ssh`
- `completion`
- `show-status` (root)

## Test plan

- [x] CLI `--help` shows new flags and `Example:` blocks on
  `deploy-project`, `context get/eval/trigger-action`, `mcp
  doctor/install/list-tools/start`.
- [x] Modules import cleanly (`scitex_hub._cli.deploy`,
  `scitex_hub._cli.context`, `scitex_hub._cli.mcp`).
- [ ] CI `scitex-hub-quality-audit-on-ubuntu-latest` continues passing
  (skip_rules still cover §2/§4/§5/§6/§6b until all groups land).
- [ ] Once every group is conformant, drop the audit-cli skip_rules
  entries from `tests/develop/test_audit.py` in a final chunk.
