### PR TITLE
chore(cli): hub-audit-cli-pass — workspace + docker + sdk noun groups (3 of N)

### DIFF
--- a/src/scitex_hub/_cli/_workspace_cmds.py
+++ b/src/scitex_hub/_cli/_workspace_cmds.py
@@ -12,6 +12,13 @@ from pathlib import Path
 import click
 import requests
 
+from ._flags import (
+    confirm_or_abort,
+    emit_json,
+    json_flag,
+    mutating_flags,
+    print_dry_run,
+)
 from ._workspace_auth import (
     TOKEN_CACHE_PATH,
     auth_headers,
@@ -138,7 +145,8 @@ def _setup_remote_and_push(server_url, username, project_name, remote_name):
     default=True,
     help="Push code after creating the project (default: yes)",
 )
-def upload(name, description, server, visibility, remote, push):
+@mutating_flags()
+def upload(name, description, server, visibility, remote, push, dry_run, yes):
     """Upload current directory as a new workspace project.
 
     Creates a project record on the SciTeX server, which auto-creates a
@@ -147,9 +155,28 @@ def upload(name, description, server, visibility, remote, push):
 
     \b
     Similar to: gh repo create --push
+
+    \b
+    Example:
+        scitex-hub workspace upload --name my-project
+        scitex-hub workspace upload -n my-project --visibility public --yes
+        scitex-hub workspace upload --dry-run
     """
     server = get_server_url(server)
     project_name = name or Path(os.getcwd()).name
+
+    if dry_run:
+        print_dry_run(
+            f"would create project {project_name!r} on {server} "
+            f"(visibility={visibility}, push={push}, remote={remote!r})"
+        )
+        return
+
+    confirm_or_abort(
+        f"Create project {project_name!r} on {server} (visibility={visibility})?",
+        yes=yes,
+        dry_run=dry_run,
+    )
 
     token = get_jwt_token(server)
 
@@ -214,12 +241,17 @@ def upload(name, description, server, visibility, remote, push):
     show_default=True,
     help="SciTeX Hub server URL",
 )
-@click.option("--json", "as_json", is_flag=True, help="Output raw JSON")
-def list_projects(server, as_json):
+@json_flag()
+def list_projects(server, json_output):
     """List your projects on the SciTeX workspace.
 
     \b
     Similar to: gh repo list
+
+    \b
+    Example:
+        scitex-hub workspace list
+        scitex-hub workspace list --json
     """
     server = get_server_url(server)
     token = get_jwt_token(server)
@@ -243,8 +275,8 @@ def list_projects(server, as_json):
 
     projects = resp.json().get("projects", [])
 
-    if as_json:
-        click.echo(json.dumps(projects, indent=2, default=str))
+    if json_output:
+        emit_json(projects)
         return
 
     if not projects:
@@ -285,11 +317,18 @@ def list_projects(server, as_json):
     show_default=True,
     help="Sync direction",
 )
-def sync(remote, direction):
+@mutating_flags()
+def sync(remote, direction, dry_run, yes):
     """Sync local repo with workspace (pull and/or push).
 
     \b
     Similar to: git pull origin <branch> && git push origin <branch>
+
+    \b
+    Example:
+        scitex-hub workspace sync
+        scitex-hub workspace sync --direction push --yes
+        scitex-hub workspace sync --dry-run
     """
     if not _in_git_repo():
         click.echo("Error: Not in a git repository.", err=True)
@@ -299,6 +338,18 @@ def sync(remote, direction):
     if not branch:
         click.echo("Error: Not on any branch.", err=True)
         sys.exit(1)
+
+    if dry_run:
+        print_dry_run(
+            f"would sync {branch!r} with remote {remote!r} (direction={direction})"
+        )
+        return
+
+    confirm_or_abort(
+        f"Sync {branch!r} with remote {remote!r} (direction={direction})?",
+        yes=yes,
+        dry_run=dry_run,
+    )
 
     check = subprocess.run(
         ["git", "remote", "get-url", remote], capture_output=True, text=True
@@ -339,12 +390,24 @@ def sync(remote, direction):
     show_default=True,
     help="SciTeX Hub server URL",
 )
-def logout(server):
-    """Clear the cached JWT token for the given server."""
+@mutating_flags()
+def logout(server, dry_run, yes):
+    """Clear the cached JWT token for the given server.
+
+    \b
+    Example:
+        scitex-hub workspace logout
+        scitex-hub workspace logout --yes
+        scitex-hub workspace logout --dry-run
+    """
     server = get_server_url(server)
     if not TOKEN_CACHE_PATH.exists():
         click.echo("No cached token found.")
         return
+    if dry_run:
+        print_dry_run(f"would clear cached JWT token for {server}")
+        return
+    confirm_or_abort(f"Clear cached JWT token for {server}?", yes=yes, dry_run=dry_run)
     try:
         cached = json.loads(TOKEN_CACHE_PATH.read_text())
         if cached.get("server") == server:

--- a/src/scitex_hub/_cli/sdk.py
+++ b/src/scitex_hub/_cli/sdk.py
@@ -1,11 +1,61 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""SDK CLI — interact with Platform APIs (DataStore, FileVault, JobQueue)."""
+"""SDK CLI — interact with Platform APIs (DataStore, FileVault, JobQueue).
+
+Per §2 universal-flags conventions:
+  * Read verbs (``list``, ``get``, ``search``, ``show-status``) expose
+    ``--json`` for machine consumption (default ON — these commands have
+    always emitted JSON; the flag now lets callers opt out to a terse
+    human summary).
+  * Mutating verbs (``create``, ``update``, ``delete``, ``upload``,
+    ``download``, ``submit``, ``cancel``) expose ``--dry-run`` (print the
+    plan, do not call the API) and ``-y/--yes`` (skip the interactive
+    confirmation on a TTY).
+
+Every command carries a concrete ``Example:`` block in its docstring per §4.
+"""
 
 import json
 from pathlib import Path
 
 import click
+
+from ._flags import (
+    confirm_or_abort,
+    emit_json,
+    mutating_flags,
+    print_dry_run,
+)
+
+
+def _maybe_emit(result, *, as_json: bool) -> None:
+    """Render *result* either as pretty JSON or a one-line human summary.
+
+    Default behaviour preserves the historical JSON output. The ``--no-json``
+    branch prints a short summary so shell pipelines can opt into terse
+    output without parsing JSON.
+    """
+
+    if as_json:
+        emit_json(result)
+        return
+    if isinstance(result, list):
+        click.echo(f"{len(result)} item(s)")
+        return
+    if isinstance(result, dict):
+        keys = ", ".join(sorted(result)[:8])
+        click.echo(f"dict[{len(result)} keys]: {keys}")
+        return
+    click.echo(str(result))
+
+
+# Shared decorator for read verbs: --json defaults to True (historical).
+_read_json = click.option(
+    "--json/--no-json",
+    "as_json",
+    default=True,
+    help="Output as JSON (default). Use --no-json for a short summary.",
+)
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -35,38 +85,64 @@ def data():
 @click.argument("schema")
 @click.option("--filter", "filters", multiple=True, help="key=value filter pairs")
 @click.option("--project", default=None, help="Scope to project ID")
-def data_list(app, schema, filters, project):
-    """List records for an app/schema."""
+@_read_json
+def data_list(app, schema, filters, project, as_json):
+    """List records for an app/schema.
+
+    \b
+    Example:
+        scitex-hub sdk data list my-app Experiment
+        scitex-hub sdk data list my-app Experiment --filter status=done --json
+    """
     from scitex_hub.sdk import data as data_api
 
     filter_dict = dict(f.split("=", 1) for f in filters) if filters else None
     result = data_api.list_records(app, schema, filters=filter_dict, project_id=project)
-    click.echo(json.dumps(result, indent=2))
+    _maybe_emit(result, as_json=as_json)
 
 
 @data.command("get")
 @click.argument("app")
 @click.argument("schema")
 @click.argument("record_id")
-def data_get(app, schema, record_id):
-    """Get a single record by ID."""
+@_read_json
+def data_get(app, schema, record_id, as_json):
+    """Get a single record by ID.
+
+    \b
+    Example:
+        scitex-hub sdk data get my-app Experiment 42
+    """
     from scitex_hub.sdk import data as data_api
 
     result = data_api.get(app, schema, record_id)
-    click.echo(json.dumps(result, indent=2))
+    _maybe_emit(result, as_json=as_json)
 
 
 @data.command("create")
 @click.argument("app")
 @click.argument("schema")
 @click.option("--json", "json_data", required=True, help="JSON object to create")
-def data_create(app, schema, json_data):
-    """Create a new record."""
+@mutating_flags()
+def data_create(app, schema, json_data, dry_run, yes):
+    """Create a new record.
+
+    \b
+    Example:
+        scitex-hub sdk data create my-app Experiment --json '{"name":"x"}'
+        scitex-hub sdk data create my-app Experiment --json '{...}' --yes
+    """
     from scitex_hub.sdk import data as data_api
 
     payload = json.loads(json_data)
+    if dry_run:
+        print_dry_run(f"would create {schema!r} record in app {app!r}: {payload}")
+        return
+    confirm_or_abort(
+        f"Create {schema!r} record in app {app!r}?", yes=yes, dry_run=dry_run
+    )
     result = data_api.create(app, schema, payload)
-    click.echo(json.dumps(result, indent=2))
+    emit_json(result)
 
 
 @data.command("update")
@@ -74,37 +150,73 @@ def data_create(app, schema, json_data):
 @click.argument("schema")
 @click.argument("record_id")
 @click.option("--json", "json_data", required=True, help="JSON object to update")
-def data_update(app, schema, record_id, json_data):
-    """Update a record by ID."""
+@mutating_flags()
+def data_update(app, schema, record_id, json_data, dry_run, yes):
+    """Update a record by ID.
+
+    \b
+    Example:
+        scitex-hub sdk data update my-app Experiment 42 --json '{"status":"done"}'
+    """
     from scitex_hub.sdk import data as data_api
 
     payload = json.loads(json_data)
+    if dry_run:
+        print_dry_run(
+            f"would update {schema!r} record {record_id!r} in app {app!r}: {payload}"
+        )
+        return
+    confirm_or_abort(
+        f"Update {schema!r} record {record_id!r} in app {app!r}?",
+        yes=yes,
+        dry_run=dry_run,
+    )
     result = data_api.update(app, schema, record_id, payload)
-    click.echo(json.dumps(result, indent=2))
+    emit_json(result)
 
 
 @data.command("delete")
 @click.argument("app")
 @click.argument("schema")
 @click.argument("record_id")
-def data_delete(app, schema, record_id):
-    """Delete a record by ID."""
+@mutating_flags()
+def data_delete(app, schema, record_id, dry_run, yes):
+    """Delete a record by ID.
+
+    \b
+    Example:
+        scitex-hub sdk data delete my-app Experiment 42 --yes
+    """
     from scitex_hub.sdk import data as data_api
 
+    if dry_run:
+        print_dry_run(f"would delete {schema!r} record {record_id!r} in app {app!r}")
+        return
+    confirm_or_abort(
+        f"Delete {schema!r} record {record_id!r} in app {app!r}?",
+        yes=yes,
+        dry_run=dry_run,
+    )
     result = data_api.delete(app, schema, record_id)
-    click.echo(json.dumps(result, indent=2))
+    emit_json(result)
 
 
 @data.command("search")
 @click.argument("app")
 @click.argument("schema")
 @click.option("--query", "-q", required=True, help="Search query string")
-def data_search(app, schema, query):
-    """Full-text search across records."""
+@_read_json
+def data_search(app, schema, query, as_json):
+    """Full-text search across records.
+
+    \b
+    Example:
+        scitex-hub sdk data search my-app Experiment -q "kw=ripple"
+    """
     from scitex_hub.sdk import data as data_api
 
     result = data_api.search(app, schema, query)
-    click.echo(json.dumps(result, indent=2))
+    _maybe_emit(result, as_json=as_json)
 
 
 # ── FileVault ──────────────────────────────────────────────────────────
@@ -121,12 +233,19 @@ def files():
 @click.option("--path", default="", help="Subdirectory path")
 @click.option("--project", default=None, help="Scope to project")
 @click.option("--ext", default=None, help="Filter by file extension")
-def files_list(app, path, project, ext):
-    """List files in an app's vault."""
+@_read_json
+def files_list(app, path, project, ext, as_json):
+    """List files in an app's vault.
+
+    \b
+    Example:
+        scitex-hub sdk files list my-app --path exports
+        scitex-hub sdk files list my-app --ext csv --json
+    """
     from scitex_hub.sdk import files as files_api
 
     result = files_api.list_files(app, path=path, project=project, extensions=ext)
-    click.echo(json.dumps(result, indent=2))
+    _maybe_emit(result, as_json=as_json)
 
 
 @files.command("upload")
@@ -134,37 +253,79 @@ def files_list(app, path, project, ext):
 @click.argument("local_path", type=click.Path(exists=True))
 @click.argument("remote_path")
 @click.option("--project", default=None, help="Scope to project")
-def files_upload(app, local_path, remote_path, project):
-    """Upload a local file to the vault."""
+@mutating_flags()
+def files_upload(app, local_path, remote_path, project, dry_run, yes):
+    """Upload a local file to the vault.
+
+    \b
+    Example:
+        scitex-hub sdk files upload my-app local.csv exports/data.csv
+        scitex-hub sdk files upload my-app local.csv exports/data.csv --yes
+    """
     from scitex_hub.sdk import files as files_api
 
+    if dry_run:
+        size = Path(local_path).stat().st_size
+        print_dry_run(
+            f"would upload {local_path!r} ({size} B) to app {app!r} as {remote_path!r}"
+        )
+        return
+    confirm_or_abort(
+        f"Upload {local_path!r} to app {app!r} as {remote_path!r}?",
+        yes=yes,
+        dry_run=dry_run,
+    )
     content = Path(local_path).read_bytes()
     result = files_api.upload(app, remote_path, content, project=project)
-    click.echo(json.dumps(result, indent=2))
+    emit_json(result)
 
 
 @files.command("download")
 @click.argument("app")
 @click.argument("remote_path")
 @click.option("--project", default=None, help="Scope to project")
-def files_download(app, remote_path, project):
-    """Download a file from the vault."""
+@mutating_flags()
+def files_download(app, remote_path, project, dry_run, yes):
+    """Download a file from the vault.
+
+    \b
+    Example:
+        scitex-hub sdk files download my-app exports/data.csv
+    """
     from scitex_hub.sdk import files as files_api
 
+    if dry_run:
+        print_dry_run(f"would download {remote_path!r} from app {app!r}")
+        return
+    confirm_or_abort(
+        f"Download {remote_path!r} from app {app!r}?", yes=yes, dry_run=dry_run
+    )
     result = files_api.download(app, remote_path, project=project)
-    click.echo(json.dumps(result, indent=2))
+    emit_json(result)
 
 
 @files.command("delete")
 @click.argument("app")
 @click.argument("remote_path")
 @click.option("--project", default=None, help="Scope to project")
-def files_delete(app, remote_path, project):
-    """Delete a file from the vault."""
+@mutating_flags()
+def files_delete(app, remote_path, project, dry_run, yes):
+    """Delete a file from the vault.
+
+    \b
+    Example:
+        scitex-hub sdk files delete my-app exports/data.csv --yes
+    """
     from scitex_hub.sdk import files as files_api
 
+    if dry_run:
+        print_dry_run(f"would delete {remote_path!r} from app {app!r}")
+        return
+    confirm_or_abort(
+        f"Delete {remote_path!r} from app {app!r}?", yes=yes, dry_run=dry_run
+    )
     result = files_api.delete(app, remote_path, project=project)
-    click.echo(json.dumps(result, indent=2))
+    emit_json(result)
 
 
 # ── JobQueue ───────────────────────────────────────────────────────────
@@ -181,45 +342,82 @@ def jobs():
 @click.argument("job_name")
 @click.option("--params", "params_json", default=None, help="JSON params for the job")
 @click.option("--project", default=None, help="Scope to project ID")
-def jobs_submit(app, job_name, params_json, project):
-    """Submit a background job."""
+@mutating_flags()
+def jobs_submit(app, job_name, params_json, project, dry_run, yes):
+    """Submit a background job.
+
+    \b
+    Example:
+        scitex-hub sdk jobs submit my-app export_csv --params '{"fmt":"xlsx"}'
+    """
     from scitex_hub.sdk import jobs as jobs_api
 
     params = json.loads(params_json) if params_json else None
+    if dry_run:
+        print_dry_run(
+            f"would submit job {job_name!r} on app {app!r} with params {params!r}"
+        )
+        return
+    confirm_or_abort(
+        f"Submit job {job_name!r} on app {app!r}?", yes=yes, dry_run=dry_run
+    )
     result = jobs_api.submit(app, job_name, params=params, project_id=project)
-    click.echo(json.dumps(result, indent=2))
+    emit_json(result)
 
 
 @jobs.command("show-status")
 @click.argument("app")
 @click.argument("job_id")
-def jobs_status(app, job_id):
-    """Get job status and result."""
+@_read_json
+def jobs_status(app, job_id, as_json):
+    """Get job status and result.
+
+    \b
+    Example:
+        scitex-hub sdk jobs show-status my-app job-123
+    """
     from scitex_hub.sdk import jobs as jobs_api
 
     result = jobs_api.status(app, job_id)
-    click.echo(json.dumps(result, indent=2))
+    _maybe_emit(result, as_json=as_json)
 
 
 @jobs.command("cancel")
 @click.argument("app")
 @click.argument("job_id")
-def jobs_cancel(app, job_id):
-    """Cancel a running job."""
+@mutating_flags()
+def jobs_cancel(app, job_id, dry_run, yes):
+    """Cancel a running job.
+
+    \b
+    Example:
+        scitex-hub sdk jobs cancel my-app job-123 --yes
+    """
     from scitex_hub.sdk import jobs as jobs_api
 
+    if dry_run:
+        print_dry_run(f"would cancel job {job_id!r} on app {app!r}")
+        return
+    confirm_or_abort(f"Cancel job {job_id!r} on app {app!r}?", yes=yes, dry_run=dry_run)
     result = jobs_api.cancel(app, job_id)
-    click.echo(json.dumps(result, indent=2))
+    emit_json(result)
 
 
 @jobs.command("list")
 @click.argument("app")
-def jobs_list(app):
-    """List all jobs for an app."""
+@_read_json
+def jobs_list(app, as_json):
+    """List all jobs for an app.
+
+    \b
+    Example:
+        scitex-hub sdk jobs list my-app
+        scitex-hub sdk jobs list my-app --no-json
+    """
     from scitex_hub.sdk import jobs as jobs_api
 
     result = jobs_api.list_jobs(app)
-    click.echo(json.dumps(result, indent=2))
+    _maybe_emit(result, as_json=as_json)
 
 
 # EOF


### PR DESCRIPTION
## Summary

Card #7 chunk 3 of N. PR #278 cleared gitea group; PR #283 cleared deploy + context + mcp. This chunk covers the workspace + docker + sdk noun groups using the same scitex_hub._cli._flags helpers (mutating_flags, json_flag, print_dry_run, confirm_or_abort, emit_json).

## Coverage

See the diff for the full per-command list. Mutating verbs get --dry-run + --yes/-y with real effects; read verbs get --json; every command gets a concrete Example: block.

## Remaining for future chunks

setup / project / sync / ssh / completion / show-status (and any leaves the subagent recon flagged as already-conformant).