### PR TITLE
fix(audit): whoami verb-class + SK-710 skill-tag (hub audit gate green)

### DIFF
--- a/.scitex/dev/cli-audit-dict.yaml
+++ b/.scitex/dev/cli-audit-dict.yaml
@@ -6,13 +6,22 @@
 # Merged with `~/.scitex/dev/cli-audit-dict.yaml` (user-level) at audit
 # time. Project entries take precedence on collision.
 
-nouns:
-  # `scitex-hub account whoami` — polysemous-leaf identity check that
-  # follows the convention doctrine's "show-me-X" carve-out
-  # (_skills/general/03_interface/02_cli/02_subcommand-structure-noun-verb.md
-  # §"polysemous show-me-X"). Standard *nix utility name (POSIX-derived
-  # via `who am i`), but not in the bundled English catalog or Moby POS.
-  - whoami
+nouns: []
 
 transitive_verbs: []
-intransitive_verbs: []
+
+intransitive_verbs:
+  # audit-cli §1 escape hatch (the same mechanism `next`, scitex-ssh's
+  # `attach`, and figrecipe's `plot`/`crop` use). `scitex-hub account
+  # whoami` is the imperative the user types to ask the server "who am
+  # I?" — a universal Unix idiom (POSIX `who am i` → `whoami(1)`), like
+  # `id`, `pwd`, `hostname`. It is unambiguously a VERB in this CLI's
+  # grammar:
+  #   scitex-hub account whoami            — print the logged-in identity
+  #   scitex-hub account whoami --json     — same, machine-readable
+  # A rename to `<verb>-whoami` / `whoami show` would be worse UX and
+  # break the established *nix idiom. Declaring it an intransitive verb
+  # records that intent and clears §1 (the leaf-noun check). Previously
+  # this was (incorrectly) listed under `nouns:`, which CONFIRMED the
+  # §1 violation rather than clearing it.
+  - whoami

--- a/src/scitex_hub/_skills/scitex-hub/40_user-publish-runbook.md
+++ b/src/scitex_hub/_skills/scitex-hub/40_user-publish-runbook.md
@@ -4,7 +4,7 @@ description: |
   [DETAILS] Human-facing walkthrough for publishing an App to the scitex-hub
   app store. Covers one-time PAT setup, project scaffold, local iteration,
   cross-repo submit, and on-hub verification. Audience: a USER (not an agent).
-tags: [scitex-hub-user-publish, scitex-hub-runbook]
+tags: [scitex-hub-user-publish-runbook, scitex-hub-user-publish, scitex-hub-runbook]
 audience: user
 ---
 


### PR DESCRIPTION
Safe audit-only fixes: whoami nouns->intransitive_verbs; SK-710 skill-tag canonicalized. No test/runtime changes. hub migration deferred (pre-existing app-tier pytest failures); no-test-mirror capability deferred.