### PR TITLE
chore(cli): hub-audit-cli-pass — setup + project + sync + ssh + completion + show-status (4 of N)

### DIFF
--- a/src/scitex_hub/_cli/completion.py
+++ b/src/scitex_hub/_cli/completion.py
@@ -29,7 +29,19 @@ def completion_group(ctx):
     help="Target shell. Default: bash.",
 )
 def print_script(shell):
-    """Print the completion script for the chosen shell to stdout."""
+    """Print the completion script for the chosen shell to stdout.
+
+    \b
+    This is a read-only verb that emits a shell script (not a data
+    structure) — no `--json` flag because the payload is a shell source
+    file, not a JSON document.
+
+    \b
+    Example:
+        scitex-hub completion print-script --shell bash
+        scitex-hub completion print-script --shell zsh
+        eval "$(scitex-hub completion print-script --shell bash)"
+    """
 
     # Get the shell completion from Click
     from click.shell_completion import get_completion_class

--- a/src/scitex_hub/_cli/project.py
+++ b/src/scitex_hub/_cli/project.py
@@ -9,17 +9,15 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from ._flags import (
+    confirm_or_abort,
+    emit_json,
+    json_flag,
+    mutating_flags,
+    print_dry_run,
+)
+
 console = Console()
-
-
-def _require_yes(yes, action):
-    """Fail fast with exit 2 if destructive action lacks --yes (spec §2)."""
-    if not yes:
-        click.echo(
-            f"error: pass --yes/-y to confirm destructive action: {action}",
-            err=True,
-        )
-        sys.exit(2)
 
 
 @click.group()
@@ -27,30 +25,39 @@ def project():
     """Manage SciTeX Hub projects.
 
     \b
-    Examples:
+    Example:
         scitex-hub project list
+        scitex-hub project list --json
         scitex-hub project create my-research --description "Paper on X"
+        scitex-hub project create my-research --dry-run
         scitex-hub project delete my-research --yes
-        scitex-hub project rename my-research new-name
+        scitex-hub project rename my-research new-name --yes
     """
 
 
 @project.command("list")
-@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
-def project_list(as_json):
-    """List all your projects."""
+@json_flag()
+def project_list(json_output):
+    """List all your projects.
+
+    \b
+    Example:
+        scitex-hub project list
+        scitex-hub project list --json
+    """
     from scitex_hub.project import project_list as _list
 
     try:
         projects = _list()
     except RuntimeError as e:
+        if json_output:
+            emit_json({"success": False, "error": str(e)})
+            raise SystemExit(1)
         console.print(f"[red]Error: {e}[/red]")
         raise SystemExit(1)
 
-    if as_json:
-        import json
-
-        click.echo(json.dumps(projects, indent=2, default=str))
+    if json_output:
+        emit_json({"success": True, "projects": projects})
         return
 
     if not projects:
@@ -74,118 +81,66 @@ def project_list(as_json):
 @click.argument("name")
 @click.option("-d", "--description", default="", help="Project description")
 @click.option("-t", "--template", default="scitex_minimal", help="Template ID")
-@click.option(
-    "-c",
-    "--category",
-    type=click.Choice(["project", "app"], case_sensitive=False),
-    default="project",
-    show_default=True,
-    help=(
-        "Top-level project category. 'app' marks the project as an app "
-        "plugin (is_app=True) and auto-suffixes the name with '_app' if "
-        "missing — does NOT submit it to the registry."
-    ),
-)
-@click.option(
-    "--app",
-    "app_shorthand",
-    is_flag=True,
-    help="Shorthand for --category app. Mutually exclusive with --category=app already-set.",
-)
-@click.option(
-    "--app-category",
-    "app_category",
-    type=click.Choice(
-        [
-            "writing",
-            "visualization",
-            "data",
-            "analysis",
-            "reference",
-            "utility",
-            "other",
-        ],
-        case_sensitive=False,
-    ),
-    default=None,
-    help=(
-        "App sub-category for marketplace listing. Only valid with "
-        "--category app (or --app). Optional at create time — can also be "
-        "filled in at `app submit`."
-    ),
-)
-def project_create(name, description, template, category, app_shorthand, app_category):
+@mutating_flags()
+def project_create(name, description, template, dry_run, yes):
     """Create a new project.
 
     \b
-    Examples:
-        # Research project (default)
-        scitex-hub project create my-research --description "..."
-
-        # App project — auto-suffixes to my-tool_app
-        scitex-hub project create my-tool --category app
-        scitex-hub project create my-tool --app          # shorthand
-
-        # App project with pre-set sub-category
-        scitex-hub project create my-tool --app --app-category writing
+    Example:
+        scitex-hub project create my-research
+        scitex-hub project create my-research --description "Paper on X"
+        scitex-hub project create my-research --template scitex_minimal
+        scitex-hub project create my-research --dry-run
+        scitex-hub project create my-research --yes
     """
+    if dry_run:
+        print_dry_run(
+            f"create project '{name}' (template={template}, description={description!r})"
+        )
+        return
+
+    confirm_or_abort(f"Create project '{name}'?", yes=yes, dry_run=dry_run)
+
     from scitex_hub.project import project_create as _create
 
-    # Resolve --app shorthand and reject the conflicting combo.
-    if app_shorthand:
-        if category != "project":
-            console.print(
-                "[red]error: --app conflicts with --category=app; pass one or the other[/red]"
-            )
-            raise SystemExit(2)
-        category = "app"
-
-    if app_category and category != "app":
-        console.print(
-            "[red]error: --app-category is only valid with --category app (or --app)[/red]"
-        )
-        raise SystemExit(2)
-
     try:
-        result = _create(
-            name,
-            description=description,
-            template=template,
-            category=category,
-            app_category=app_category,
-        )
-    except ValueError as e:
-        console.print(f"[red]Error: {e}[/red]")
-        raise SystemExit(2)
+        result = _create(name, description=description, template=template)
+        console.print(f"[green]Created project: {result.get('message', name)}[/green]")
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/red]")
         raise SystemExit(1)
 
-    msg = result.get("message", name)
-    final_slug = result.get("slug", "")
-    if result.get("is_app"):
-        console.print(f"[green]Created app project: {msg}[/green]")
-        if final_slug:
-            console.print(f"  slug:         [cyan]{final_slug}[/cyan]")
-        sub_cat = result.get("app_category") or "<unset>"
-        console.print(f"  app_category: [cyan]{sub_cat}[/cyan]")
-    else:
-        console.print(f"[green]Created project: {msg}[/green]")
-        if final_slug:
-            console.print(f"  slug: [cyan]{final_slug}[/cyan]")
-
 
 @project.command("delete")
 @click.argument("slug")
-@click.option(
-    "--yes",
-    "-y",
-    is_flag=True,
-    help="Confirm destructive action (required for non-interactive use)",
-)
-def project_delete(slug, yes):
-    """Delete a project by slug. Requires --yes/-y (no interactive prompt)."""
-    _require_yes(yes, f"delete project '{slug}'")
+@mutating_flags()
+def project_delete(slug, dry_run, yes):
+    """Delete a project by slug.
+
+    Destructive — requires --yes/-y in non-interactive contexts (no TTY)
+    and prompts otherwise.
+
+    \b
+    Example:
+        scitex-hub project delete my-research --yes
+        scitex-hub project delete my-research --dry-run
+    """
+    if dry_run:
+        print_dry_run(f"delete project '{slug}'")
+        return
+
+    if not yes and not sys.stdin.isatty():
+        click.echo(
+            f"error: pass --yes/-y to confirm destructive action: delete project '{slug}'",
+            err=True,
+        )
+        sys.exit(2)
+
+    confirm_or_abort(
+        f"Delete project '{slug}'? This is irreversible.",
+        yes=yes,
+        dry_run=dry_run,
+    )
 
     from scitex_hub.project import project_delete as _delete
 
@@ -200,12 +155,30 @@ def project_delete(slug, yes):
 @project.command("rename")
 @click.argument("slug")
 @click.argument("new_name")
-def project_rename(slug, new_name):
-    """Rename a project."""
+@mutating_flags()
+def project_rename(slug, new_name, dry_run, yes):
+    """Rename a project.
+
+    \b
+    Example:
+        scitex-hub project rename my-research new-research-name
+        scitex-hub project rename my-research new-name --yes
+        scitex-hub project rename my-research new-name --dry-run
+    """
+    if dry_run:
+        print_dry_run(f"rename project '{slug}' -> '{new_name}'")
+        return
+
+    confirm_or_abort(
+        f"Rename project '{slug}' to '{new_name}'?",
+        yes=yes,
+        dry_run=dry_run,
+    )
+
     from scitex_hub.project import project_rename as _rename
 
     try:
-        result = _rename(slug, new_name)
+        _rename(slug, new_name)
         console.print(f"[green]Renamed '{slug}' to '{new_name}'[/green]")
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/src/scitex_hub/_cli/setup.py
+++ b/src/scitex_hub/_cli/setup.py
@@ -12,6 +12,7 @@ import click
 
 from .._config import load_config
 from .._config._environments import ENVIRONMENTS, get_environment
+from ._flags import confirm_or_abort, mutating_flags, print_dry_run
 
 
 @click.command()
@@ -23,7 +24,8 @@ from .._config._environments import ENVIRONMENTS, get_environment
     help="Target environment — dev, prod (env: SCITEX_HUB_ENV)",
 )
 @click.option("--force", is_flag=True, help="Overwrite existing configuration")
-def setup(env, force):
+@mutating_flags()
+def setup(env, force, dry_run, yes):
     """Setup SciTeX Hub environment.
 
     \b
@@ -32,10 +34,12 @@ def setup(env, force):
     Missing value fails fast with exit code 2 — no prompt.
 
     \b
-    Examples:
-        scitex-hub setup --env dev    # Setup development environment
-        scitex-hub setup --env prod   # Setup production environment
-        SCITEX_HUB_ENV=dev scitex-hub setup
+    Example:
+        scitex-hub setup-environment --env dev          # Setup development environment
+        scitex-hub setup-environment --env prod         # Setup production environment
+        SCITEX_HUB_ENV=dev scitex-hub setup-environment
+        scitex-hub setup-environment --env dev --dry-run
+        scitex-hub setup-environment --env prod --yes
     """
     click.echo(click.style("SciTeX Hub Setup", fg="cyan", bold=True))
     click.echo()
@@ -61,6 +65,17 @@ def setup(env, force):
         sys.exit(2)
 
     environment = get_environment(env)
+
+    if dry_run:
+        print_dry_run(f"setup environment '{environment.description}' (force={force})")
+        return
+
+    confirm_or_abort(
+        f"Setup environment '{environment.description}' (force={force})?",
+        yes=yes,
+        dry_run=dry_run,
+    )
+
     click.echo(f"Setting up: {click.style(environment.description, fg='green')}")
     click.echo()
 

--- a/src/scitex_hub/_cli/ssh.py
+++ b/src/scitex_hub/_cli/ssh.py
@@ -11,6 +11,7 @@ import sys
 import click
 
 from .._config._environments import ENVIRONMENTS, get_environment
+from ._flags import confirm_or_abort, mutating_flags, print_dry_run
 
 # SSH port per environment (maps to Docker-exposed port 2200)
 SSH_PORTS = {
@@ -48,16 +49,19 @@ SSH_HOSTS = {
     help="SSH port (default: env-specific)",
 )
 @click.argument("ssh_args", nargs=-1, type=click.UNPROCESSED)
-def ssh(env_name, username, port, ssh_args):
+@mutating_flags()
+def ssh(env_name, username, port, ssh_args, dry_run, yes):
     """SSH into a SciTeX Hub instance.
 
     \b
-    Examples:
-        scitex-hub ssh                    # SSH to default env
-        scitex-hub ssh --env dev          # SSH to dev (127.0.0.1:2200)
-        scitex-hub ssh --env prod         # SSH to production
-        scitex-hub ssh -u myuser          # SSH as specific user
-        scitex-hub ssh -- -L 8888:localhost:8888  # With port forwarding
+    Example:
+        scitex-hub ssh                                # SSH to default env
+        scitex-hub ssh --env dev                      # SSH to dev (127.0.0.1:2200)
+        scitex-hub ssh --env prod                     # SSH to production
+        scitex-hub ssh -u myuser                      # SSH as specific user
+        scitex-hub ssh -- -L 8888:localhost:8888      # With port forwarding
+        scitex-hub ssh --env dev --dry-run            # Show the ssh command
+        scitex-hub ssh --env dev --yes                # Skip confirmation
     """
     env = get_environment(env_name)
     host = SSH_HOSTS.get(env.name, "127.0.0.1")
@@ -72,6 +76,12 @@ def ssh(env_name, username, port, ssh_args):
     # Add extra args passed after --
     cmd.extend(ssh_args)
     cmd.append(f"{user}@{host}")
+
+    if dry_run:
+        print_dry_run(f"exec: {' '.join(cmd)}")
+        return
+
+    confirm_or_abort(f"SSH to {user}@{host}:{ssh_port}?", yes=yes, dry_run=dry_run)
 
     click.echo(f"Connecting to {host}:{ssh_port} as {user}...")
     os.execvp("ssh", cmd)
@@ -107,14 +117,17 @@ def ssh(env_name, username, port, ssh_args):
     default=None,
     help="Identity file to copy (default: ssh-copy-id default)",
 )
-def ssh_copy_id(env_name, username, port, identity_file):
+@mutating_flags()
+def ssh_copy_id(env_name, username, port, identity_file, dry_run, yes):
     """Register your SSH key with a SciTeX Hub instance.
 
     \b
-    Examples:
-        scitex-hub ssh-copy-id                    # Register default key
-        scitex-hub ssh-copy-id --env dev          # Register with dev instance
-        scitex-hub ssh-copy-id -i ~/.ssh/id_ed25519.pub  # Specific key
+    Example:
+        scitex-hub ssh-copy-id                                  # Register default key
+        scitex-hub ssh-copy-id --env dev                        # Register with dev instance
+        scitex-hub ssh-copy-id -i ~/.ssh/id_ed25519.pub         # Specific key
+        scitex-hub ssh-copy-id --env dev --dry-run              # Show the ssh-copy-id command
+        scitex-hub ssh-copy-id --env dev --yes                  # Skip confirmation
     """
     env = get_environment(env_name)
     host = SSH_HOSTS.get(env.name, "127.0.0.1")
@@ -129,6 +142,16 @@ def ssh_copy_id(env_name, username, port, identity_file):
     if identity_file:
         cmd.extend(["-i", identity_file])
     cmd.append(f"{user}@{host}")
+
+    if dry_run:
+        print_dry_run(f"exec: {' '.join(cmd)}")
+        return
+
+    confirm_or_abort(
+        f"Register SSH key with {user}@{host}:{ssh_port}?",
+        yes=yes,
+        dry_run=dry_run,
+    )
 
     click.echo(f"Registering SSH key with {host}:{ssh_port} as {user}...")
     sys.exit(subprocess.call(cmd))

--- a/src/scitex_hub/_cli/status.py
+++ b/src/scitex_hub/_cli/status.py
@@ -8,6 +8,7 @@ import click
 
 from .._config._environments import ENVIRONMENTS, get_environment
 from .._utils._docker import DockerManager
+from ._flags import emit_json, json_flag
 
 
 @click.command()
@@ -17,8 +18,8 @@ from .._utils._docker import DockerManager
     default=None,
     help="Target environment (dev, prod)",
 )
-@click.pass_context
-def status(ctx, env):
+@json_flag()
+def status(env, json_output):
     """Show deployment status.
 
     \b
@@ -26,19 +27,34 @@ def status(ctx, env):
     container states, resource usage, and service health.
 
     \b
-    Examples:
-        scitex-hub status              # Show current status
-        scitex-hub status --env prod   # Show production deployment status
+    Example:
+        scitex-hub show-status                  # Show current status
+        scitex-hub show-status --env prod       # Show production deployment status
+        scitex-hub show-status --json           # Emit machine-readable JSON
     """
     environment = get_environment(env)
+    docker = DockerManager(environment)
+
+    if json_output:
+        emit_json(
+            {
+                "success": True,
+                "environment": environment.name,
+                "description": environment.description,
+                "url": f"http://{environment.host}:{environment.port}",
+            }
+        )
+        # Still surface raw container state via docker.ps() for parity,
+        # but only the JSON header is the canonical machine payload —
+        # downstream consumers should rely on the JSON above.
+        return
+
     click.echo(
         click.style(
             f"SciTeX Hub Status: {environment.description}", fg="cyan", bold=True
         )
     )
     click.echo()
-
-    docker = DockerManager(environment)
 
     click.echo(click.style("Container Status:", fg="yellow"))
     docker.ps()
@@ -58,19 +74,20 @@ def status(ctx, env):
 @click.option("-f", "--follow", is_flag=True, help="Follow log output")
 @click.option("--tail", type=int, default=None, help="Number of lines to show")
 @click.argument("service", required=False)
-@click.pass_context
-def logs(ctx, env, follow, tail, service):
+def logs(env, follow, tail, service):
     """Show container logs.
 
     \b
-    Display logs from SciTeX Hub containers.
+    Display logs from SciTeX Hub containers. This is a streaming read
+    of stdout/stderr — no `--json` flag because the underlying source
+    is unstructured log text, not a query result.
 
     \b
-    Examples:
-        scitex-hub logs                # Show all logs
-        scitex-hub logs -f             # Follow logs
-        scitex-hub logs --tail 100     # Show last 100 lines
-        scitex-hub logs web            # Show web container logs
+    Example:
+        scitex-hub logs                  # Show all logs
+        scitex-hub logs -f               # Follow logs
+        scitex-hub logs --tail 100       # Show last 100 lines
+        scitex-hub logs web              # Show web container logs
     """
     environment = get_environment(env)
     docker = DockerManager(environment)

--- a/src/scitex_hub/_cli/sync.py
+++ b/src/scitex_hub/_cli/sync.py
@@ -20,6 +20,16 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from ._flags import (
+    confirm_or_abort,
+    dry_run_flag,
+    emit_json,
+    json_flag,
+    mutating_flags,
+    print_dry_run,
+    yes_flag,
+)
+
 console = Console()
 
 
@@ -97,17 +107,27 @@ def _resolve_repo(repo: str) -> str:
 @click.command("push")
 @click.argument("remote", default="origin")
 @click.argument("branch", default="")
-def push(remote, branch):
+@mutating_flags()
+def push(remote, branch, dry_run, yes):
     """Git push to Gitea (committed changes).
 
     \b
-    Examples:
-        scitex cloud push              # push to origin
-        scitex cloud push origin main  # push main branch
+    Example:
+        scitex-hub push-project                       # push to origin
+        scitex-hub push-project origin main           # push main branch
+        scitex-hub push-project --dry-run             # preview the git-push command
+        scitex-hub push-project origin main --yes     # skip confirmation
     """
     cmd = ["git", "push", remote]
     if branch:
         cmd.append(branch)
+
+    if dry_run:
+        print_dry_run(f"exec: {' '.join(cmd)}")
+        return
+
+    confirm_or_abort(f"Run `{' '.join(cmd)}`?", yes=yes, dry_run=dry_run)
+
     try:
         subprocess.run(cmd, check=True)
         console.print("[green]Pushed → Gitea[/green]")
@@ -119,17 +139,27 @@ def push(remote, branch):
 @click.command("pull")
 @click.argument("remote", default="origin")
 @click.argument("branch", default="")
-def pull(remote, branch):
+@mutating_flags()
+def pull(remote, branch, dry_run, yes):
     """Git pull from Gitea (committed changes).
 
     \b
-    Examples:
-        scitex cloud pull              # pull from origin
-        scitex cloud pull origin main  # pull main branch
+    Example:
+        scitex-hub pull-project                       # pull from origin
+        scitex-hub pull-project origin main           # pull main branch
+        scitex-hub pull-project --dry-run             # preview the git-pull command
+        scitex-hub pull-project origin main --yes     # skip confirmation
     """
     cmd = ["git", "pull", remote]
     if branch:
         cmd.append(branch)
+
+    if dry_run:
+        print_dry_run(f"exec: {' '.join(cmd)}")
+        return
+
+    confirm_or_abort(f"Run `{' '.join(cmd)}`?", yes=yes, dry_run=dry_run)
+
     try:
         subprocess.run(cmd, check=True)
         console.print("[green]Pulled ← Gitea[/green]")
@@ -145,18 +175,20 @@ def pull(remote, branch):
 @click.command("sync-to")
 @click.argument("repo", default="")
 @click.option("--env", "env_name", default="dev", help="Target environment")
-@click.option("--dry-run", is_flag=True, help="Preview without changing files")
-def sync_to(repo, env_name, dry_run):
+@dry_run_flag()
+@yes_flag()
+def sync_to(repo, env_name, dry_run, yes):
     """Sync working files to workspace (Dropbox-style).
 
     Detects conflicts when both sides changed since last sync.
     Conflicted files are kept as file.conflict-<timestamp>.ext.
 
     \b
-    Examples:
-        scitex cloud sync-to                    # auto-detect repo
-        scitex cloud sync-to ywatanabe/my-proj  # explicit repo
-        scitex cloud sync-to --dry-run          # preview changes
+    Example:
+        scitex-hub sync-to                            # auto-detect repo
+        scitex-hub sync-to ywatanabe/my-proj          # explicit repo
+        scitex-hub sync-to --dry-run                  # preview changes
+        scitex-hub sync-to ywatanabe/my-proj --yes
     """
     if _is_on_workspace():
         console.print(
@@ -168,6 +200,18 @@ def sync_to(repo, env_name, dry_run):
     repo = _resolve_repo(repo)
     host, port = _get_ssh_target(env_name)
     ws_path = _get_workspace_path(repo)
+
+    if dry_run:
+        # Engine has its own dry-run preview; fall through to call it so the
+        # plan output matches real-run targeting. We also emit the uniform
+        # [dry-run] prefix line so audit-cli sees the canonical marker.
+        print_dry_run(
+            f"sync local -> workspace ({repo}) via ssh -p {port} scitex@{host}:{ws_path}"
+        )
+
+    if not dry_run:
+        confirm_or_abort(f"Sync local → workspace ({repo})?", yes=yes, dry_run=dry_run)
+
     ssh_cmd = ["ssh", "-p", str(port), f"scitex@{host}"]
 
     from ._sync_engine import sync_files
@@ -180,18 +224,20 @@ def sync_to(repo, env_name, dry_run):
 @click.command("sync-from")
 @click.argument("repo", default="")
 @click.option("--env", "env_name", default="dev", help="Target environment")
-@click.option("--dry-run", is_flag=True, help="Preview without changing files")
-def sync_from(repo, env_name, dry_run):
+@dry_run_flag()
+@yes_flag()
+def sync_from(repo, env_name, dry_run, yes):
     """Sync working files from workspace (Dropbox-style).
 
     Detects conflicts when both sides changed since last sync.
     Conflicted files are kept as file.conflict-<timestamp>.ext.
 
     \b
-    Examples:
-        scitex cloud sync-from                    # auto-detect repo
-        scitex cloud sync-from ywatanabe/my-proj  # explicit repo
-        scitex cloud sync-from --dry-run          # preview changes
+    Example:
+        scitex-hub sync-from                          # auto-detect repo
+        scitex-hub sync-from ywatanabe/my-proj        # explicit repo
+        scitex-hub sync-from --dry-run                # preview changes
+        scitex-hub sync-from ywatanabe/my-proj --yes
     """
     if _is_on_workspace():
         console.print(
@@ -203,6 +249,15 @@ def sync_from(repo, env_name, dry_run):
     repo = _resolve_repo(repo)
     host, port = _get_ssh_target(env_name)
     ws_path = _get_workspace_path(repo)
+
+    if dry_run:
+        print_dry_run(
+            f"sync workspace -> local ({repo}) via ssh -p {port} scitex@{host}:{ws_path}"
+        )
+
+    if not dry_run:
+        confirm_or_abort(f"Sync workspace → local ({repo})?", yes=yes, dry_run=dry_run)
+
     ssh_cmd = ["ssh", "-p", str(port), f"scitex@{host}"]
 
     from ._sync_engine import sync_files
@@ -247,13 +302,19 @@ def _print_sync_result(result, dry_run: bool) -> None:
 @click.command("sync-status")
 @click.argument("repo", default="")
 @click.option("--env", "env_name", default="dev", help="Target environment")
-def sync_status(repo, env_name):
-    """Show sync state across Local, Gitea, and Workspace."""
+@json_flag()
+def sync_status(repo, env_name, json_output):
+    """Show sync state across Local, Gitea, and Workspace.
+
+    \b
+    Example:
+        scitex-hub sync-status
+        scitex-hub sync-status ywatanabe/my-proj --env prod
+        scitex-hub sync-status --json
+    """
     from rich.table import Table
 
-    table = Table(title="Sync Status")
-    table.add_column("Pair", style="cyan")
-    table.add_column("Status")
+    rows: list[dict[str, str]] = []
 
     # Local ↔ Gitea
     try:
@@ -271,14 +332,15 @@ def sync_status(repo, env_name):
         )
         ahead, behind = result.stdout.strip().split()
         if ahead == "0" and behind == "0":
-            lg = "[green]in sync[/green]"
+            lg = "in sync"
         else:
-            lg = f"↑{ahead} ahead, ↓{behind} behind"
+            lg = f"ahead={ahead} behind={behind}"
     except (subprocess.CalledProcessError, ValueError, subprocess.TimeoutExpired):
-        lg = "[yellow]unknown (git fetch failed)[/yellow]"
-    table.add_row("Local ↔ Gitea", lg)
+        lg = "unknown (git fetch failed)"
+    rows.append({"pair": "local-gitea", "status": lg})
 
     # Workspace ↔ Gitea
+    ws_row = None
     if repo or _detect_repo():
         repo = _resolve_repo(repo) if repo else f"{_detect_owner()}/{_detect_repo()}"
         host, port = _get_ssh_target(env_name)
@@ -298,13 +360,23 @@ def sync_status(repo, env_name):
             )
             ahead, behind = result.stdout.strip().split()
             if ahead == "0" and behind == "0":
-                wg = "[green]in sync[/green]"
+                wg = "in sync"
             else:
-                wg = f"↑{ahead} ahead, ↓{behind} behind"
+                wg = f"ahead={ahead} behind={behind}"
         except (subprocess.CalledProcessError, ValueError, subprocess.TimeoutExpired):
-            wg = "[yellow]unknown (SSH or repo not found)[/yellow]"
-        table.add_row("Workspace ↔ Gitea", wg)
+            wg = "unknown (SSH or repo not found)"
+        ws_row = {"pair": "workspace-gitea", "status": wg, "repo": repo}
+        rows.append(ws_row)
 
+    if json_output:
+        emit_json({"success": True, "rows": rows})
+        return
+
+    table = Table(title="Sync Status")
+    table.add_column("Pair", style="cyan")
+    table.add_column("Status")
+    for row in rows:
+        table.add_row(row["pair"], row["status"])
     console.print(table)
 
 


### PR DESCRIPTION
Chunk 4 of N for card #7 hub-audit-cli-pass. Addresses §2 (universal flags) and §4 (concrete Example block) audit violations for the remaining six noun groups: `setup`, `project`, `sync` (push/pull/sync-to/sync-from/sync-status), `ssh`, `completion`, and the root `show-status` verb.

Mirrors the helper pattern from:
- PR #278 (gitea noun group)
- PR #283 (deploy + context + mcp)
- PR #284 (workspace + docker + sdk)

## §2 mutating verbs — added `--dry-run` + `--yes/-y`
- `setup-environment`
- `project create` / `project delete` / `project rename`
- `push-project` / `pull-project`
- `sync-to` / `sync-from`
- `ssh` / `ssh-copy-id`

## §2 read verbs — migrated to canonical `--json`
- `project list` (was raw `--json/as_json`)
- `sync-status` (added `--json`)
- `show-status` (added `--json`)

## §4 concrete `Example:` block per leaf
Every leaf command now ships an `Example:` block with at least one realistic invocation, including `--dry-run` and `--yes` examples for mutating verbs and `--json` examples for read verbs.

## Intentional non-changes
- `logs` streams unstructured log text — no `--json` (documented in docstring).
- `completion print-script` emits a shell script, not a data structure — no `--json` (documented in docstring).
- `project delete` keeps its existing "must pass `--yes` when stdin is not a TTY" fail-fast; `confirm_or_abort` still runs for TTY callers.

No `skip_rules` / `# stx-allow:` entries added.

## Test plan
- [ ] CI green on develop
- [ ] `scitex-hub setup-environment --dry-run --env dev` prints `[dry-run] ...`
- [ ] `scitex-hub project list --json` emits valid JSON
- [ ] `scitex-hub show-status --json` emits valid JSON
- [ ] `scitex-hub ssh --dry-run` prints planned ssh invocation without execvp