### PR TITLE
fix(apps_app): restore lazy-import guard for scitex_live_paper (unbreak develop CI)

### DIFF
--- a/apps/workspace/apps_app/urls_user_apps.py
+++ b/apps/workspace/apps_app/urls_user_apps.py
@@ -48,13 +48,45 @@ import logging
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.urls import URLResolver, path, re_path
 from django.urls.resolvers import RegexPattern
-from scitex_live_paper import (
-    BundleAccessDenied,
-    BundleNotFound,
-    BundleResolverError,
-)
 
+# scitex-live-paper exception hierarchy — kept LAZY (top-level
+# try/except + None fallback) because the package is not yet on PyPI
+# and is therefore NOT declarable as a hard runtime dep in
+# scitex-hub's pyproject.toml. PR #292 promoted this to a hard
+# top-level import on the assumption that live-paper PR #47 had
+# landed and the dep would be added — but the dep was never added,
+# so every CI run (and any hub install without live-paper on the
+# PYTHONPATH) broke Django startup at config/urls.py import time.
+#
+# Restoring the lazy guard. The dispatch logic below ``and`` checks
+# `is not None` before isinstance(), so when live-paper IS installed
+# the user-app exception-hierarchy translation works exactly as it
+# did under #292; when it ISN'T installed, an unmapped exception just
+# flows through the generic 500-with-logged-trace path (no live-paper
+# user-app would be running anyway in that case).
+#
+# REVERT this back to a hard import (and drop the None checks below)
+# once scitex-live-paper is published to PyPI AND declared as a
+# scitex-hub runtime dep in pyproject.toml.
 logger = logging.getLogger(__name__)
+
+try:
+    from scitex_live_paper import (
+        BundleAccessDenied,
+        BundleNotFound,
+        BundleResolverError,
+    )
+except (
+    Exception
+) as _live_paper_import_err:  # noqa: BLE001 — STX-EH001: catch runtime-init too
+    logger.debug(
+        "[urls_user_apps] scitex_live_paper import failed (%s) — "
+        "exception-hierarchy translation will skip via None checks",
+        _live_paper_import_err,
+    )
+    BundleNotFound = None  # type: ignore[assignment]
+    BundleAccessDenied = None  # type: ignore[assignment]
+    BundleResolverError = None  # type: ignore[assignment]
 
 
 def _dispatch(
@@ -104,19 +136,19 @@ def _invoke(view, request, args, kwargs, module_name: str) -> HttpResponse:
     a misbehaving user-app can't be probed for internals via crafted
     requests. Per CodeQL py/stack-trace-exposure fix on PR #290 v2.
     """
-    # Resolver-side exception hierarchy per the contract pin (live-paper
-    # PR #47 merged + on develop; the import is now hard at module level
-    # — fail-loud at Django startup if scitex-live-paper isn't installed
-    # rather than silently misrouting exceptions to a generic 500 at
-    # request time).
+    # Resolver-side exception hierarchy per the contract pin
+    # (live-paper PR #47). Lazy-imported at module top (None fallback
+    # when scitex-live-paper isn't installed); the isinstance() checks
+    # below short-circuit safely via the `is not None` guard so hub
+    # boots clean without live-paper.
     try:
         return view(request, *args, **kwargs)
     except Exception as exc:  # noqa: BLE001 - mapped to a real HTTP surface
-        if isinstance(exc, BundleNotFound):
+        if BundleNotFound is not None and isinstance(exc, BundleNotFound):
             return JsonResponse({"error": "not found", "kind": "not_found"}, status=404)
-        if isinstance(exc, BundleAccessDenied):
+        if BundleAccessDenied is not None and isinstance(exc, BundleAccessDenied):
             return JsonResponse({"error": "forbidden", "kind": "forbidden"}, status=403)
-        if isinstance(exc, BundleResolverError):
+        if BundleResolverError is not None and isinstance(exc, BundleResolverError):
             logger.exception(
                 "[urls_user_apps] resolver error from user-app %r", module_name
             )


### PR DESCRIPTION
## Summary

Unbreaks develop. PR #292 dropped the lazy guard around the scitex-live-paper exception hierarchy import, asserting it was a hard dep post-live-paper-PR-#47. But the dep was **never added to scitex-hub's pyproject.toml runtime deps**, AND scitex-live-paper isn't published to PyPI yet — so every fresh-install CI run (and any hub install without live-paper on the PYTHONPATH) breaks Django startup at config/urls.py import time:

```
config/urls.py:114: in <module>
    include("apps.workspace.apps_app.urls_user_apps"),
apps/workspace/apps_app/urls_user_apps.py:51: in <module>
    from scitex_live_paper import (...)
E   ModuleNotFoundError: No module named 'scitex_live_paper'
```

This is blocking **every PR**, not just one. Confirmed reproduction in PR #294 CI (pytest-matrix-3.11/3.12/3.13 + audit, all RED with this same trace).

## Add-dep vs restore-guard decision

**Restore the guard** (this PR). Rationale: scitex-live-paper distribution name `scitex-live-paper` is not on PyPI (`pip index versions scitex-live-paper` → "No matching distribution found"). Adding it to runtime deps would just shift the failure from import-time to pip-install-time. The package exists in `/home/ywatanabe/proj/scitex-live-paper/pyproject.toml` (v0.1.0) but hasn't been published. The lazy guard is the lighter-touch fix that unblocks all PRs immediately.

REVERT this back to a hard import + drop the None checks when:
1. scitex-live-paper is published to PyPI, AND
2. it's declared as a scitex-hub runtime dep in pyproject.toml

The header doc + dispatch comment record the trigger condition for reversion.

## Changes

- Top-level `try: from scitex_live_paper import ... except Exception: BundleNotFound = BundleAccessDenied = BundleResolverError = None`
- `except Exception` (not `except ImportError`) per STX-EH001 — catches runtime-init errors (protobuf version mismatches, etc.) too
- Dispatch checks `is not None and isinstance(exc, ...)` before mapping to the typed HTTP responses
- When live-paper IS installed → behavior identical to pre-PR-#292 + post-#292 (the hierarchy translation works)
- When live-paper ISN'T installed → unmapped exceptions flow through the generic 500-with-logged-trace path (no live-paper user-app would be running anyway in that case)
- `logger.debug()` records the import failure cause when the fallback fires (debuggability without log noise)

## Test plan

- [ ] CI matrix green on this branch (pytest-matrix-3.11/12/13 + audit + sphinx + e2e mobile)
- [ ] After merge: PR #294 CI auto-reruns + goes green for the M4 bump
- [ ] Future follow-up: once scitex-live-paper publishes to PyPI, add as runtime dep + revert this guard

## Refs

- scitex-cloud PR #292 (`feat(apps_app): drop urls_user_apps lazy-import guard — scitex-live-paper is hard-dep post-PR-#47`) — premature; dep never landed
- Lead msgs `60253a69` / `d8381821` ("FIX IT FIRST — unbreaking develop is the higher priority")