### PR TITLE
feat(apps_app): drop urls_user_apps lazy-import guard (M4 finish-line cleanup)

### DIFF
--- a/apps/workspace/apps_app/urls_user_apps.py
+++ b/apps/workspace/apps_app/urls_user_apps.py
@@ -48,6 +48,11 @@ import logging
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.urls import URLResolver, path, re_path
 from django.urls.resolvers import RegexPattern
+from scitex_live_paper import (
+    BundleAccessDenied,
+    BundleNotFound,
+    BundleResolverError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,26 +104,19 @@ def _invoke(view, request, args, kwargs, module_name: str) -> HttpResponse:
     a misbehaving user-app can't be probed for internals via crafted
     requests. Per CodeQL py/stack-trace-exposure fix on PR #290 v2.
     """
-    # Resolver-side exception hierarchy per the contract pin
-    # (live-paper PR #47 merged; importing lazily still so hosts without
-    # live-paper installed don't break test collection on hub-only deploys).
+    # Resolver-side exception hierarchy per the contract pin (live-paper
+    # PR #47 merged + on develop; the import is now hard at module level
+    # — fail-loud at Django startup if scitex-live-paper isn't installed
+    # rather than silently misrouting exceptions to a generic 500 at
+    # request time).
     try:
         return view(request, *args, **kwargs)
     except Exception as exc:  # noqa: BLE001 - mapped to a real HTTP surface
-        try:
-            from scitex_live_paper import (
-                BundleAccessDenied,
-                BundleNotFound,
-                BundleResolverError,
-            )
-        except Exception:
-            BundleNotFound = BundleAccessDenied = BundleResolverError = None
-
-        if BundleNotFound is not None and isinstance(exc, BundleNotFound):
+        if isinstance(exc, BundleNotFound):
             return JsonResponse({"error": "not found", "kind": "not_found"}, status=404)
-        if BundleAccessDenied is not None and isinstance(exc, BundleAccessDenied):
+        if isinstance(exc, BundleAccessDenied):
             return JsonResponse({"error": "forbidden", "kind": "forbidden"}, status=403)
-        if BundleResolverError is not None and isinstance(exc, BundleResolverError):
+        if isinstance(exc, BundleResolverError):
             logger.exception(
                 "[urls_user_apps] resolver error from user-app %r", module_name
             )


### PR DESCRIPTION
## Summary

M4 finish-line cleanup. PR #290 (F0+F1) shipped urls_user_apps with a lazy try/except guard around the live-paper exception-hierarchy import because at that time live-paper PR #47 (BundleResolverError/BundleNotFound/BundleAccessDenied) was still in flight. PR #47 merged + the hierarchy is on live-paper develop.

This PR converts the lazy guard to a hard top-level import. If scitex-live-paper isn't installed in the hub venv, Django startup fails LOUD at import time rather than silently misrouting exceptions to a generic 500 at request time. That's the right failure mode for a deploy where F0+F1 is active.

## Diff

-13/+15 LOC in apps/workspace/apps_app/urls_user_apps.py:
- Import `from scitex_live_paper import BundleAccessDenied, BundleNotFound, BundleResolverError` at module level.
- Drop the try/except wrapping the same import inside `_invoke`.
- Drop the now-redundant `if BundleResolverError is not None` guard.

## Family

PR #290 ⇒ this cleanup ⇒ /tmp/m4-pathB-scaffolds.tar.gz rebundle (operator-handoff scaffold tarball — no PR; runs out-of-band) ⇒ integration-test PR + negative sub-card (M4 done-gate) ⇒ operator runs the 2 scitex-hub app submit commands. Per lead msg 6e2a99d3.

## Not in scope

- No new tests in this PR (1-LOC guard removal; covered by the upcoming integration-test PR per the f0-f1-integration-test scitex-todo card).
- audit-cli + audit-project pre-existing debt — out of scope; merge per green-except-pre-existing-debt.
- Repo-wide 30 HIGH CodeQL backlog — separate card hub-codeql-backlog-pass (priority 6).