### PR TITLE
feat(apps_app): F0+F1 — pip-install user-apps + URL mount-point (M4 path-A unblock)

### DIFF
--- a/apps/workspace/apps_app/services/_user_app_install.py
+++ b/apps/workspace/apps_app/services/_user_app_install.py
@@ -47,6 +47,7 @@ import sys
 from pathlib import Path
 
 from django.conf import settings
+from django.utils._os import safe_join
 
 logger = logging.getLogger(__name__)
 
@@ -158,25 +159,17 @@ def pip_install_user_app(app_module) -> Path:
     install_dir = _user_apps_dir()
     install_dir.mkdir(parents=True, exist_ok=True)
 
-    # INLINE sanitization at the path-construction sink (lead msg
-    # d9cc8441 path-A): resolve() + is_relative_to() + raise-on-escape
-    # at each call site is the canonical CodeQL-recognized form. A
-    # helper function hides the sanitization from interprocedural taint
-    # analysis (proven on PR #290 v3 — _safe_join helper kept the
-    # alerts). The 4× repetition is a deliberate, justified cost:
-    # security-critical sinks earn the verbosity.
-    install_dir_abs = install_dir.resolve()
-    pkg_dir = (install_dir_abs / module_name).resolve()
-    if not pkg_dir.is_relative_to(install_dir_abs):
-        raise ValueError(
-            f"path traversal blocked: {module_name!r} resolved outside "
-            f"{install_dir_abs!s}"
-        )
-    sentinel = (pkg_dir / ".scitex_hub_pinned_at").resolve()
-    if not sentinel.is_relative_to(pkg_dir):
-        raise ValueError(
-            f"path traversal blocked: sentinel resolved outside {pkg_dir!s}"
-        )
+    # SANITIZATION via Django's `safe_join` (lead msg e40711ed path
+    # β+γ): Django's safe-path-join is the FileSystemStorage primitive
+    # — joins base+segment, raises SuspiciousFileOperation if the
+    # result escapes base, returns the sanitized path STRING. Because
+    # `pkg_dir` and `sentinel` come OUT of `safe_join`, CodeQL sees
+    # them as sanitized AT THE SOURCE; all downstream uses inherit
+    # the clean flow (which the v3 helper + v4 inline-is_relative_to
+    # patterns failed to propagate, see PR #290 v3/v4 CodeQL re-runs).
+    # `_safe_identifier` regex still runs first as defense-in-depth.
+    pkg_dir = Path(safe_join(str(install_dir), module_name))
+    sentinel = Path(safe_join(str(pkg_dir), ".scitex_hub_pinned_at"))
     if sentinel.is_file() and sentinel.read_text(encoding="utf-8").strip() == commit:
         logger.debug(
             "[user_app_install] %r already at pinned %s — skipping pip",

--- a/apps/workspace/apps_app/services/_user_app_install.py
+++ b/apps/workspace/apps_app/services/_user_app_install.py
@@ -13,29 +13,34 @@ Design choices:
 
   - Install via ``pip install --no-deps --target=<hub-managed-dir>``
     so the user-app's transitive deps do NOT pollute the hub venv.
-    Deps the user-app declares in its pyproject get checked at
-    activation time (PS-210 pattern); missing → loud error.
   - Target dir is ``<settings.SCITEX_HUB_USER_APPS_DIR>`` (defaults to
     ``<BASE_DIR>/data/user_apps/``) — added to ``sys.path`` at first
     activation so subsequent imports succeed.
-  - The Gitea mirror's wheel URL is derived from the pinned commit
-    (post-merge auto-pin in ``app_loader.pin_commit``) so installs
-    are reproducible.
+  - The Gitea mirror's tarball URL is derived from the pinned commit
+    so installs are reproducible.
   - Fail-loud: any ``subprocess.run`` non-zero exits get raised
     rather than swallowed; ``_activate_approved_app`` MUST roll
     back the registration on install failure (caller's
     responsibility, this module just surfaces the error).
 
-No skip_rules, no silent fallback. The default-dir fallback is a
-documented production-image convention (mirrors how the
-``settings.USER_DATA_ROOT`` default works in
-``views/terminal/config``).
+SECURITY (per lead msg 37b38d69 + CodeQL HIGH alerts on PR #290 v1):
+every user-controlled string that feeds a filesystem path OR a
+subprocess argument goes through a STRICT regex validator
+(``_safe_identifier`` / ``_safe_commit``) FIRST. Module name,
+Gitea owner, Gitea repo, commit SHA all rejected hard if they
+contain ``/`` ``..`` or any non-allowlisted character. No silent
+fallback, no path normalization that could be bypassed.
+
+Log statements use ``%r`` (repr) on user-string args so control
+chars / newlines from a malicious submission can't inject fake
+log lines.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -48,6 +53,40 @@ logger = logging.getLogger(__name__)
 #: Default install root if ``settings.SCITEX_HUB_USER_APPS_DIR`` is
 #: unset; mirrors the production Docker image convention.
 _DEFAULT_USER_APPS_DIR = Path("/app/data/user_apps")
+
+#: Python-identifier-shaped regex. Matches the python-module-name
+#: convention + rejects every char that could escape a filesystem
+#: path or smuggle into a subprocess arg. ``a/b`` ``../evil`` ``..``
+#: ``a;rm -rf /`` all fail.
+_IDENT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
+
+#: Git SHA — hex digits, length 7-64 (short-SHA through full SHA-256).
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+
+
+def _safe_identifier(name: str, field: str) -> str:
+    """Validate ``name`` against ``_IDENT_RE``; raise ValueError if not.
+
+    Used for module_name, Gitea owner, Gitea repo — anything that gets
+    interpolated into a filesystem path or subprocess argv.
+    """
+    if not isinstance(name, str) or not _IDENT_RE.match(name):
+        raise ValueError(
+            f"unsafe value for {field}: {name!r} — must match "
+            f"{_IDENT_RE.pattern} (Python-identifier shape; no '/' '..' or "
+            f"shell metachars)"
+        )
+    return name
+
+
+def _safe_commit(commit: str) -> str:
+    """Validate Git SHA; raise ValueError if not."""
+    if not isinstance(commit, str) or not _COMMIT_RE.match(commit):
+        raise ValueError(
+            f"unsafe value for commit: {commit!r} — must match "
+            f"{_COMMIT_RE.pattern} (hex SHA, 7-64 chars)"
+        )
+    return commit
 
 
 def _user_apps_dir() -> Path:
@@ -67,14 +106,14 @@ def _ensure_on_path(install_dir: Path) -> None:
     if install_dir_str in sys.path:
         return
     sys.path.insert(0, install_dir_str)
-    logger.info("[user_app_install] Added %s to sys.path", install_dir_str)
+    logger.info("[user_app_install] Added %r to sys.path", install_dir_str)
 
 
 def _gitea_wheel_url(owner: str, repo: str, commit: str) -> str:
     """Return the Gitea archive URL for ``owner/repo`` at ``commit``.
 
-    Pip can install from a tarball URL via ``pip install <url>``; this
-    is simpler than uploading a built wheel to a registry.
+    Inputs assumed pre-validated by the caller (raises in
+    :func:`pip_install_user_app` before this is reached).
     """
     base = getattr(settings, "GITEA_URL", None) or "http://gitea:3000"
     return f"{base.rstrip('/')}/{owner}/{repo}/archive/{commit}.tar.gz"
@@ -83,39 +122,51 @@ def _gitea_wheel_url(owner: str, repo: str, commit: str) -> str:
 def pip_install_user_app(app_module) -> Path:
     """Install ``app_module``'s package into the user-apps dir.
 
+    SECURITY: ``module_name``, Gitea ``owner``, ``repo``, and the
+    pinned ``commit`` SHA are validated against strict regexes BEFORE
+    any filesystem path or subprocess call sees them. A malicious
+    submission with ``module_name='../evil'`` (or any other traversal
+    shape) raises ValueError immediately and nothing is touched.
+
     Idempotent: if the pinned commit is already installed (sentinel
     file ``<install_dir>/<module>/.scitex_hub_pinned_at`` matches), this
     is a no-op + just returns the install dir.
 
-    Raises ``RuntimeError`` on any pip non-zero exit; the caller MUST
-    roll back the app activation in that case (no half-state).
+    Raises ``RuntimeError`` on any pip non-zero exit; ``ValueError``
+    on validation failure. The caller MUST roll back the app
+    activation in either case (no half-state).
     """
     if not app_module.pinned_commit:
         raise RuntimeError(
-            f"app_module '{app_module.module_name}' has no pinned_commit; "
+            f"app_module {app_module.module_name!r} has no pinned_commit; "
             f"cannot install (call pin_commit() first)"
         )
 
     project = app_module.project
     if project is None:
         raise RuntimeError(
-            f"app_module '{app_module.module_name}' has no project; "
+            f"app_module {app_module.module_name!r} has no project; "
             f"cannot derive the Gitea owner/repo for install"
         )
 
-    owner = project.owner.username
-    repo = project.slug
-    commit = app_module.pinned_commit
+    # STRICT VALIDATION — every user-controlled string before path/subprocess.
+    module_name = _safe_identifier(app_module.module_name, "module_name")
+    owner = _safe_identifier(project.owner.username, "gitea_owner")
+    repo = _safe_identifier(project.slug, "gitea_repo")
+    commit = _safe_commit(app_module.pinned_commit)
 
     install_dir = _user_apps_dir()
     install_dir.mkdir(parents=True, exist_ok=True)
 
-    pkg_dir = install_dir / app_module.module_name
+    # All three components below are post-validation; CodeQL's
+    # py/path-injection on these lines is a known false-positive given
+    # the _safe_identifier gate above.
+    pkg_dir = install_dir / module_name
     sentinel = pkg_dir / ".scitex_hub_pinned_at"
     if sentinel.is_file() and sentinel.read_text(encoding="utf-8").strip() == commit:
         logger.debug(
-            "[user_app_install] '%s' already at pinned %s — skipping pip",
-            app_module.module_name,
+            "[user_app_install] %r already at pinned %s — skipping pip",
+            module_name,
             commit[:8],
         )
         _ensure_on_path(install_dir)
@@ -123,10 +174,10 @@ def pip_install_user_app(app_module) -> Path:
 
     url = _gitea_wheel_url(owner, repo, commit)
     logger.info(
-        "[user_app_install] pip-installing %s from %s into %s",
-        app_module.module_name,
+        "[user_app_install] pip-installing %r from %r into %r",
+        module_name,
         url,
-        install_dir,
+        str(install_dir),
     )
 
     # Clean any previous version so --target doesn't get a stale tree.
@@ -135,7 +186,7 @@ def pip_install_user_app(app_module) -> Path:
 
     env = os.environ.copy()
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603 - argv is list, no shell; url validated
         [
             sys.executable,
             "-m",
@@ -154,7 +205,7 @@ def pip_install_user_app(app_module) -> Path:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"pip install of '{app_module.module_name}' (commit {commit[:8]}) "
+            f"pip install of {module_name!r} (commit {commit[:8]}) "
             f"failed with exit {result.returncode}:\n"
             f"--- stderr ---\n{result.stderr}\n"
             f"--- stdout ---\n{result.stdout}"
@@ -166,9 +217,9 @@ def pip_install_user_app(app_module) -> Path:
 
     _ensure_on_path(install_dir)
     logger.info(
-        "[user_app_install] Installed %s at %s (pinned %s)",
-        app_module.module_name,
-        pkg_dir,
+        "[user_app_install] Installed %r at %r (pinned %s)",
+        module_name,
+        str(pkg_dir),
         commit[:8],
     )
     return install_dir

--- a/apps/workspace/apps_app/services/_user_app_install.py
+++ b/apps/workspace/apps_app/services/_user_app_install.py
@@ -89,6 +89,28 @@ def _safe_commit(commit: str) -> str:
     return commit
 
 
+def _safe_join(parent: Path, child: str) -> Path:
+    """Join ``parent / child`` and PROVE the result is contained.
+
+    Defense-in-depth on top of :func:`_safe_identifier` (which already
+    rejects ``/`` ``..`` etc): resolves both paths to absolute form +
+    checks containment with ``Path.is_relative_to``. CodeQL recognises
+    this pattern as a sufficient sanitizer for ``py/path-injection``
+    (the validator alone, while semantically airtight, is not
+    statically tractable to the analyzer).
+
+    Raises ValueError on any escape — caller MUST treat as fatal +
+    refuse the install.
+    """
+    parent_abs = parent.resolve()
+    joined = (parent_abs / child).resolve()
+    if not joined.is_relative_to(parent_abs):
+        raise ValueError(
+            f"path traversal blocked: {child!r} resolved outside {parent_abs!s}"
+        )
+    return joined
+
+
 def _user_apps_dir() -> Path:
     """Return the directory user-app packages land in."""
     configured = getattr(settings, "SCITEX_HUB_USER_APPS_DIR", None)
@@ -158,11 +180,13 @@ def pip_install_user_app(app_module) -> Path:
     install_dir = _user_apps_dir()
     install_dir.mkdir(parents=True, exist_ok=True)
 
-    # All three components below are post-validation; CodeQL's
-    # py/path-injection on these lines is a known false-positive given
-    # the _safe_identifier gate above.
-    pkg_dir = install_dir / module_name
-    sentinel = pkg_dir / ".scitex_hub_pinned_at"
+    # Defense-in-depth: _safe_identifier already rejected '/' / '..' /
+    # other escapes, but _safe_join additionally resolves + verifies
+    # containment so the static analyzer (CodeQL py/path-injection)
+    # can prove there's no traversal. Single source of truth for the
+    # safe-path construction.
+    pkg_dir = _safe_join(install_dir, module_name)
+    sentinel = _safe_join(pkg_dir, ".scitex_hub_pinned_at")
     if sentinel.is_file() and sentinel.read_text(encoding="utf-8").strip() == commit:
         logger.debug(
             "[user_app_install] %r already at pinned %s — skipping pip",

--- a/apps/workspace/apps_app/services/_user_app_install.py
+++ b/apps/workspace/apps_app/services/_user_app_install.py
@@ -89,28 +89,6 @@ def _safe_commit(commit: str) -> str:
     return commit
 
 
-def _safe_join(parent: Path, child: str) -> Path:
-    """Join ``parent / child`` and PROVE the result is contained.
-
-    Defense-in-depth on top of :func:`_safe_identifier` (which already
-    rejects ``/`` ``..`` etc): resolves both paths to absolute form +
-    checks containment with ``Path.is_relative_to``. CodeQL recognises
-    this pattern as a sufficient sanitizer for ``py/path-injection``
-    (the validator alone, while semantically airtight, is not
-    statically tractable to the analyzer).
-
-    Raises ValueError on any escape — caller MUST treat as fatal +
-    refuse the install.
-    """
-    parent_abs = parent.resolve()
-    joined = (parent_abs / child).resolve()
-    if not joined.is_relative_to(parent_abs):
-        raise ValueError(
-            f"path traversal blocked: {child!r} resolved outside {parent_abs!s}"
-        )
-    return joined
-
-
 def _user_apps_dir() -> Path:
     """Return the directory user-app packages land in."""
     configured = getattr(settings, "SCITEX_HUB_USER_APPS_DIR", None)
@@ -180,13 +158,25 @@ def pip_install_user_app(app_module) -> Path:
     install_dir = _user_apps_dir()
     install_dir.mkdir(parents=True, exist_ok=True)
 
-    # Defense-in-depth: _safe_identifier already rejected '/' / '..' /
-    # other escapes, but _safe_join additionally resolves + verifies
-    # containment so the static analyzer (CodeQL py/path-injection)
-    # can prove there's no traversal. Single source of truth for the
-    # safe-path construction.
-    pkg_dir = _safe_join(install_dir, module_name)
-    sentinel = _safe_join(pkg_dir, ".scitex_hub_pinned_at")
+    # INLINE sanitization at the path-construction sink (lead msg
+    # d9cc8441 path-A): resolve() + is_relative_to() + raise-on-escape
+    # at each call site is the canonical CodeQL-recognized form. A
+    # helper function hides the sanitization from interprocedural taint
+    # analysis (proven on PR #290 v3 — _safe_join helper kept the
+    # alerts). The 4× repetition is a deliberate, justified cost:
+    # security-critical sinks earn the verbosity.
+    install_dir_abs = install_dir.resolve()
+    pkg_dir = (install_dir_abs / module_name).resolve()
+    if not pkg_dir.is_relative_to(install_dir_abs):
+        raise ValueError(
+            f"path traversal blocked: {module_name!r} resolved outside "
+            f"{install_dir_abs!s}"
+        )
+    sentinel = (pkg_dir / ".scitex_hub_pinned_at").resolve()
+    if not sentinel.is_relative_to(pkg_dir):
+        raise ValueError(
+            f"path traversal blocked: sentinel resolved outside {pkg_dir!s}"
+        )
     if sentinel.is_file() and sentinel.read_text(encoding="utf-8").strip() == commit:
         logger.debug(
             "[user_app_install] %r already at pinned %s — skipping pip",

--- a/apps/workspace/apps_app/services/_user_app_install.py
+++ b/apps/workspace/apps_app/services/_user_app_install.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Pip-install user-published apps from the ``scitex-apps`` Gitea mirror.
+
+F0 of the F0+F1 framework change (operator picked A, lead msg
+34a4b271). The user-published-apps reframe (lead msg 9844e07c) puts
+each approved app at ``scitex-apps/<repo>`` on Gitea; for the hub
+Django process to ACTUALLY import + serve those apps' code, the
+package has to land on PYTHONPATH. This module is the install
+side; ``urls_user_apps.py`` is the URL-routing side.
+
+Design choices:
+
+  - Install via ``pip install --no-deps --target=<hub-managed-dir>``
+    so the user-app's transitive deps do NOT pollute the hub venv.
+    Deps the user-app declares in its pyproject get checked at
+    activation time (PS-210 pattern); missing → loud error.
+  - Target dir is ``<settings.SCITEX_HUB_USER_APPS_DIR>`` (defaults to
+    ``<BASE_DIR>/data/user_apps/``) — added to ``sys.path`` at first
+    activation so subsequent imports succeed.
+  - The Gitea mirror's wheel URL is derived from the pinned commit
+    (post-merge auto-pin in ``app_loader.pin_commit``) so installs
+    are reproducible.
+  - Fail-loud: any ``subprocess.run`` non-zero exits get raised
+    rather than swallowed; ``_activate_approved_app`` MUST roll
+    back the registration on install failure (caller's
+    responsibility, this module just surfaces the error).
+
+No skip_rules, no silent fallback. The default-dir fallback is a
+documented production-image convention (mirrors how the
+``settings.USER_DATA_ROOT`` default works in
+``views/terminal/config``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+#: Default install root if ``settings.SCITEX_HUB_USER_APPS_DIR`` is
+#: unset; mirrors the production Docker image convention.
+_DEFAULT_USER_APPS_DIR = Path("/app/data/user_apps")
+
+
+def _user_apps_dir() -> Path:
+    """Return the directory user-app packages land in."""
+    configured = getattr(settings, "SCITEX_HUB_USER_APPS_DIR", None)
+    if configured:
+        return Path(configured)
+    base_dir = getattr(settings, "BASE_DIR", None)
+    if base_dir:
+        return Path(base_dir) / "data" / "user_apps"
+    return _DEFAULT_USER_APPS_DIR
+
+
+def _ensure_on_path(install_dir: Path) -> None:
+    """Prepend ``install_dir`` to ``sys.path`` if not already there."""
+    install_dir_str = str(install_dir)
+    if install_dir_str in sys.path:
+        return
+    sys.path.insert(0, install_dir_str)
+    logger.info("[user_app_install] Added %s to sys.path", install_dir_str)
+
+
+def _gitea_wheel_url(owner: str, repo: str, commit: str) -> str:
+    """Return the Gitea archive URL for ``owner/repo`` at ``commit``.
+
+    Pip can install from a tarball URL via ``pip install <url>``; this
+    is simpler than uploading a built wheel to a registry.
+    """
+    base = getattr(settings, "GITEA_URL", None) or "http://gitea:3000"
+    return f"{base.rstrip('/')}/{owner}/{repo}/archive/{commit}.tar.gz"
+
+
+def pip_install_user_app(app_module) -> Path:
+    """Install ``app_module``'s package into the user-apps dir.
+
+    Idempotent: if the pinned commit is already installed (sentinel
+    file ``<install_dir>/<module>/.scitex_hub_pinned_at`` matches), this
+    is a no-op + just returns the install dir.
+
+    Raises ``RuntimeError`` on any pip non-zero exit; the caller MUST
+    roll back the app activation in that case (no half-state).
+    """
+    if not app_module.pinned_commit:
+        raise RuntimeError(
+            f"app_module '{app_module.module_name}' has no pinned_commit; "
+            f"cannot install (call pin_commit() first)"
+        )
+
+    project = app_module.project
+    if project is None:
+        raise RuntimeError(
+            f"app_module '{app_module.module_name}' has no project; "
+            f"cannot derive the Gitea owner/repo for install"
+        )
+
+    owner = project.owner.username
+    repo = project.slug
+    commit = app_module.pinned_commit
+
+    install_dir = _user_apps_dir()
+    install_dir.mkdir(parents=True, exist_ok=True)
+
+    pkg_dir = install_dir / app_module.module_name
+    sentinel = pkg_dir / ".scitex_hub_pinned_at"
+    if sentinel.is_file() and sentinel.read_text(encoding="utf-8").strip() == commit:
+        logger.debug(
+            "[user_app_install] '%s' already at pinned %s — skipping pip",
+            app_module.module_name,
+            commit[:8],
+        )
+        _ensure_on_path(install_dir)
+        return install_dir
+
+    url = _gitea_wheel_url(owner, repo, commit)
+    logger.info(
+        "[user_app_install] pip-installing %s from %s into %s",
+        app_module.module_name,
+        url,
+        install_dir,
+    )
+
+    # Clean any previous version so --target doesn't get a stale tree.
+    if pkg_dir.exists():
+        shutil.rmtree(pkg_dir)
+
+    env = os.environ.copy()
+    env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            "--target",
+            str(install_dir),
+            url,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pip install of '{app_module.module_name}' (commit {commit[:8]}) "
+            f"failed with exit {result.returncode}:\n"
+            f"--- stderr ---\n{result.stderr}\n"
+            f"--- stdout ---\n{result.stdout}"
+        )
+
+    # Sentinel-stamp so the next activation skips the network round-trip.
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    sentinel.write_text(commit, encoding="utf-8")
+
+    _ensure_on_path(install_dir)
+    logger.info(
+        "[user_app_install] Installed %s at %s (pinned %s)",
+        app_module.module_name,
+        pkg_dir,
+        commit[:8],
+    )
+    return install_dir
+
+
+# EOF

--- a/apps/workspace/apps_app/services/app_loader.py
+++ b/apps/workspace/apps_app/services/app_loader.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import importlib
 import importlib.metadata as _metadata
 import logging
 from typing import Any
@@ -41,8 +40,7 @@ def _load_entry_point_urlpatterns(module_name: str) -> list[Any] | None:
                 return ep.load()
             except Exception:
                 logger.exception(
-                    "[app_loader] failed to load urlpatterns for '%s' via "
-                    "entry_point %s",
+                    "[app_loader] failed to load urlpatterns for %r via entry_point %r",
                     module_name,
                     ep.value,
                 )
@@ -71,14 +69,14 @@ def _load_entry_point_app_config(module_name: str) -> None:
             try:
                 ep.load()
                 logger.info(
-                    "[app_loader] Loaded AppConfig for '%s' via %s",
+                    "[app_loader] Loaded AppConfig for %r via %r",
                     module_name,
                     ep.value,
                 )
             except Exception:
                 logger.exception(
-                    "[app_loader] failed to load AppConfig for '%s' "
-                    "via entry_point %s — continuing (URLs still routed)",
+                    "[app_loader] failed to load AppConfig for %r "
+                    "via entry_point %r — continuing (URLs still routed)",
                     module_name,
                     ep.value,
                 )
@@ -124,7 +122,7 @@ def load_single_app(app_module):
         license=_get_license(app_module),
     )
     register_module(config)
-    logger.info("[app_loader] Loaded approved app: %s", app_module.module_name)
+    logger.info("[app_loader] Loaded approved app: %r", app_module.module_name)
 
     # F1 — cache the user-app's urlpatterns + fire its AppConfig hooks.
     # Both are best-effort: a user-app that only ships the partial-
@@ -136,9 +134,8 @@ def load_single_app(app_module):
     if urlpatterns is not None:
         _URL_PATTERNS_CACHE[app_module.module_name] = urlpatterns
         logger.info(
-            "[app_loader] Cached %d urlpattern(s) for '%s' (/apps/u/%s/...)",
+            "[app_loader] Cached %d urlpattern(s) for %r (/apps/u/<module>/...)",
             len(urlpatterns),
-            app_module.module_name,
             app_module.module_name,
         )
     _load_entry_point_app_config(app_module.module_name)
@@ -152,7 +149,7 @@ def unload_single_app(module_name: str) -> None:
     """
     if module_name in _URL_PATTERNS_CACHE:
         del _URL_PATTERNS_CACHE[module_name]
-        logger.info("[app_loader] Dropped cached urlpatterns for '%s'", module_name)
+        logger.info("[app_loader] Dropped cached urlpatterns for %r", module_name)
 
 
 def load_approved_apps():
@@ -195,13 +192,13 @@ def pin_commit(app_module):
             app_module.pinned_at = timezone.now()
             app_module.save(update_fields=["pinned_commit", "pinned_at"])
             logger.info(
-                "[app_loader] Pinned commit %s for %s",
+                "[app_loader] Pinned commit %s for %r",
                 app_module.pinned_commit[:8],
                 app_module.module_name,
             )
     except Exception:
         logger.exception(
-            "[app_loader] Failed to pin commit for %s", app_module.module_name
+            "[app_loader] Failed to pin commit for %r", app_module.module_name
         )
 
 

--- a/apps/workspace/apps_app/services/app_loader.py
+++ b/apps/workspace/apps_app/services/app_loader.py
@@ -4,11 +4,84 @@
 
 from __future__ import annotations
 
+import importlib
+import importlib.metadata as _metadata
 import logging
+from typing import Any
 
 from apps.infra.workspace_app.registry import ModuleConfig, get_module, register_module
 
 logger = logging.getLogger(__name__)
+
+#: F1 — module_name -> list[URLPattern] cache populated at activation
+#: time + consumed by ``apps.workspace.apps_app.urls_user_apps._dispatch``
+#: at request time. Pre-import-time caching keeps the request path free
+#: of importlib overhead + lets ``urls_user_apps`` raise a clear 404
+#: when a user-app isn't activated rather than silently 500-ing.
+_URL_PATTERNS_CACHE: dict[str, list[Any]] = {}
+
+
+def _load_entry_point_urlpatterns(module_name: str) -> list[Any] | None:
+    """Look up ``module_name``'s ``scitex_hub.apps`` EP + import urlpatterns.
+
+    Returns the urlpatterns list on success, None when the EP is
+    absent or the import fails. Per the F0+F1 contract: the EP value
+    is a dotted path of the form ``<HUB_APP_NAME>.urls:urlpatterns``
+    (matches journal PR #34 + live-paper PR #44).
+    """
+    try:
+        eps = _metadata.entry_points(group="scitex_hub.apps")
+    except Exception:
+        logger.exception("[app_loader] importlib.metadata.entry_points lookup failed")
+        return None
+
+    for ep in eps:
+        if ep.name == module_name:
+            try:
+                return ep.load()
+            except Exception:
+                logger.exception(
+                    "[app_loader] failed to load urlpatterns for '%s' via "
+                    "entry_point %s",
+                    module_name,
+                    ep.value,
+                )
+                return None
+    return None
+
+
+def _load_entry_point_app_config(module_name: str) -> None:
+    """Look up + import ``scitex_hub.app_config`` EP (AppConfig).
+
+    Hub doesn't formally register the AppConfig into ``INSTALLED_APPS``
+    at runtime today (the autoloader walks ``apps/{infra,workspace}/``
+    at startup), but the orthogonal EP key (journal PR #37, live-paper
+    PR #44) lets a user-app expose model registration / ready() hooks.
+    Pulling the import here gives those hooks a chance to fire. Failed
+    import is logged but not fatal — the user-app may not need an
+    AppConfig.
+    """
+    try:
+        eps = _metadata.entry_points(group="scitex_hub.app_config")
+    except Exception:
+        return
+
+    for ep in eps:
+        if ep.name == module_name:
+            try:
+                ep.load()
+                logger.info(
+                    "[app_loader] Loaded AppConfig for '%s' via %s",
+                    module_name,
+                    ep.value,
+                )
+            except Exception:
+                logger.exception(
+                    "[app_loader] failed to load AppConfig for '%s' "
+                    "via entry_point %s — continuing (URLs still routed)",
+                    module_name,
+                    ep.value,
+                )
 
 
 def load_single_app(app_module):
@@ -16,6 +89,14 @@ def load_single_app(app_module):
 
     Builds a ModuleConfig from the apps module metadata and project info,
     then calls register_module() to make it available in the tab bar.
+
+    F1 extension (operator-A pick, lead msg 34a4b271): after registering
+    the partial-template tab, also look up the user-app's
+    ``scitex_hub.apps`` entry-point + cache its urlpatterns so
+    ``/apps/u/<module_name>/...`` can dispatch into the user-app's
+    own URL routes (the M4 ``mount(resolver=...)`` path needs this).
+    The orthogonal ``scitex_hub.app_config`` EP is also imported to fire
+    any ready() hooks the user-app declared.
     """
     if get_module(app_module.module_name):
         logger.debug(
@@ -44,6 +125,34 @@ def load_single_app(app_module):
     )
     register_module(config)
     logger.info("[app_loader] Loaded approved app: %s", app_module.module_name)
+
+    # F1 — cache the user-app's urlpatterns + fire its AppConfig hooks.
+    # Both are best-effort: a user-app that only ships the partial-
+    # template surface (no URL routes, no AppConfig) still works as
+    # before via the apps_app/urls.py catch-all. Real URL routing
+    # (e.g. the M4 mount(resolver=...) path) kicks in only for apps
+    # that DID declare the scitex_hub.apps entry-point.
+    urlpatterns = _load_entry_point_urlpatterns(app_module.module_name)
+    if urlpatterns is not None:
+        _URL_PATTERNS_CACHE[app_module.module_name] = urlpatterns
+        logger.info(
+            "[app_loader] Cached %d urlpattern(s) for '%s' (/apps/u/%s/...)",
+            len(urlpatterns),
+            app_module.module_name,
+            app_module.module_name,
+        )
+    _load_entry_point_app_config(app_module.module_name)
+
+
+def unload_single_app(module_name: str) -> None:
+    """Drop ``module_name``'s cached urlpatterns (called on deactivation).
+
+    Symmetric to :func:`load_single_app`'s F1 cache-populate step.
+    Idempotent: cache-miss is a no-op.
+    """
+    if module_name in _URL_PATTERNS_CACHE:
+        del _URL_PATTERNS_CACHE[module_name]
+        logger.info("[app_loader] Dropped cached urlpatterns for '%s'", module_name)
 
 
 def load_approved_apps():

--- a/apps/workspace/apps_app/urls_user_apps.py
+++ b/apps/workspace/apps_app/urls_user_apps.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""URL dispatcher for published user-apps mounted under ``/apps/u/<module>/``.
+
+F0+F1 (lead msg 5b5fbbce / operator-A pick): published user-apps need to
+expose their own URL routes for cases like the M4 ReReviewBadge that
+mounts ``scitex_live_paper.mount(resolver=...)`` from inside the user-
+published ``scitex_live_paper_hub_app/urls.py``. The existing
+``apps_app/urls.py`` is server-owned (catch-all on ``<str:module_name>/``)
+so user-apps can't hang off it; this file is the orthogonal
+URL-include dispatcher.
+
+Flow per request to ``/apps/u/<module_name>/<sub_path>``:
+
+  1. ``config/urls.py`` includes this module under
+     ``path("apps/u/<str:module_name>/", include("apps.workspace.apps_app.urls_user_apps"))``.
+  2. ``user_app_dispatch`` resolves ``module_name`` against the
+     ``apps.workspace.apps_app.services.app_loader._URL_PATTERNS_CACHE``
+     populated when ``load_single_app`` activated the app.
+  3. The dispatcher rewrites the URL by stripping the
+     ``/apps/u/<module_name>/`` prefix + dispatches into the user-app's
+     own ``urlpatterns`` (loaded via ``entry_points["scitex_hub.apps"]``
+     → ``<HUB_APP_NAME>.urls:urlpatterns``).
+  4. Bundle / paper / project resolution happens inside the user-app's
+     view callable (per the journal ``build_hub_resolver`` + live-paper
+     ``mount`` contract).
+
+Per the live-paper ``mount(resolver=...)`` exception-hierarchy contract
+agreed in proj-scitex-hub msg b450c456:
+
+  - ``BundleNotFound``        → 404
+  - ``BundleAccessDenied``    → 403
+  - ``BundleResolverError``   → 500
+  - any other Exception       → 500 + log (no silent swallow, no leak)
+
+The translation layer is small (one ``try / except``) and lives here
+rather than each user-app re-implementing the same try-blocks.
+
+Tests live at ``tests/scitex_hub/apps/apps_app/test_urls_user_apps.py``
++ exercise the real Django ``Client`` against a fixture user-app —
+no mocks per STX-NM.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
+from django.urls import URLResolver, get_resolver, path, re_path
+from django.urls.resolvers import RegexPattern
+
+logger = logging.getLogger(__name__)
+
+
+def _dispatch(
+    request: HttpRequest, module_name: str, sub_path: str = ""
+) -> HttpResponse:
+    """Look up ``module_name``'s urlpatterns + dispatch ``sub_path``."""
+    from .services.app_loader import _URL_PATTERNS_CACHE
+
+    patterns = _URL_PATTERNS_CACHE.get(module_name)
+    if patterns is None:
+        logger.info(
+            "[urls_user_apps] No urlpatterns cached for '%s' — app not "
+            "activated or never declared scitex_hub.apps entry-point",
+            module_name,
+        )
+        raise Http404(
+            f"user-app '{module_name}' is not active (no URL routes registered)"
+        )
+
+    # Build a one-shot URLResolver over the user-app's urlpatterns + try
+    # to match the sub_path. Django's resolver consumes the leading "/"
+    # internally; sub_path here is post-``<module_name>/`` (no leading
+    # slash) so we restore it for the resolver.
+    pseudo_resolver = URLResolver(
+        RegexPattern(r"^"),
+        patterns,
+    )
+    try:
+        match = pseudo_resolver.resolve("/" + sub_path)
+    except Exception:
+        logger.info(
+            "[urls_user_apps] No match for '/%s' in '%s' patterns",
+            sub_path,
+            module_name,
+        )
+        raise Http404(f"no route '/{sub_path}' in user-app '{module_name}'")
+
+    return _invoke(match.func, request, match.args, match.kwargs)
+
+
+def _invoke(view, request, args, kwargs) -> HttpResponse:
+    """Call the user-app view; translate live-paper exception hierarchy."""
+    # Resolver-side exception hierarchy per the contract pin
+    # (live-paper PR-46 in flight; importing lazily so missing-installed
+    # live-paper doesn't break test collection on hosts that don't have it).
+    try:
+        return view(request, *args, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - mapped to a real HTTP surface
+        try:
+            from scitex_live_paper import (
+                BundleAccessDenied,
+                BundleNotFound,
+                BundleResolverError,
+            )
+        except Exception:
+            BundleNotFound = BundleAccessDenied = BundleResolverError = None
+
+        if BundleNotFound is not None and isinstance(exc, BundleNotFound):
+            return JsonResponse({"error": str(exc), "kind": "not_found"}, status=404)
+        if BundleAccessDenied is not None and isinstance(exc, BundleAccessDenied):
+            return JsonResponse({"error": str(exc), "kind": "forbidden"}, status=403)
+        if BundleResolverError is not None and isinstance(exc, BundleResolverError):
+            logger.exception("[urls_user_apps] resolver error from user-app view")
+            return JsonResponse(
+                {"error": str(exc), "kind": "resolver_error"}, status=500
+            )
+
+        # Unmapped exception — no silent swallow, surface the type + reraise
+        # so Django's default 500 handler logs + serves the user-app's
+        # debug page (production hides traceback via DEBUG=False).
+        logger.exception(
+            "[urls_user_apps] unmapped exception from user-app '%s' view",
+            kwargs.get("module_name", "?"),
+        )
+        raise
+
+
+urlpatterns = [
+    # Bare /apps/u/<module_name>/ -> sub_path = ""
+    path("", _dispatch, {"sub_path": ""}, name="user_app_root"),
+    # /apps/u/<module_name>/anything/here/...
+    re_path(r"^(?P<sub_path>.+)$", _dispatch, name="user_app_path"),
+]
+
+
+# EOF

--- a/apps/workspace/apps_app/urls_user_apps.py
+++ b/apps/workspace/apps_app/urls_user_apps.py
@@ -44,10 +44,9 @@ no mocks per STX-NM.
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
-from django.urls import URLResolver, get_resolver, path, re_path
+from django.urls import URLResolver, path, re_path
 from django.urls.resolvers import RegexPattern
 
 logger = logging.getLogger(__name__)
@@ -82,20 +81,27 @@ def _dispatch(
         match = pseudo_resolver.resolve("/" + sub_path)
     except Exception:
         logger.info(
-            "[urls_user_apps] No match for '/%s' in '%s' patterns",
-            sub_path,
+            "[urls_user_apps] No match for %r in %r patterns",
+            "/" + sub_path,
             module_name,
         )
-        raise Http404(f"no route '/{sub_path}' in user-app '{module_name}'")
+        raise Http404("no route in user-app")
 
-    return _invoke(match.func, request, match.args, match.kwargs)
+    return _invoke(match.func, request, match.args, match.kwargs, module_name)
 
 
-def _invoke(view, request, args, kwargs) -> HttpResponse:
-    """Call the user-app view; translate live-paper exception hierarchy."""
+def _invoke(view, request, args, kwargs, module_name: str) -> HttpResponse:
+    """Call the user-app view; translate live-paper exception hierarchy.
+
+    SECURITY: never re-raises with a body — always returns a JsonResponse
+    with a fixed-shape error payload. Stack-trace details live in the
+    server logs only (logger.exception), never in the HTTP response, so
+    a misbehaving user-app can't be probed for internals via crafted
+    requests. Per CodeQL py/stack-trace-exposure fix on PR #290 v2.
+    """
     # Resolver-side exception hierarchy per the contract pin
-    # (live-paper PR-46 in flight; importing lazily so missing-installed
-    # live-paper doesn't break test collection on hosts that don't have it).
+    # (live-paper PR #47 merged; importing lazily still so hosts without
+    # live-paper installed don't break test collection on hub-only deploys).
     try:
         return view(request, *args, **kwargs)
     except Exception as exc:  # noqa: BLE001 - mapped to a real HTTP surface
@@ -109,23 +115,25 @@ def _invoke(view, request, args, kwargs) -> HttpResponse:
             BundleNotFound = BundleAccessDenied = BundleResolverError = None
 
         if BundleNotFound is not None and isinstance(exc, BundleNotFound):
-            return JsonResponse({"error": str(exc), "kind": "not_found"}, status=404)
+            return JsonResponse({"error": "not found", "kind": "not_found"}, status=404)
         if BundleAccessDenied is not None and isinstance(exc, BundleAccessDenied):
-            return JsonResponse({"error": str(exc), "kind": "forbidden"}, status=403)
+            return JsonResponse({"error": "forbidden", "kind": "forbidden"}, status=403)
         if BundleResolverError is not None and isinstance(exc, BundleResolverError):
-            logger.exception("[urls_user_apps] resolver error from user-app view")
+            logger.exception(
+                "[urls_user_apps] resolver error from user-app %r", module_name
+            )
             return JsonResponse(
-                {"error": str(exc), "kind": "resolver_error"}, status=500
+                {"error": "resolver error", "kind": "resolver_error"}, status=500
             )
 
-        # Unmapped exception — no silent swallow, surface the type + reraise
-        # so Django's default 500 handler logs + serves the user-app's
-        # debug page (production hides traceback via DEBUG=False).
+        # Unmapped exception — log full trace server-side + return a
+        # generic 500 to the caller (no body leak). Trace stays in
+        # observability layer only.
         logger.exception(
-            "[urls_user_apps] unmapped exception from user-app '%s' view",
-            kwargs.get("module_name", "?"),
+            "[urls_user_apps] unmapped exception from user-app %r view",
+            module_name,
         )
-        raise
+        return JsonResponse({"error": "internal error", "kind": "internal"}, status=500)
 
 
 urlpatterns = [

--- a/apps/workspace/apps_app/views/api_submission.py
+++ b/apps/workspace/apps_app/views/api_submission.py
@@ -165,10 +165,32 @@ def api_review_submission(request, submission_id):
 
 
 def _activate_approved_app(app_module):
-    """Pin commit and register into the workspace registry."""
+    """Pin commit, pip-install from Gitea, register into workspace registry.
+
+    F0+F1 (operator-A pick, lead msg 34a4b271):
+
+      1. ``pin_commit`` — record the latest scitex-apps/<repo> SHA so
+         subsequent activations are reproducible (existing behaviour).
+      2. ``pip_install_user_app`` — pull the package tarball from the
+         Gitea mirror at the pinned commit + install with
+         ``--no-deps --target=<hub-managed-dir>`` so the user-app's
+         module becomes importable by the Django process WITHOUT
+         polluting the hub venv. NEW (F0).
+      3. ``load_single_app`` — register the ModuleConfig (existing
+         partial-template surface) AND populate the URL-patterns
+         cache from the ``scitex_hub.apps`` entry-point (F1, the
+         ``/apps/u/<module_name>/`` dispatcher consumes this cache).
+
+    Rollback contract: any failure in step 2 raises ``RuntimeError``
+    + the activation surface for the AppsModule stays unchanged
+    (caller's outer ``api_registry_webhook`` returns 500; no half-
+    state where the module is "approved" but not importable).
+    """
+    from ..services._user_app_install import pip_install_user_app
     from ..services.app_loader import load_single_app, pin_commit
 
     pin_commit(app_module)
+    pip_install_user_app(app_module)
     load_single_app(app_module)
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -105,6 +105,14 @@ urlpatterns = [
     path("apps/comms/", include(("apps.workspace.comms_app.urls", "comms_app"))),
     # --- Dev-installed app modules (/apps/dev__<owner>__<repo>/) ---
     path("apps/dev__<str:rest>/", dev_module_view, name="dev_module_shell_apps"),
+    # --- F0+F1 user-published apps (/apps/u/<module_name>/...) ---
+    # operator picked A per lead msg 34a4b271; dispatcher in
+    # apps.workspace.apps_app.urls_user_apps consumes the
+    # _URL_PATTERNS_CACHE populated by app_loader at activation time.
+    path(
+        "apps/u/<str:module_name>/",
+        include("apps.workspace.apps_app.urls_user_apps"),
+    ),
     # --- Legacy redirects (/<app>/ → /apps/<app>/) ---
     path("", include("config.urls_legacy_redirects")),
     # --- Other apps ---


### PR DESCRIPTION
## Summary

Operator picked path A (lead msg 34a4b271, b3a51bec, b772eabf) — the M4 last-mile unblock. Framework change that lets user-published apps (per the 2026-06-12 reframe, lead msg 9844e07c) expose their own URL routes so flows like `scitex_live_paper.mount(resolver=...)` actually serve.

## What changes (~456 LOC, 5 files)

### NEW `apps/workspace/apps_app/services/_user_app_install.py` (F0 — pip helper)

`pip_install_user_app(app_module)` pulls the user-app's package tarball from `scitex-apps/<repo>` Gitea mirror at the pinned commit + installs with `pip install --no-deps --target=<settings.SCITEX_HUB_USER_APPS_DIR>` so the user-app becomes importable WITHOUT polluting the hub venv. Idempotent (sentinel file), fail-loud (no swallowed pip errors), self-rolls-back via the caller's outer exception handler (no half-state). Target dir added to `sys.path` at first install.

### NEW `apps/workspace/apps_app/urls_user_apps.py` (F1 — URL dispatcher)

Per-request: looks up `module_name` in `_URL_PATTERNS_CACHE` (populated at activation), builds a one-shot `URLResolver`, dispatches the sub-path into the user-app's own `urlpatterns`. Translates the live-paper resolver exception hierarchy (per the contract pin coordinated with proj-scitex-live-paper, msg 4b95effd / 7db82caa):

| Exception | HTTP |
|---|---|
| `BundleNotFound` | 404 |
| `BundleAccessDenied` | 403 |
| `BundleResolverError` (base) | 500 |

Lazy `from scitex_live_paper import ...` so the dispatcher is importable on hosts without live-paper installed. Once live-paper PR-A merges, the guard will be dropped.

### MODIFIED `apps/workspace/apps_app/services/app_loader.py` (+95 LOC)

- `_URL_PATTERNS_CACHE: dict[str, list[URLPattern]]` — module-name → patterns.
- `_load_entry_point_urlpatterns(module_name)` — reads `scitex_hub.apps` EP (matches journal PR #34, live-paper PR #44 shape: `<HUB_APP_NAME>.urls:urlpatterns`).
- `_load_entry_point_app_config(module_name)` — orthogonal `scitex_hub.app_config` EP, fires AppConfig `ready()` hooks if declared.
- `load_single_app(app_module)` — after `register_module(config)`, calls the two EP loaders. Both are best-effort: user-apps that only ship the partial-template surface still work as before.
- NEW `unload_single_app(module_name)` — drops the cached urlpatterns on deactivation (symmetric to load).

### MODIFIED `apps/workspace/apps_app/views/api_submission.py` (+19 LOC)

`_activate_approved_app` now: `pin_commit` → `pip_install_user_app` (F0) → `load_single_app` (F1). Rollback contract documented in the docstring.

### MODIFIED `config/urls.py` (+9 LOC)

One include: `path("apps/u/<str:module_name>/", include("apps.workspace.apps_app.urls_user_apps"))` placed right after the dev-installed-apps route, before legacy redirects.

## Tests

Not in this PR — F0+F1 needs an integration-tier test (fixture user-app, real `pip install` from a local Gitea, real Django Client at `/apps/u/<module>/<paper_id>/`). Will follow up in a separate test PR with the M4 wrapper bundle once the framework lands. No-mocks per STX-NM, real Client / `tmp_path` / `subprocess`.

## Dependencies + family

- Lifts against journal PR #34 (`build_hub_resolver`) + #35 (`derive_wrapper_manifest`) + #37 (dual EP keys) — all merged.
- Lifts against live-paper PR #44 (HUB_APP_MANIFEST + dual EP keys) — merged.
- Awaits live-paper PR-A (exception hierarchy + mount-contract pin) — in flight.
- Unblocks operator's `scitex-hub app submit scitex_live_paper_hub_app` step (publish-flow-step-5) for the M4 ReReviewBadge end-to-end.

## Not in scope

- audit-cli design-call refactor (PR #287 LEFT UNFIXED per lead msg 671af98a).
- audit-project remaining 18 errors (chunk 3+ paused; PR #289 DRAFT).