### PR TITLE
fix(audit): PA-202/PA-501 version + SK-710 tag (gate partial; §1 whoami flagged)

### DIFF
--- a/src/scitex_hub/__init__.py
+++ b/src/scitex_hub/__init__.py
@@ -20,30 +20,23 @@ MCP Server:
     scitex-hub serve -t sse       # SSE (remote)
 """
 
+from __future__ import annotations
 
-def _get_version() -> str:
-    """Read installed package version via ``importlib.metadata``.
+from importlib.metadata import PackageNotFoundError, version
 
-    PEP 566 / 621 publishes the distribution version in the package
-    metadata. ``importlib.metadata.version`` reads that without
-    re-parsing pyproject.toml — which (a) works the same on editable
-    installs and on built wheels, (b) doesn't break when pyproject.toml
-    isn't shipped (wheel / sdist install), and (c) matches the rule
-    PA-202 §2 (version-not-from-metadata) the ecosystem audit enforces.
+# PEP 566 / 621 publishes the distribution version in the package
+# metadata. ``importlib.metadata.version`` reads that without re-parsing
+# pyproject.toml — it works the same on editable installs and built
+# wheels, doesn't break when pyproject.toml isn't shipped (wheel / sdist
+# install), and matches the ecosystem audit rule PA-202 §2
+# (version-not-from-metadata). Falls back to the PEP 440 local segment
+# when the dist isn't installed (e.g. a checkout without `pip install -e .`)
+# so import never raises.
+try:
+    __version__ = version("scitex-hub")
+except PackageNotFoundError:
+    __version__ = "0.0.0+local"
 
-    Falls back to ``"unknown"`` when the dist isn't installed (e.g.
-    running directly from a checkout without ``pip install -e .``),
-    so import never raises.
-    """
-    from importlib.metadata import PackageNotFoundError, version
-
-    try:
-        return version("scitex-hub")
-    except PackageNotFoundError:
-        return "unknown"
-
-
-__version__ = _get_version()
 __author__ = "SciTeX Team"
 
 from . import account as account

--- a/src/scitex_hub/_skills/scitex-hub/40_user-publish-runbook.md
+++ b/src/scitex_hub/_skills/scitex-hub/40_user-publish-runbook.md
@@ -4,7 +4,7 @@ description: |
   [DETAILS] Human-facing walkthrough for publishing an App to the scitex-hub
   app store. Covers one-time PAT setup, project scaffold, local iteration,
   cross-repo submit, and on-hub verification. Audience: a USER (not an agent).
-tags: [scitex-hub-user-publish, scitex-hub-runbook]
+tags: [scitex-hub-user-publish-runbook, scitex-hub-runbook]
 audience: user
 ---
 


### PR DESCRIPTION
## Summary

Partial fix for the `develop` `tests` job (`tests/develop/test_audit.py::test_audit_all_clean`, the brand-quality gate). The originally-reported "Django-settings/import error from the lazy-import-guard commit" was a **misdiagnosis**: commit 6317462f8 ("restore lazy-import guard") actually *fixed* the Django startup import; the gate's remaining red is **audit-debt**, not an import error.

The gate runs `audit-all scitex-hub`, which reports **1464+ violations** (overwhelmingly `PA-306 no-mocks` across the Django test suite, plus `audit-cli §2` interactive-prompt and `audit-mcp-tools §5/§6` errors). Almost all are intentionally deferred via the `skip_rules` list in `test_audit.py`. After re-classification, exactly **two** non-skipped violations remained and were failing the gate; this PR fixes one bucket of real issues and leaves the other for an explicit decision.

## Fixed (real fixes — confirmed locally with scitex-dev 0.17.4 + full `.[dev]` install)

- **PA-202 `version-not-from-metadata`** — `scitex_hub/__init__.py` computed `__version__` via a `_get_version()` helper. The auditor AST-matches the `__version__` assignment and only recognizes a direct `version('<dist>')` / `importlib.metadata.version(...)` call, so the helper indirection tripped the rule. Inlined the canonical `try: __version__ = version('scitex-hub') except PackageNotFoundError: __version__ = '0.0.0+local'` pattern. Shim identity preserved — `test_scitex_cloud_shim.py` green (5/5), `scitex_cloud.__version__ == scitex_hub.__version__`.
- **PA-501 `missing-future-annotations`** — added `from __future__ import annotations` to `scitex_hub/__init__.py`.
- **SK-710 `frontmatter-tags-canonical-mismatch`** — `40_user-publish-runbook.md` `tags[0]` was `scitex-hub-user-publish`; the canonical name derived from the filename is `scitex-hub-user-publish-runbook`.

`PA-202`, `PA-501` (and `PA-306`, etc.) are currently in the `test_audit.py` `skip_rules` deferral list. With these fixes the first two can be **removed from `skip_rules`** (real fix supersedes the deferral). I left the `skip_rules` edit out of this PR so the gate change is a deliberate follow-up.

## FLAGGED — needs an operator decision (the one remaining non-skipped gate blocker)

- **audit-cli `[§1]`**: `scitex-hub account whoami: leaf token looks like a noun — use '<verb>-whoami' (e.g. start-whoami) or add a sibling verb`.
  - `whoami` is a universal Unix idiom (`whoami(1)`); it is also referenced in the user-facing publish runbook. Verb-prefixing (`show-whoami`) is awkward and user-facing; "add a sibling verb" injects a redundant command. **Options:** (a) rename `whoami` → `show-whoami` (breaking, updates docs/skills); (b) add a sibling verb under `account` so the noun is no longer the only leaf; (c) add `§1` (or this specific command) to the auditor's allow-list / `skip_rules` if `whoami` is a sanctioned idiom. No ecosystem precedent — only hub has `whoami`.

## Not addressed (pre-existing managed debt, out of scope)

The bulk `PA-306 no-mocks` debt (hundreds of `unittest.mock` imports across the Django test suite) and the `audit-cli §2` / `audit-mcp-tools §5/§6` errors remain deferred via `skip_rules`. Removing mocks from this Django app's tests is a large refactor, not a low-risk mechanical fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
