### PR TITLE
fix(chat-welcome): respect active element — don't steal focus mid-type

### DIFF
--- a/static/shared/ts/components/chat-welcome.ts
+++ b/static/shared/ts/components/chat-welcome.ts
@@ -20,25 +20,47 @@ function initChatWelcome(): void {
 
   if (!welcomeInput || !welcomePane) return;
 
-  // Auto-focus welcome input on load
-  setTimeout(() => welcomeInput.focus(), 200);
+  // Auto-focus welcome input on load — but ONLY if no other element
+  // already holds focus. Without this guard, an SPA-like re-init or a
+  // delayed boot of this component would steal focus FROM whatever
+  // textarea the user is actively typing in (operator-reported bug:
+  // "textarea activation/focus repeatedly stolen mid-type").
+  // `document.body` / `null` represent "no real focus" — safe to grab.
+  setTimeout(() => {
+    if (
+      document.activeElement === null ||
+      document.activeElement === document.body
+    ) {
+      welcomeInput.focus();
+    }
+  }, 200);
 
-  // Auto-focus when switching to chat pane
+  // Auto-focus when switching to chat pane — same guard. Pane-changed
+  // events can fire during workspace shell layout adjustments while
+  // the user is typing elsewhere; respect the user's focus.
   document.addEventListener("workspace-pane-changed", (e: Event) => {
     const detail = (e as CustomEvent).detail;
-    if (detail?.pane === "chat") {
-      setTimeout(() => {
-        if (!welcomePane.classList.contains("has-messages")) {
-          welcomeInput.focus();
-        } else {
-          // Focus the AI chat input when session has messages
-          const aiInput = document.getElementById(
-            "stx-shell-ai-input",
-          ) as HTMLTextAreaElement | null;
-          aiInput?.focus();
-        }
-      }, 100);
-    }
+    if (detail?.pane !== "chat") return;
+    setTimeout(() => {
+      // Skip if user is already focused on a real input/textarea
+      // (anywhere in the document — they're typing, don't steal it).
+      const active = document.activeElement;
+      const userIsTyping =
+        active instanceof HTMLInputElement ||
+        active instanceof HTMLTextAreaElement ||
+        (active instanceof HTMLElement && active.isContentEditable);
+      if (userIsTyping) return;
+
+      if (!welcomePane.classList.contains("has-messages")) {
+        welcomeInput.focus();
+      } else {
+        // Focus the AI chat input when session has messages
+        const aiInput = document.getElementById(
+          "stx-shell-ai-input",
+        ) as HTMLTextAreaElement | null;
+        aiInput?.focus();
+      }
+    }, 100);
   });
 
   // Check if messages already exist (session was restored)


### PR DESCRIPTION
## Summary

Operator-reported bug (via lead msgs `5d86b7b0` / `7be9328d`): textarea focus is REPEATEDLY STOLEN while typing on the staging hub.

Root cause: two unconditional `welcomeInput.focus()` calls in `static/shared/ts/components/chat-welcome.ts` that fire on init AND on every `workspace-pane-changed` event — no check for whether the user already holds focus on a real input.

## Fix

1. **Line 24 init auto-focus**: only call `welcomeInput.focus()` if `document.activeElement` is `null` or `document.body` (no real element holds focus). Without this guard, an SPA-like re-init or a delayed boot of this component steals focus from whatever textarea the user is actively typing in.

2. **Lines 27-42 pane-changed refocus**: skip the refocus entirely if the user is already focused on a real `HTMLInputElement` / `HTMLTextAreaElement` / `contentEditable` element ANYWHERE in the document. Pane-changed events can fire during workspace shell layout adjustments while the user is typing elsewhere; respect the user's focus.

Net: +38/-16 lines, single file.

## Why this matches the symptom

The operator's exact phrasing was *"textarea activation/focus repeatedly stolen mid-type"*. That's the textbook symptom of an unconditional `.focus()` re-firing on some lifecycle/event. Both call sites were unguarded; both now check `activeElement`.

## What's preserved

- Fresh page load with no focus → chat-welcome input still auto-focuses (correct UX).
- Pane-switch to chat with no other input focused → refocus still happens (correct UX).
- Alt+Tab away + back → activeElement is body → auto-focus reapplies if conditions match.

## What's dropped

The `getUserMedia` / mic question was investigated in parallel (no auto-firing call found; lead msg `86478588` confirmed the mic prompt is a separate browser per-origin permission concern, NOT a hub bug). This PR is the standalone focus-steal fix.

## Test plan

- [ ] Load the hub with the AI chat panel open, focus on a workspace textarea (terminal / scholar search), wait for pane-changed events → focus STAYS in the user's textarea.
- [ ] Load the hub without focusing anywhere → chat-welcome input auto-focuses as before.
- [ ] Alt+Tab away then back → activeElement is body → auto-focus reapplies on init.

## Deploy note (critical for staging)

The staging hub on NAS serves develop via the pre-built static bundle (Dockerfile.prod / daphne). After merge, the TS bundle must be rebuilt and the staging django container force-recreated to pick up the fix. Redeploy command in the comment thread.

## Refs

- Lead msgs: `5d86b7b0` (initial), `7be9328d` (broaden audit), `d4459015` (approve PR), `86478588` (drop mic from scope)
- Branch: `fix/chat-welcome-respect-active-element`
- Commit: `bf7cfa2af`